### PR TITLE
Transcribe locally on whisper.cpp, and clean up on DeepSeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Dikte
 
-Press `Ctrl+Space`, talk, press again. The recording goes to OpenAI or OpenRouter
-for transcription, a model on OpenRouter cleans it up (dropping the *uh*s, the
+Press `Ctrl+Space`, talk, press again. The recording is transcribed by whisper.cpp
+on your own machine, a model on OpenRouter cleans it up (dropping the *uh*s, the
 restarts, the missing punctuation), and the result lands in your clipboard and
-is pasted into whatever window you were typing in.
+is pasted into whatever window you were typing in. OpenAI and OpenRouter are
+there as alternatives for the transcription too.
 
 Built for KDE Plasma 6 on Wayland. No dependencies beyond system packages:
 just the Python standard library and PyQt6.
@@ -23,7 +24,9 @@ just the Python standard library and PyQt6.
 
 ```sh
 sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6
-systemctl --user enable --now ydotool     # needed for auto-paste
+sudo pacman -S --needed whisper-cpp      # local speech to text
+sudo pacman -S --needed cuda             # its GPU backend, on an NVIDIA card
+systemctl --user enable --now ydotool    # needed for auto-paste
 
 ./install.sh                 # or:  ./install.sh "Ctrl+Alt+Space"
 dikte                        # the settings window opens on first run
@@ -32,13 +35,26 @@ dikte                        # the settings window opens on first run
 `install.sh` adds the `dikte` command, a menu entry, an autostart entry and the
 KDE shortcut.
 
-Two keys go in the settings window: **OpenAI** and **OpenRouter**. Speech to text
-runs on either one (`gpt-4o-transcribe` by default), cleanup always on
-OpenRouter (`google/gemini-3.5-flash-lite`), so a single OpenRouter key can
-cover both. They fall back to `OPENAI_API_KEY` and `OPENROUTER_API_KEY`, and are
-stored in `~/.config/dikte/config.json`, mode 600. Cleanup can be switched off,
-in which case the raw transcript is pasted, and a thinking model's effort can be
-set next to it.
+Speech to text runs locally by default, on whisper.cpp. Pick a model under
+Settings → API and models and press **Download**: `large-v3-turbo` (1.5 GB) is
+the default, and the list runs from `tiny` up to `large-v3`. Models land in
+`~/.local/share/dikte/models`. Nothing of the audio leaves the machine, and it
+costs nothing per dictation.
+
+Cleanup runs on **DeepSeek** (`deepseek-v4-flash`) or **OpenRouter**
+(`google/gemini-3.5-flash-lite`), whichever you pick; the same choice also writes
+the meeting minutes. It can be switched off, in which case the raw transcript is
+pasted. Transcription can also be moved to **OpenAI** or **OpenRouter** under the
+same tab, on a machine that would rather not run a model itself. The keys fall
+back to `OPENAI_API_KEY`, `OPENROUTER_API_KEY` and `DEEPSEEK_API_KEY`, and are
+stored in `~/.config/dikte/config.json`, mode 600.
+
+One thing worth knowing about DeepSeek: it thinks unless it is told not to, and
+cleanup is not a job worth thinking about. Measured on the example below,
+thinking took six times as long for the same sentence, spent 95% of its output
+tokens on the reasoning, and sometimes came back with nothing to paste at all.
+So Dikte ships DeepSeek's cleanup with **Thinking: Off** and leaves the minutes,
+which are worth thinking about, to think.
 
 ## Using it
 
@@ -61,7 +77,15 @@ second one stacks above the first while both are up.
 
 ## What it does
 
-- **Silence never reaches the API.** Handed near-silence, a transcription model
+- **Transcription runs on this machine.** whisper.cpp is kept alive as a server
+  next to Dikte, on the `/v1/audio/transcriptions` path the hosted providers
+  use, which is what makes it one more base URL rather than a second code path:
+  dictation, file transcription, subtitles and meetings all go through it
+  unchanged. The model is loaded while Dikte starts rather than on the first
+  dictation, so a few seconds of speech comes back in about as long as it took
+  to say — the loading is the slow part, not the transcribing. Turn that off
+  under Settings → Local whisper to keep the graphics memory free.
+- **Silence never reaches the model.** Handed near-silence, a transcription model
   invents a sentence instead of returning nothing ("Thanks for watching", or in
   Turkish "Altyazı M.K."). A recording is dropped when nothing rose 10 dB above
   *that recording's own* noise floor for at least 0.3 s, which is also what
@@ -128,7 +152,8 @@ dikte.py          entry point, tray icon, state machine, IPC
 audio.py          PCM capture: pw-record for dictation, ffmpeg for a meeting
 meeting.py        channel split, speaker labelling, cleanup, minutes
 assistant.py      running a dictation through Claude Code, Codex or OpenRouter
-api.py            transcription on either provider, OpenRouter cleanup (stdlib only)
+api.py            transcription on any provider, OpenRouter cleanup (stdlib only)
+whispercpp.py     the local whisper.cpp server and its model downloads
 worker.py         transcribe → clean up → clipboard → paste
 vad.py            deciding whether a recording holds speech at all
 filetranscribe.py file transcription: ffmpeg, chunking, timestamps

--- a/README.tr.md
+++ b/README.tr.md
@@ -1,9 +1,9 @@
 # Dikte
 
-`Ctrl+Space`'e bas, konuş, tekrar bas. Ses OpenAI'ye ya da OpenRouter'a gidip
-yazıya çevrilir, OpenRouter'daki bir model transkripti temizler (ıı'lar,
-tekrarlar, eksik noktalama), sonuç panoya kopyalanır ve o an yazdığın pencereye
-yapıştırılır.
+`Ctrl+Space`'e bas, konuş, tekrar bas. Ses kendi makinende whisper.cpp ile yazıya
+çevrilir, OpenRouter'daki bir model transkripti temizler (ıı'lar, tekrarlar,
+eksik noktalama), sonuç panoya kopyalanır ve o an yazdığın pencereye
+yapıştırılır. Yazıya çevirme için OpenAI ve OpenRouter da seçenek olarak duruyor.
 
 KDE Plasma 6 / Wayland için yazıldı. Sistem paketleri dışında bağımlılığı yok:
 sadece Python standart kütüphanesi ve PyQt6.
@@ -23,7 +23,9 @@ sadece Python standart kütüphanesi ve PyQt6.
 
 ```sh
 sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6
-systemctl --user enable --now ydotool     # otomatik yapıştırma için
+sudo pacman -S --needed whisper-cpp      # yerel sesten yazıya
+sudo pacman -S --needed cuda             # NVIDIA kartta ekran kartı arka ucu
+systemctl --user enable --now ydotool    # otomatik yapıştırma için
 
 ./install.sh                 # ya da:  ./install.sh "Ctrl+Alt+Space"
 dikte                        # ilk açılışta ayarlar penceresi gelir
@@ -32,13 +34,27 @@ dikte                        # ilk açılışta ayarlar penceresi gelir
 `install.sh` `dikte` komutunu, menü girdisini, oturum açılışında otomatik
 başlatmayı ve KDE kısayolunu kurar.
 
-Ayarlar penceresinde iki anahtar istenir: **OpenAI** ve **OpenRouter**. Sesi
-yazıya çevirme ikisinden birinde çalışır (varsayılan `gpt-4o-transcribe`),
-temizleme her zaman OpenRouter'da (`google/gemini-3.5-flash-lite`), yani tek bir
-OpenRouter anahtarı ikisine de yeter. Boş bırakırsan `OPENAI_API_KEY` ve
-`OPENROUTER_API_KEY` kullanılır; anahtarlar `~/.config/dikte/config.json`
-içinde, izinler 600. Temizlemeyi tamamen kapatabilirsin, o zaman ham transkript
-yapıştırılır; modelin yanındaki kutudan düşünme seviyesini de seçebilirsin.
+Sesi yazıya çevirme varsayılan olarak yerelde, whisper.cpp üzerinde çalışır.
+Ayarlar → API ve modeller altından bir model seçip **İndir**'e bas: varsayılan
+`large-v3-turbo` (1,5 GB), liste `tiny`'den `large-v3`'e kadar gidiyor. Modeller
+`~/.local/share/dikte/models` altına iner. Ses makineden çıkmıyor ve dikte başına
+bir maliyeti yok.
+
+Temizleme, seçtiğine göre **DeepSeek** (`deepseek-v4-flash`) ya da **OpenRouter**
+(`google/gemini-3.5-flash-lite`) üzerinde çalışır; aynı seçim toplantı tutanağını
+da yazar. Temizlemeyi tamamen kapatabilirsin, o zaman ham transkript
+yapıştırılır. Yazıya çevirmeyi aynı sekmeden **OpenAI** ya da **OpenRouter**'a
+taşıyabilirsin — kendi üstünde model çalıştırmak istemeyen makine için.
+Anahtarları boş bırakırsan `OPENAI_API_KEY`, `OPENROUTER_API_KEY` ve
+`DEEPSEEK_API_KEY` kullanılır; `~/.config/dikte/config.json` içinde saklanır,
+izinler 600.
+
+DeepSeek hakkında bilinmesi gereken bir şey var: aksi söylenmedikçe düşünüyor, ve
+temizleme düşünmeye değecek bir iş değil. Aşağıdaki örnekte ölçüldü: düşünme aynı
+cümle için altı kat uzun sürdü, çıktı token'larının %95'ini akıl yürütmeye
+harcadı ve zaman zaman yapıştıracak hiçbir şey döndürmedi. Bu yüzden Dikte,
+DeepSeek'in temizlemesini **Düşünme: Kapalı** ile getiriyor; düşünmeye değen
+tutanağı ise düşünmeye bırakıyor.
 
 ## Kullanım
 
@@ -61,7 +77,15 @@ birden ekrandayken ikincisi birincinin üstüne yerleşir.
 
 ## Neler yapıyor
 
-- **Sessizlik API'ye gitmez.** Sessize yakın bir ses verildiğinde model boş dize
+- **Yazıya çevirme bu makinede.** whisper.cpp, Dikte'nin yanında bir sunucu
+  olarak ayakta tutuluyor ve bulut sağlayıcılarının kullandığı
+  `/v1/audio/transcriptions` yoluna oturtuluyor; ikinci bir kod yolu değil de
+  bir base URL daha olmasını sağlayan bu: dikte, dosya transkripsiyonu, altyazı
+  ve toplantı hiç değişmeden bunun üzerinden geçiyor. Model ilk diktede değil
+  Dikte açılırken yükleniyor, böylece birkaç saniyelik konuşma söylendiği kadar
+  sürede geri geliyor — yavaş olan kısım yükleme, çevirme değil. Ekran kartı
+  belleğini boş tutmak istersen Ayarlar → Yerel whisper altından kapat.
+- **Sessizlik modele gitmez.** Sessize yakın bir ses verildiğinde model boş dize
   döndürmez, bir cümle uydurur ("Altyazı M.K.", "Thanks for watching"). *O
   kaydın kendi* gürültü tabanının 10 dB üstüne en az 0,3 saniye çıkan bir şey
   yoksa kayıt atılır; ne kadar yüksek olursa olsun sabit fanı ya da cızırtıyı
@@ -126,7 +150,8 @@ dikte.py          giriş noktası, tepsi simgesi, durum makinesi, IPC
 audio.py          PCM kaydı: diktede pw-record, toplantıda ffmpeg
 meeting.py        kanal ayırma, konuşmacı etiketi, temizleme, tutanak
 assistant.py      dikteyi Claude Code, Codex ya da OpenRouter'dan geçirme
-api.py            iki sağlayıcıda transkript + OpenRouter temizleme (yalnız stdlib)
+api.py            her sağlayıcıda transkript + OpenRouter temizleme (yalnız stdlib)
+whispercpp.py     yerel whisper.cpp sunucusu ve model indirmeleri
 worker.py         transkript → temizleme → pano → yapıştırma
 vad.py            kayıtta gerçekten konuşma var mı kararı
 filetranscribe.py dosyadan transkript: ffmpeg, parçalama, zaman damgaları

--- a/api.py
+++ b/api.py
@@ -1,9 +1,11 @@
 """OpenAI and OpenRouter calls, stdlib only.
 
-Transcription runs on either provider: OpenRouter mirrors OpenAI's
-/audio/transcriptions endpoint field for field, so one multipart request serves
-both and only the key, the base URL and the model id change. Cleanup is always
-OpenRouter.
+Transcription runs on any of three providers: OpenRouter mirrors OpenAI's
+/audio/transcriptions endpoint field for field, and the local whisper.cpp server
+is started on that same path, so one multipart request serves all three and only
+the key, the base URL and the model id change. The local one has no key and its
+base URL is not known until the server is up, which is the one thing
+_transcribe_request has to fill in. Cleanup is always OpenRouter.
 """
 
 import collections
@@ -14,21 +16,42 @@ import secrets
 import urllib.error
 import urllib.request
 
+import whispercpp
 from i18n import t
 
 APP_URL = "https://github.com/yusufipk/dikte"
 USER_AGENT = f"dikte/1.0 (+{APP_URL})"
 OPENAI_URL = "https://api.openai.com/v1"
 OPENROUTER_URL = "https://openrouter.ai/api/v1"
+DEEPSEEK_URL = "https://api.deepseek.com"
+# The floor for a local transcription: whisper.cpp sends nothing until it is
+# finished, so this is how long a single chunk may take.
+LOCAL_TIMEOUT = 3600
 
-# Where a transcription request goes; built by config.Config.transcribe_target().
-# `service` is the name the user sees in an error, `provider` the one the code
-# branches on.
-Target = collections.namedtuple("Target", "provider service api_key base_url model")
+# Where a request goes; built by config.Config's *_target() methods. `service`
+# is the name the user sees in an error, `provider` the one the code branches
+# on. `reasoning` is only read by cleanup, which is the only job that has a
+# model thinking about anything.
+Target = collections.namedtuple(
+    "Target", "provider service api_key base_url model reasoning", defaults=("",))
+
+# How hard to think, in each provider's own vocabulary — the same idea as
+# assistant.py's CLAUDE_EFFORT and CODEX_EFFORT. DeepSeek has two rungs where
+# Dikte offers seven, and this is the mapping DeepSeek documents for its own
+# API. None means the thinking is turned off rather than turned down.
+DEEPSEEK_EFFORT = {"none": None, "minimal": "high", "low": "high",
+                   "medium": "high", "high": "high", "xhigh": "max", "max": "max"}
 
 
-def timestamp_model(provider):
-    """Only whisper-1 returns segment times, and OpenRouter namespaces the id."""
+def timestamp_model(provider, model):
+    """Only whisper-1 returns segment times, and OpenRouter namespaces the id.
+
+    Whisper is what the local server runs whatever the model is called, so there
+    it stays on the one that is already loaded; swapping it would name a model
+    the server has never heard of.
+    """
+    if provider == "local":
+        return model
     return "openai/whisper-1" if provider == "openrouter" else "whisper-1"
 
 
@@ -60,6 +83,7 @@ def _request(url, data, headers, timeout=120):
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", "replace")
+        exc.close()   # it holds the response body open until it is collected
         raise ApiError(f"HTTP {exc.code}: {_extract_error(body)}", exc.code) from exc
     except urllib.error.URLError as exc:
         raise ApiError(t("Could not connect: {reason}", reason=exc.reason)) from exc
@@ -118,15 +142,29 @@ def _headers(provider, api_key, content_type=None):
 
 def _transcribe_request(target, wav_path, language, prompt, response_format,
                         granularity=None, timeout=300):
-    if not target.api_key:
+    if target.provider == "local":
+        # The server is started on demand and picks its own port, so this is the
+        # first moment its address exists. serve() is idempotent: once it is up
+        # this costs nothing.
+        try:
+            target = target._replace(base_url=whispercpp.serve())
+        except whispercpp.LocalWhisperError as exc:
+            raise ApiError(str(exc)) from None
+        # The timeouts here are sized for a hosted API, where a slow answer is a
+        # bill running. Locally the only thing being spent is time, and a ten
+        # minute chunk of a film on a machine without a usable GPU takes a good
+        # deal of it; cutting that off would throw the work away for nothing.
+        timeout = max(timeout, LOCAL_TIMEOUT)
+    elif not target.api_key:
         raise ApiError(t("{service} API key is empty. Add it in Settings.",
                          service=target.service))
     fields = [("model", target.model), ("response_format", response_format)]
     if language and language != "auto":
         fields.append(("language", language))
     # OpenRouter takes the hint field and throws it away, so spare it the bytes.
-    # The same words still reach the cleanup model as a glossary.
-    if prompt and target.provider == "openai":
+    # The same words still reach the cleanup model as a glossary. whisper.cpp
+    # takes it as the initial prompt, the way OpenAI does.
+    if prompt and target.provider in ("openai", "local"):
         fields.append(("prompt", prompt))
     if granularity:
         fields.append(("timestamp_granularities[]", granularity))
@@ -137,14 +175,62 @@ def _transcribe_request(target, wav_path, language, prompt, response_format,
             _headers(target.provider, target.api_key, ctype), timeout=timeout,
         )
     except ApiError as exc:
+        if target.provider == "local":
+            # A server that died mid-request would otherwise report only that
+            # the connection dropped, when the reason is in its own output.
+            detail = whispercpp.error()
+            raise ApiError(f"{target.service}: {exc}"
+                           + (f" ({detail})" if detail else ""), exc.status) from None
         raise explain(exc, target.service) from None
+
+
+# Whisper marks the start of a word with a leading space, so a piece of text
+# that does not begin with one continues the word before it rather than
+# starting a new one. Both helpers below turn on that.
+def _continues_a_word(previous, following):
+    return bool(previous) and not previous[-1:].isspace() and not following[:1].isspace()
+
+
+def _local_text(text):
+    """whisper.cpp's segments, joined back into the flowing line OpenAI returns.
+
+    Its plain text puts one segment per line, and a segment boundary falls
+    wherever the tokens fell — in Turkish that lands inside a word often enough
+    to matter. Nothing takes the line break's place: whisper's own leading
+    spaces are what separate the words, and a break inside "değ|iller" has
+    nothing on either side of it to keep.
+    """
+    return "".join(text.split("\n"))
+
+
+def _merge_word_splits(segments):
+    """Fold a segment that begins mid-word into the one it continues.
+
+    The hosted whisper-1 hands back segments cut on sentences; whisper.cpp cuts
+    them on tokens, and a subtitle cue reading "değ" is not a cue. The times of
+    the two are joined along with the text, so the merged segment still covers
+    the whole word.
+    """
+    merged = []
+    for seg in segments:
+        text = seg.get("text") or ""
+        if merged and _continues_a_word(merged[-1]["text"], text):
+            merged[-1]["text"] += text
+            merged[-1]["end"] = seg.get("end") or merged[-1]["end"]
+            continue
+        merged.append({"text": text, "start": seg.get("start") or 0.0,
+                       "end": seg.get("end") or 0.0})
+    return merged
 
 
 def transcribe(target, wav_path, language="", prompt="", timeout=300):
     data = _transcribe_request(
         target, wav_path, language, prompt, "json", timeout=timeout
     )
-    text = (data.get("text") or "").strip()
+    text = data.get("text") or ""
+    if target.provider == "local":
+        text = _local_text(text)
+    text = text.strip()
     if not text:
         raise ApiError(t("Transcript came back empty."))
     return text
@@ -153,11 +239,13 @@ def transcribe(target, wav_path, language="", prompt="", timeout=300):
 def transcribe_segments(target, wav_path, language="", prompt="", timeout=300):
     """[(start_seconds, end_seconds, text)] using whisper-1's verbose response."""
     data = _transcribe_request(
-        target._replace(model=timestamp_model(target.provider)),
+        target._replace(model=timestamp_model(target.provider, target.model)),
         wav_path, language, prompt, "verbose_json",
         granularity="segment", timeout=timeout,
     )
     segments = data.get("segments") or []
+    if target.provider == "local":
+        segments = _merge_word_splits(segments)
     out = []
     for seg in segments:
         text = (seg.get("text") or "").strip()
@@ -166,45 +254,69 @@ def transcribe_segments(target, wav_path, language="", prompt="", timeout=300):
             end = float(seg.get("end") or 0.0)
             out.append((start, max(end, start), text))
     if not out:
-        text = (data.get("text") or "").strip()
+        text = data.get("text") or ""
+        if target.provider == "local":
+            text = _local_text(text)
+        text = text.strip()
         if not text:
             raise ApiError(t("Transcript came back empty."))
         out = [(0.0, 0.0, text)]
     return out
 
 
-def cleanup(text, api_key, model, system_prompt, reasoning="",
-            base_url=OPENROUTER_URL, timeout=180):
-    if not api_key:
+def _thinking(target, payload):
+    """Ask for as much thinking as the target's provider understands.
+
+    An empty level means "whatever the model does on its own", so nothing is
+    sent. It is worth knowing that the two providers mean opposite things by
+    that: OpenRouter's cleanup models answer straight away, DeepSeek thinks
+    unless told not to, which is why the setting is kept per provider.
+    """
+    if not target.reasoning:
+        return
+    if target.provider == "deepseek":
+        effort = DEEPSEEK_EFFORT.get(target.reasoning, "high")
+        payload["thinking"] = ({"type": "disabled"} if effort is None
+                               else {"type": "enabled", "reasoning_effort": effort})
+    else:
+        # The thinking itself is never shown, so ask for it to be left out.
+        payload["reasoning"] = {"effort": target.reasoning, "exclude": True}
+
+
+def cleanup(target, text, system_prompt, timeout=180):
+    if not target.api_key:
         raise ApiError(t("{service} API key is empty. Add it in Settings.",
-                         service="OpenRouter"))
+                         service=target.service))
     payload = {
-        "model": model,
+        "model": target.model,
         "temperature": 0,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": f"<transcript>\n{text}\n</transcript>"},
         ],
     }
-    # An empty level means "whatever the model does on its own"; anything else is
-    # one of OpenRouter's efforts. The thinking itself is never shown, so ask for
-    # it to be left out of the reply.
-    if reasoning:
-        payload["reasoning"] = {"effort": reasoning, "exclude": True}
+    _thinking(target, payload)
     try:
         data = _request(
-            f"{base_url.rstrip('/')}/chat/completions",
+            f"{target.base_url.rstrip('/')}/chat/completions",
             json.dumps(payload).encode("utf-8"),
-            _headers("openrouter", api_key, "application/json"),
+            _headers(target.provider, target.api_key, "application/json"),
             timeout=timeout,
         )
     except ApiError as exc:
-        raise explain(exc, "OpenRouter") from None
+        raise explain(exc, target.service) from None
     choices = data.get("choices") or []
     if not choices:
         raise ApiError(_extract_error(json.dumps(data)))
-    content = ((choices[0].get("message") or {}).get("content") or "").strip()
+    message = choices[0].get("message") or {}
+    content = (message.get("content") or "").strip()
     if not content:
+        # A thinking model can spend the whole reply on the thinking and leave
+        # nothing to paste. Worth naming, because the fix is a setting rather
+        # than a retry: cleanup is not a job that wants thinking.
+        if message.get("reasoning_content"):
+            raise ApiError(t("The cleanup model spent its whole reply on "
+                             "thinking. Set Thinking to “Off”."))
         raise ApiError(t("The cleanup model returned an empty reply."))
     return content
 
@@ -250,6 +362,7 @@ def _get_json(url, headers, timeout=20):
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode("utf-8", "replace")
+        exc.close()   # it holds the response body open until it is collected
         raise ApiError(f"HTTP {exc.code}: {_extract_error(body)}", exc.code) from exc
     except urllib.error.URLError as exc:
         raise ApiError(t("Could not connect: {reason}", reason=exc.reason)) from exc
@@ -295,6 +408,43 @@ def openrouter_models(api_key="", transcription=False):
                   if "transcription" in (m.get("architecture") or {}).get(
                       "output_modalities", [])]
     return sorted(m["id"] for m in models if m.get("id"))
+
+
+def deepseek_key_status(api_key, base_url=DEEPSEEK_URL):
+    """Check the key against DeepSeek's own balance endpoint."""
+    if not api_key:
+        raise ApiError(t("{service} API key is empty. Add it in Settings.",
+                         service="DeepSeek"))
+    try:
+        data = _get_json(f"{base_url.rstrip('/')}/user/balance",
+                         {"Authorization": f"Bearer {api_key}", "User-Agent": USER_AGENT})
+    except ApiError as exc:
+        raise explain(exc, "DeepSeek") from None
+    infos = data.get("balance_infos") or []
+    if not infos:
+        return t("Key works.")
+    first = infos[0]
+    if not data.get("is_available", True):
+        return t("Key works, but the balance is spent ({balance} {currency}).",
+                 balance=first.get("total_balance", "0"),
+                 currency=first.get("currency", ""))
+    return t("Key works. Balance: {balance} {currency}.",
+             balance=first.get("total_balance", "?"),
+             currency=first.get("currency", ""))
+
+
+def deepseek_models(api_key, base_url=DEEPSEEK_URL):
+    if not api_key:
+        raise ApiError(t("{service} API key is empty. Add it in Settings.",
+                         service="DeepSeek"))
+    try:
+        data = _get_json(
+            f"{base_url.rstrip('/')}/models",
+            {"Authorization": f"Bearer {api_key}", "User-Agent": USER_AGENT},
+        )
+    except ApiError as exc:
+        raise explain(exc, "DeepSeek") from None
+    return sorted(m["id"] for m in data.get("data", []) if m.get("id"))
 
 
 def openai_models(api_key, base_url=OPENAI_URL):

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ import pathlib
 
 import api
 import i18n
+import whispercpp
+from i18n import t
 
 
 def _xdg(var, default):
@@ -365,14 +367,36 @@ DEFAULTS = {
     "openai_base_url": "https://api.openai.com/v1",
     "openrouter_api_key": "",
     "openrouter_base_url": "https://openrouter.ai/api/v1",
-    "transcribe_provider": "openai",  # openai | openrouter
+    "transcribe_provider": "local",  # local | openai | openrouter
     "transcribe_model": "gpt-4o-transcribe",           # used when provider is openai
     "openrouter_transcribe_model": "openai/gpt-4o-transcribe",
+
+    # --- local whisper.cpp ---------------------------------------------------
+    "local_model": whispercpp.DEFAULT_MODEL,
+    "local_threads": 0,             # 0 -> whisper.cpp picks
+    "local_gpu": True,
+    "local_preload": True,          # load the model while Dikte starts, not on
+                                    # the first dictation
+    "local_binary": "",             # empty -> whisper-server from PATH
     "language": "tr",
     "transcribe_prompt": "",
     "cleanup_enabled": True,
+    "cleanup_provider": "openrouter",   # openrouter | deepseek
     "cleanup_model": "google/gemini-3.5-flash-lite",
     "cleanup_reasoning": "",        # empty -> whatever the model does by default
+
+    # --- DeepSeek --------------------------------------------------------
+    # Its own API rather than OpenRouter's copy of it: no middleman's cut, and
+    # one more key instead of one more account. The thinking settings are kept
+    # apart from OpenRouter's because the two default to opposite things —
+    # DeepSeek thinks unless told not to, and cleanup is not worth thinking
+    # about, while minutes are.
+    "deepseek_api_key": "",
+    "deepseek_base_url": "https://api.deepseek.com",
+    "deepseek_cleanup_model": "deepseek-v4-flash",
+    "deepseek_cleanup_reasoning": "none",
+    "deepseek_meeting_model": "deepseek-v4-flash",
+    "deepseek_meeting_reasoning": "",
     "cleanup_prompt": "",           # empty -> language-specific default
     "auto_paste": True,
     "paste_shortcut": "ctrl+v",
@@ -494,14 +518,64 @@ class Config:
     def openrouter_key(self):
         return self["openrouter_api_key"].strip() or os.environ.get("OPENROUTER_API_KEY", "").strip()
 
+    def deepseek_key(self):
+        return self["deepseek_api_key"].strip() or os.environ.get("DEEPSEEK_API_KEY", "").strip()
+
+    def cleanup_target(self):
+        """Key, endpoint, model and thinking level for the cleanup job."""
+        if self["cleanup_provider"] == "deepseek":
+            return api.Target("deepseek", "DeepSeek", self.deepseek_key(),
+                              self["deepseek_base_url"],
+                              self["deepseek_cleanup_model"],
+                              self["deepseek_cleanup_reasoning"])
+        return api.Target("openrouter", "OpenRouter", self.openrouter_key(),
+                          self["openrouter_base_url"], self["cleanup_model"],
+                          self["cleanup_reasoning"])
+
+    def minutes_target(self):
+        """The same provider, but the model and effort meant for the minutes."""
+        if self["cleanup_provider"] == "deepseek":
+            return api.Target("deepseek", "DeepSeek", self.deepseek_key(),
+                              self["deepseek_base_url"],
+                              self["deepseek_meeting_model"],
+                              self["deepseek_meeting_reasoning"])
+        return api.Target("openrouter", "OpenRouter", self.openrouter_key(),
+                          self["openrouter_base_url"], self["meeting_model"],
+                          self["meeting_reasoning"])
+
     def transcribe_target(self):
-        """Key, endpoint and model for whichever provider does speech to text."""
-        if self["transcribe_provider"] == "openrouter":
+        """Key, endpoint and model for whichever provider does speech to text.
+
+        The local one leaves its base URL empty on purpose: the server picks a
+        port when it starts, and starting it here would make reading the
+        settings launch a process. api.py fills the address in when it is about
+        to send the request, which is the moment the server is needed anyway.
+        """
+        provider = self["transcribe_provider"]
+        if provider == "local":
+            return api.Target("local", t("Local Whisper"), "local", "",
+                              self["local_model"])
+        if provider == "openrouter":
             return api.Target("openrouter", "OpenRouter", self.openrouter_key(),
                               self["openrouter_base_url"],
                               self["openrouter_transcribe_model"])
         return api.Target("openai", "OpenAI", self.openai_key(),
                           self["openai_base_url"], self["transcribe_model"])
+
+    def transcribe_ready(self):
+        """Whether speech to text could run right now, without opening Settings."""
+        if self["transcribe_provider"] == "local":
+            return whispercpp.ready(self["local_model"], self["local_binary"])
+        return bool(self.transcribe_target().api_key)
+
+    def apply_local_whisper(self):
+        """Hand the local settings to the server, restarting it if they changed."""
+        whispercpp.configure(
+            model=self["local_model"],
+            threads=int(self["local_threads"]),
+            gpu=bool(self["local_gpu"]),
+            binary=self["local_binary"],
+        )
 
     def cleanup_prompt(self, with_timestamps=False, with_speakers=False,
                        subtitles=False):

--- a/dikte.py
+++ b/dikte.py
@@ -15,15 +15,19 @@ Usage:
   dikte.py quit          shut the application down
 """
 
+import contextlib
 import os
+import signal
+import socket
 import sys
+import threading
 
 # A Wayland client cannot place a window in a screen corner, so the indicator
 # is drawn through XWayland.
 if os.environ.get("XDG_SESSION_TYPE") == "wayland" and os.environ.get("DISPLAY"):
     os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
 
-from PyQt6.QtCore import QTimer, QElapsedTimer  # noqa: E402
+from PyQt6.QtCore import QTimer, QElapsedTimer, QSocketNotifier  # noqa: E402
 from PyQt6.QtGui import QAction, QIcon  # noqa: E402
 from PyQt6.QtNetwork import QLocalServer, QLocalSocket  # noqa: E402
 from PyQt6.QtWidgets import QApplication, QMenu, QSystemTrayIcon  # noqa: E402
@@ -34,6 +38,7 @@ import config as cfg  # noqa: E402
 import hotkey  # noqa: E402
 import i18n  # noqa: E402
 import meeting  # noqa: E402
+import whispercpp  # noqa: E402
 from i18n import t  # noqa: E402
 from meeting import MeetingPipeline  # noqa: E402
 from overlay import Overlay  # noqa: E402
@@ -87,6 +92,10 @@ class Dikte:
         self.meeting_recorder = audio.MeetingRecorder()
         self.meetings = MeetingPipeline(self.conf)
         self.evdev = hotkey.EvdevHotkey()
+        # Before anything is started: a server from a Dikte that was killed
+        # outright is still holding the model in memory.
+        whispercpp.sweep()
+        self._apply_local_whisper()
 
         self.recorder.level.connect(self._on_level)
         self.recorder.stopped.connect(self._on_recorded)
@@ -107,6 +116,11 @@ class Dikte:
         self.meetings.failed.connect(self._on_meeting_failed)
         self.evdev.triggered.connect(self._on_evdev)
         self.evdev.failed.connect(self._on_error)
+        # Started here as well as when the settings are saved: the listener is
+        # a setting like any other, and one that only came on after a visit to
+        # the settings window would be off again after the next restart —
+        # including the tray's own Restart, and the autostart on login.
+        self._apply_hotkeys()
 
         self.elapsed = QElapsedTimer()
         self.meeting_elapsed = QElapsedTimer()
@@ -655,11 +669,40 @@ class Dikte:
         # Don't drop the object while its own signal is still being delivered.
         QTimer.singleShot(0, lambda: setattr(self, "settings_window", None))
 
+    def _apply_local_whisper(self):
+        """Pass the local settings on, and hold the model ready if asked to.
+
+        Loading a large model onto the GPU takes a second or two. Doing it while
+        Dikte starts rather than on the first dictation is the whole reason a
+        server is kept alive instead of running whisper-cli per recording; the
+        checkbox is there for the machine whose VRAM is wanted elsewhere.
+        """
+        self.conf.apply_local_whisper()
+        if self.conf["transcribe_provider"] != "local":
+            whispercpp.stop()      # give the memory back when it is not in use
+            return
+        if not (self.conf["local_preload"] and self.conf.transcribe_ready()):
+            return
+
+        def warm():
+            try:
+                whispercpp.serve()
+            except whispercpp.LocalWhisperError as exc:
+                # Not worth an indicator: the first dictation raises the same
+                # thing where the user can act on it.
+                print(f"dikte: local whisper: {exc}", file=sys.stderr)
+
+        threading.Thread(target=warm, daemon=True).start()
+
     def _apply_settings(self):
         self.overlay.corner = self.conf["overlay_corner"]
         self.ask_overlay.corner = self.conf["overlay_corner"]
+        self._apply_local_whisper()
         self._build_tray()
         self._refresh_tray()
+        self._apply_hotkeys()
+
+    def _apply_hotkeys(self):
         if self.conf["evdev_hotkey"]:
             self.evdev.start({"toggle": self.conf["shortcut"],
                               "ask": self.conf["assistant_shortcut"],
@@ -688,6 +731,9 @@ class Dikte:
             self.meeting_recorder.stop()
         self.overlay.dismiss()
         self.ask_overlay.dismiss()
+        # Also on the restart path, which replaces the process without ever
+        # reaching atexit and would otherwise leave the model in memory.
+        whispercpp.stop()
         self.tray.hide()
 
 
@@ -729,6 +775,41 @@ def send_command(command, timeout=800):
     return True
 
 
+def install_signal_handlers(app):
+    """Quit properly on the signals a session sends, rather than dying where we stand.
+
+    Qt spends its time blocked inside C, and a Python signal handler only runs
+    between bytecodes, so on its own it would not run until the next event
+    arrived — which, for an idle tray icon, may be never. set_wakeup_fd writes
+    the signal number to a socket instead, and a notifier turns that into an
+    event Qt does deliver.
+
+    Worth the trouble because of what shutdown() does: a logout sends SIGTERM,
+    and without this the whisper.cpp server outlives the session holding the
+    model in graphics memory. SIGKILL cannot be caught at all, which is what
+    whispercpp.sweep() is for.
+
+    Returns the objects it made; they have to stay alive to keep working.
+    """
+    reader, writer = socket.socketpair()
+    reader.setblocking(False)
+    writer.setblocking(False)
+    signal.set_wakeup_fd(writer.fileno())
+    notifier = QSocketNotifier(reader.fileno(), QSocketNotifier.Type.Read)
+
+    def woken():
+        with contextlib.suppress(OSError):
+            reader.recv(64)
+        app.quit()          # aboutToQuit runs shutdown()
+
+    notifier.activated.connect(woken)
+    for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        # A handler that does nothing, so that the default action — stopping
+        # the process on the spot — is replaced by the wakeup above.
+        signal.signal(sig, lambda *_: None)
+    return reader, writer, notifier
+
+
 def main():
     args = [a for a in sys.argv[1:] if not a.startswith("-")]
     command = args[0] if args else ""
@@ -743,6 +824,12 @@ def main():
     app.setApplicationName("Dikte")
     app.setDesktopFileName("dikte")
     app.setQuitOnLastWindowClosed(False)
+    # Before Dikte is built, because building it is what starts the whisper.cpp
+    # server, and a signal arriving in the middle of that would otherwise take
+    # the default action and leave the server behind. A signal this early lands
+    # in the socket and is delivered as soon as the event loop starts.
+    # Held in a name so the notifier and its socket outlive this function.
+    signal_plumbing = install_signal_handlers(app)  # noqa: F841
 
     # No command and an instance already running: bring its settings forward.
     if send_command(command or "settings"):
@@ -795,9 +882,10 @@ def main():
     server.newConnection.connect(on_connection)
     app.aboutToQuit.connect(dikte.shutdown)
 
-    # No key for the chosen transcription provider means nothing can work yet,
-    # so the settings window is the only useful thing to open.
-    if command == "settings" or not dikte.conf.transcribe_target().api_key:
+    # A transcription provider that cannot run yet — no API key, or no local
+    # model downloaded — means nothing can work, so the settings window is the
+    # only useful thing to open.
+    if command == "settings" or not dikte.conf.transcribe_ready():
         dikte.open_settings()
     elif command == "toggle":
         QTimer.singleShot(0, dikte.toggle)

--- a/filetranscribe.py
+++ b/filetranscribe.py
@@ -127,17 +127,11 @@ class FileTranscriber(QObject):
     def _cleanup(self, text, timestamps):
         conf = self.conf
         prompt = conf.cleanup_prompt(with_timestamps=timestamps, subtitles=True)
+        target = conf.cleanup_target()
         out = []
         for block in split_text(text, timestamps):
             self._check()
-            out.append(api.cleanup(
-                block,
-                conf.openrouter_key(),
-                conf["cleanup_model"],
-                prompt,
-                reasoning=conf["cleanup_reasoning"],
-                base_url=conf["openrouter_base_url"],
-            ))
+            out.append(api.cleanup(target, block, prompt))
         return ("\n" if timestamps else "\n\n").join(out)
 
 

--- a/i18n.py
+++ b/i18n.py
@@ -157,8 +157,7 @@ TR = {
     "top-right": "sağ-üst",
     "Longest recording": "En uzun kayıt",
     " s": " sn",
-    "Skip silent recordings (don't call the API)":
-        "Sessiz kayıtları atla (API'ye gönderme)",
+    "Skip silent recordings": "Sessiz kayıtları atla",
     "Silence threshold": "Sessizlik eşiği",
     "Keep audio files (~/.local/share/dikte/recordings)":
         "Ses kayıtlarını sakla (~/.local/share/dikte/recordings)",
@@ -175,6 +174,26 @@ TR = {
     "Test": "Test et",
     "Trying…": "Deneniyor…",
     "Runs on OpenRouter.": "OpenRouter üzerinde çalışır.",
+
+    # --- settings: cleanup provider -------------------------------------
+    "sk-… (falls back to DEEPSEEK_API_KEY)": "sk-… (boşsa DEEPSEEK_API_KEY kullanılır)",
+    "Cleanup and the meeting minutes both run on {service}.":
+        "Temizleme ve toplantı tutanağı {service} üzerinde çalışır.",
+    "Key works.": "Anahtar çalışıyor.",
+    "Key works. Balance: {balance} {currency}.":
+        "Anahtar çalışıyor. Bakiye: {balance} {currency}.",
+    "Key works, but the balance is spent ({balance} {currency}).":
+        "Anahtar çalışıyor ama bakiye tükenmiş ({balance} {currency}).",
+    "DeepSeek thinks unless it is told not to, and cleanup is not a job worth "
+    "thinking about: it costs seconds and can come back with the whole reply "
+    "spent on the thinking. “Off” is the setting you want here. Minutes are the "
+    "other way round.":
+        "DeepSeek, aksi söylenmedikçe düşünür; temizleme ise düşünmeye değecek "
+        "bir iş değil: saniyeler götürür ve yanıtın tamamını düşünmeye harcayıp "
+        "boş dönebilir. Burada istediğin ayar “Kapalı”. Tutanakta tam tersi.",
+    "The cleanup model spent its whole reply on thinking. Set Thinking to “Off”.":
+        "Temizleme modeli yanıtının tamamını düşünmeye harcadı. Düşünme ayarını "
+        "“Kapalı” yap.",
     "Connection works. {count} audio models visible.":
         "Bağlantı tamam. {count} ses modeli görünüyor.",
     "Clean the transcript with a model": "Transkripti bir modelle temizle",
@@ -195,6 +214,66 @@ TR = {
         "Düşünemeyen modeller bunu yok sayar.",
     "Fetch model list": "Model listesini çek",
     "Fetching model list…": "Model listesi çekiliyor…",
+
+    # --- settings: local whisper ----------------------------------------
+    "Local (whisper.cpp)": "Yerel (whisper.cpp)",
+    "Local Whisper": "Yerel Whisper",
+    "Local whisper": "Yerel whisper",
+    "Download": "İndir",
+    "downloaded": "indirildi",
+    # "Stop", "Stopping…" and "Stopped." are already in the file transcription
+    # section below; the download buttons reuse them.
+    "Use the GPU": "Ekran kartını kullan",
+    "whisper.cpp runs on the GPU through ggml's CUDA, ROCm or Vulkan backend, "
+    "whichever the installed package was built with. Turn this off to keep the "
+    "graphics memory free.":
+        "whisper.cpp, kurulu paketin hangisiyle derlendiyse ggml'in CUDA, ROCm "
+        "veya Vulkan arka ucu üzerinden ekran kartında çalışır. Ekran kartı "
+        "belleğini boş tutmak için bunu kapatın.",
+    "Load the model when Dikte starts": "Modeli Dikte açılırken yükle",
+    "A large model takes a second or two to load. Loading it up front keeps the "
+    "first dictation as quick as the rest; leaving it off gives the memory back "
+    "until something needs it.":
+        "Büyük bir modelin yüklenmesi bir iki saniye sürer. Baştan yüklemek ilk "
+        "diktenin de diğerleri kadar hızlı olmasını sağlar; kapalı bırakmak "
+        "belleği ihtiyaç duyulana kadar geri verir.",
+    "Threads": "İş parçacığı",
+    "Automatic": "Otomatik",
+    "How many CPU threads whisper.cpp may use. It barely matters when the GPU is "
+    "doing the work.":
+        "whisper.cpp'nin kullanabileceği işlemci iş parçacığı sayısı. İşi ekran "
+        "kartı yapıyorsa neredeyse hiç fark etmez.",
+    "Models": "Modeller",
+    "Downloading {model} ({size})…": "{model} indiriliyor ({size})…",
+    "Downloading… {percent}% ({done} of {total})":
+        "İndiriliyor… %{percent} ({done} / {total})",
+    "Downloading… {done}": "İndiriliyor… {done}",
+    "{model} downloaded. Press Save to use it.":
+        "{model} indirildi. Kullanmak için Kaydet'e basın.",
+    "whisper.cpp is not installed. Install it with: sudo pacman -S whisper-cpp":
+        "whisper.cpp kurulu değil. Kurmak için: sudo pacman -S whisper-cpp",
+    "The local model “{model}” has not been downloaded. Settings → API and "
+    "models → Download.":
+        "“{model}” yerel modeli indirilmemiş. Ayarlar → API ve modeller → İndir.",
+    "“{model}” has not been downloaded yet ({size}).":
+        "“{model}” henüz indirilmedi ({size}).",
+    "Running: {model}, {device}.": "Çalışıyor: {model}, {device}.",
+    "Ready: {model}, {device}. It loads on the first dictation.":
+        "Hazır: {model}, {device}. İlk diktede yüklenir.",
+    "GPU": "ekran kartı",
+    "CPU": "işlemci",
+    "Unknown model: {model}": "Bilinmeyen model: {model}",
+    "Could not create the model directory: {error}":
+        "Model dizini oluşturulamadı: {error}",
+    "Could not download the model: HTTP {code}": "Model indirilemedi: HTTP {code}",
+    "Could not download the model: {error}": "Model indirilemedi: {error}",
+    "Could not write the model: {error}": "Model yazılamadı: {error}",
+    "Could not delete the model: {error}": "Model silinemedi: {error}",
+    "The download stopped early ({done} of {total}).":
+        "İndirme erken kesildi ({done} / {total}).",
+    "Could not start whisper.cpp: {error}": "whisper.cpp başlatılamadı: {error}",
+    "whisper.cpp did not start: {error}": "whisper.cpp açılmadı: {error}",
+    "no output": "çıktı yok",
     "Could not fetch the list: {error}": "Liste alınamadı: {error}",
     "{count} models loaded.": "{count} model yüklendi.",
     "Key works, no spending limit set.": "Anahtar çalışıyor, harcama sınırı yok.",

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,19 @@ else
   ok "All dependencies present"
 fi
 
+# whisper.cpp is what transcribes by default, on this machine rather than an
+# API. It is its own step because a setup that transcribes through OpenAI or
+# OpenRouter does not need it.
+if command -v whisper-server >/dev/null; then
+  ok "whisper.cpp present (local speech to text)"
+  say "Download a model in Settings → API and models."
+else
+  warn "whisper-server not found: local speech to text will not run"
+  say  "Arch/CachyOS:  sudo pacman -S --needed whisper-cpp"
+  say  "For an NVIDIA card, add cuda for the GPU backend:  sudo pacman -S --needed cuda"
+  say  "Or pick OpenAI/OpenRouter under Settings → API and models."
+fi
+
 # 2. ydotoold --------------------------------------------------------------
 if command -v ydotool >/dev/null; then
   if systemctl --user is-active --quiet ydotool 2>/dev/null \
@@ -101,5 +114,6 @@ fi
 
 echo
 ok "Done. Start it with:  dikte"
-say "The settings window opens on first run; add your OpenAI and OpenRouter keys."
+say "The settings window opens on first run: download a whisper.cpp model for"
+say "speech to text, and add an OpenRouter key for the cleanup step."
 echo

--- a/meeting.py
+++ b/meeting.py
@@ -118,18 +118,12 @@ class MeetingPipeline(QObject):
 
             self._check()
             self._say(t("Writing the minutes…"))
-            minutes = api.cleanup(
-                transcript,
-                self.conf.openrouter_key(),
-                self.conf["meeting_model"],
-                self.conf.meeting_prompt(),
-                reasoning=self.conf["meeting_reasoning"],
-                base_url=self.conf["openrouter_base_url"],
-                timeout=600,
-            )
+            writer = self.conf.minutes_target()
+            minutes = api.cleanup(writer, transcript, self.conf.meeting_prompt(),
+                                  timeout=600)
             title = self._write(doc_path, minutes, transcript, entry)
             cfg.update_meeting(base, status="done", error="", title=title,
-                               model=self.conf["meeting_model"])
+                               model=writer.model)
             self._discard_audio(wav_path)
             self.finished.emit(base, title)
 
@@ -201,6 +195,7 @@ class MeetingPipeline(QObject):
     def _cleanup(self, transcript):
         conf = self.conf
         prompt = conf.cleanup_prompt(with_timestamps=True, with_speakers=True)
+        target = conf.cleanup_target()
         out = []
         blocks = filetranscribe.split_text(transcript, True)
         for index, block in enumerate(blocks, start=1):
@@ -208,14 +203,7 @@ class MeetingPipeline(QObject):
             if len(blocks) > 1:
                 self._say(t("Cleaning up {index}/{count}…",
                             index=index, count=len(blocks)))
-            out.append(api.cleanup(
-                block,
-                conf.openrouter_key(),
-                conf["cleanup_model"],
-                prompt,
-                reasoning=conf["cleanup_reasoning"],
-                base_url=conf["openrouter_base_url"],
-            ))
+            out.append(api.cleanup(target, block, prompt))
         return "\n".join(out)
 
     def _write(self, doc_path, minutes, transcript, entry):

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -20,6 +20,7 @@ import config as cfg
 import filetranscribe
 import hotkey
 import meeting
+import whispercpp
 from filetranscribe import FileTranscriber
 from i18n import t
 
@@ -29,9 +30,12 @@ LANGUAGES = [
     ("German", "de"), ("French", "fr"), ("Spanish", "es"), ("Arabic", "ar"),
 ]
 CORNERS = ["bottom-left", "bottom-right", "top-left", "top-right"]
-TRANSCRIBE_PROVIDERS = [("OpenAI", "openai"), ("OpenRouter", "openrouter")]
+TRANSCRIBE_PROVIDERS = [
+    ("Local (whisper.cpp)", "local"), ("OpenAI", "openai"), ("OpenRouter", "openrouter"),
+]
 # Starting points for the model box; "Fetch model list" replaces them with
-# whatever the provider offers today.
+# whatever the provider offers today. The local list is not one of these: it is
+# a fixed catalogue of files to download, built from whispercpp.MODELS.
 TRANSCRIBE_MODELS = {
     "openai": ["gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"],
     "openrouter": [
@@ -41,6 +45,8 @@ TRANSCRIBE_MODELS = {
         "deepgram/nova-3", "google/chirp-3",
     ],
 }
+CLEANUP_PROVIDERS = [("OpenRouter", "openrouter"), ("DeepSeek", "deepseek")]
+DEEPSEEK_MODELS = ["deepseek-v4-flash", "deepseek-v4-pro"]
 CLEANUP_MODELS = [
     "google/gemini-3.5-flash-lite", "google/gemini-3.1-flash-lite",
     "google/gemini-2.5-flash-lite", "anthropic/claude-haiku-4.5",
@@ -108,8 +114,11 @@ class SettingsWindow(QDialog):
 
     _models_loaded = pyqtSignal(list, str)
     _transcribe_models_loaded = pyqtSignal(list, str)
+    _download_progress = pyqtSignal(int, int)   # bytes done, bytes expected
+    _download_done = pyqtSignal(str, str)       # model id, error ("" on success)
     _test_done = pyqtSignal(bool, str)
     _or_test_done = pyqtSignal(bool, str)
+    _ds_test_done = pyqtSignal(bool, str)
 
     def __init__(self, conf, launch_command, meeting_command=None,
                  meetings=None, ask_command=None, parent=None):
@@ -121,8 +130,15 @@ class SettingsWindow(QDialog):
         self.meetings = meetings
         # Each provider keeps its own transcription model, so switching the
         # provider back and forth never overwrites the other one's.
-        self._models = {"openai": "", "openrouter": ""}
+        self._models = {"local": "", "openai": "", "openrouter": ""}
         self._shown_provider = ""
+        self._download_thread = None
+        self._download_stop = threading.Event()
+        # Same idea for cleanup: switching provider must not overwrite the
+        # other one's model or thinking level.
+        self._cleanup_values = {name: {"openrouter": "", "deepseek": ""}
+                                for name, _, _ in self._CLEANUP_FIELDS}
+        self._shown_cleanup_provider = ""
         self.transcriber = FileTranscriber(conf, self)
         self.setWindowTitle(t("Dikte Settings"))
         self.resize(680, 640)
@@ -151,8 +167,11 @@ class SettingsWindow(QDialog):
 
         self._models_loaded.connect(self._on_models_loaded)
         self._transcribe_models_loaded.connect(self._on_transcribe_models_loaded)
+        self._download_progress.connect(self._on_download_progress)
+        self._download_done.connect(self._on_download_done)
         self._test_done.connect(self._on_test_done)
         self._or_test_done.connect(self._on_or_test_done)
+        self._ds_test_done.connect(self._on_ds_test_done)
         self.transcriber.progress.connect(self._on_file_progress)
         self.transcriber.finished.connect(self._on_file_finished)
         self.transcriber.failed.connect(self._on_file_failed)
@@ -210,7 +229,7 @@ class SettingsWindow(QDialog):
         self.max_seconds.setSuffix(t(" s"))
         form.addRow(t("Longest recording"), self.max_seconds)
 
-        self.skip_silent = QCheckBox(t("Skip silent recordings (don't call the API)"))
+        self.skip_silent = QCheckBox(t("Skip silent recordings"))
         form.addRow("", self.skip_silent)
 
         self.silence_db = QSpinBox()
@@ -263,37 +282,94 @@ class SettingsWindow(QDialog):
         self.or_test_label.setWordWrap(True)
         keys_form.addRow("OpenRouter", self._row(self.openrouter_key, self.or_test_button))
         keys_form.addRow("", self.or_test_label)
+
+        self.deepseek_key = QLineEdit()
+        self.deepseek_key.setEchoMode(QLineEdit.EchoMode.Password)
+        self.deepseek_key.setPlaceholderText(t("sk-… (falls back to DEEPSEEK_API_KEY)"))
+        self.ds_test_button = QPushButton(t("Test"))
+        self.ds_test_button.clicked.connect(self._test_deepseek)
+        self.ds_test_label = QLabel("")
+        self.ds_test_label.setWordWrap(True)
+        keys_form.addRow("DeepSeek", self._row(self.deepseek_key, self.ds_test_button))
+        keys_form.addRow("", self.ds_test_label)
         outer.addWidget(keys)
 
         stt = QGroupBox(t("Speech to text"))
         stt_form = QFormLayout(stt)
         self.transcribe_provider = QComboBox()
         for label, value in TRANSCRIBE_PROVIDERS:
-            self.transcribe_provider.addItem(label, value)
+            self.transcribe_provider.addItem(t(label), value)
         stt_form.addRow(t("Provider"), self.transcribe_provider)
 
         self.transcribe_model = QComboBox()
         self.transcribe_model.setEditable(True)
         self.refresh_transcribe_models = QPushButton(t("Fetch model list"))
         self.refresh_transcribe_models.clicked.connect(self._load_transcribe_models)
+        # Shares the row with the fetch button; only one of the two applies to
+        # the chosen provider, so only one of them is ever visible.
+        self.download_model = QPushButton(t("Download"))
+        self.download_model.clicked.connect(self._toggle_download)
         stt_form.addRow(t("Model"),
-                        self._row(self.transcribe_model, self.refresh_transcribe_models))
+                        self._row(self.transcribe_model,
+                                  self.refresh_transcribe_models, self.download_model))
         # A spanning row: in the narrow field column a wrapped label gets a
         # height that fits one line, and the rest of the text is cut off.
         self.transcribe_status = QLabel("")
         self.transcribe_status.setWordWrap(True)
         stt_form.addRow(self.transcribe_status)
         self.transcribe_provider.currentIndexChanged.connect(self._provider_changed)
+        self.transcribe_model.currentIndexChanged.connect(self._model_changed)
         outer.addWidget(stt)
+
+        # Its own box rather than rows inside the one above, so that switching
+        # provider hides the settings and their labels together.
+        self.local_box = QGroupBox(t("Local whisper"))
+        local_form = QFormLayout(self.local_box)
+        self.local_gpu = QCheckBox(t("Use the GPU"))
+        self.local_gpu.setToolTip(
+            t("whisper.cpp runs on the GPU through ggml's CUDA, ROCm or Vulkan "
+              "backend, whichever the installed package was built with. Turn "
+              "this off to keep the graphics memory free.")
+        )
+        local_form.addRow("", self.local_gpu)
+
+        self.local_preload = QCheckBox(t("Load the model when Dikte starts"))
+        self.local_preload.setToolTip(
+            t("A large model takes a second or two to load. Loading it up front "
+              "keeps the first dictation as quick as the rest; leaving it off "
+              "gives the memory back until something needs it.")
+        )
+        local_form.addRow("", self.local_preload)
+
+        self.local_threads = QSpinBox()
+        self.local_threads.setRange(0, 64)
+        self.local_threads.setSpecialValueText(t("Automatic"))
+        self.local_threads.setToolTip(
+            t("How many CPU threads whisper.cpp may use. It barely matters when "
+              "the GPU is doing the work.")
+        )
+        local_form.addRow(t("Threads"), self.local_threads)
+
+        models_link = QLabel(
+            f'<a href="file://{whispercpp.models_dir()}">{whispercpp.models_dir()}</a>'
+        )
+        models_link.setOpenExternalLinks(True)
+        models_link.setWordWrap(True)
+        local_form.addRow(t("Models"), models_link)
+        outer.addWidget(self.local_box)
 
         orr = QGroupBox(t("Transcript cleanup"))
         orr_form = QFormLayout(orr)
         self.cleanup_enabled = QCheckBox(t("Clean the transcript with a model"))
         orr_form.addRow("", self.cleanup_enabled)
 
+        self.cleanup_provider = QComboBox()
+        for label, value in CLEANUP_PROVIDERS:
+            self.cleanup_provider.addItem(t(label), value)
+        orr_form.addRow(t("Provider"), self.cleanup_provider)
+
         self.cleanup_model = QComboBox()
         self.cleanup_model.setEditable(True)
-        self.cleanup_model.addItems(CLEANUP_MODELS)
         self.refresh_models = QPushButton(t("Fetch model list"))
         self.refresh_models.clicked.connect(self._load_models)
         orr_form.addRow(t("Model"), self._row(self.cleanup_model, self.refresh_models))
@@ -301,16 +377,12 @@ class SettingsWindow(QDialog):
         self.cleanup_reasoning = QComboBox()
         for label, value in REASONING_LEVELS:
             self.cleanup_reasoning.addItem(t(label), value)
-        self.cleanup_reasoning.setToolTip(
-            t("How long a thinking model may reason before it answers. Cleanup is "
-              "a light job, so more thinking mostly costs time and tokens. Models "
-              "that cannot think ignore this.")
-        )
         orr_form.addRow(t("Thinking"), self.cleanup_reasoning)
 
-        self.models_label = QLabel(t("Runs on OpenRouter."))
+        self.models_label = QLabel("")
         self.models_label.setWordWrap(True)
         orr_form.addRow(self.models_label)
+        self.cleanup_provider.currentIndexChanged.connect(self._cleanup_provider_changed)
         outer.addWidget(orr)
         outer.addStretch(1)
         return page
@@ -921,14 +993,24 @@ class SettingsWindow(QDialog):
 
         self.openai_key.setText(conf["openai_api_key"])
         self.openrouter_key.setText(conf["openrouter_api_key"])
-        self._models = {"openai": conf["transcribe_model"],
+        self._models = {"local": conf["local_model"],
+                        "openai": conf["transcribe_model"],
                         "openrouter": conf["openrouter_transcribe_model"]}
         self._shown_provider = ""
+        self.local_gpu.setChecked(conf["local_gpu"])
+        self.local_preload.setChecked(conf["local_preload"])
+        self.local_threads.setValue(int(conf["local_threads"]))
         self._select_data(self.transcribe_provider, conf["transcribe_provider"])
         self._provider_changed()  # selecting index 0 fires no signal
+        self.deepseek_key.setText(conf["deepseek_api_key"])
         self.cleanup_enabled.setChecked(conf["cleanup_enabled"])
-        self.cleanup_model.setCurrentText(conf["cleanup_model"])
-        self._select_data(self.cleanup_reasoning, conf["cleanup_reasoning"])
+        for name, openrouter_key, deepseek_key in self._CLEANUP_FIELDS:
+            self._cleanup_values[name] = {"openrouter": conf[openrouter_key],
+                                          "deepseek": conf[deepseek_key]}
+        self._shown_cleanup_provider = ""
+        self._select_data(self.cleanup_provider, conf["cleanup_provider"])
+        # Also fills the two meeting boxes, which the cleanup provider owns.
+        self._cleanup_provider_changed()  # selecting index 0 fires no signal
         self.cleanup_prompt.setPlainText(conf["cleanup_prompt"] or cfg.default_cleanup_prompt())
         self.file_cleanup_prompt.setPlainText(
             conf["file_cleanup_prompt"] or cfg.default_file_cleanup_prompt()
@@ -958,8 +1040,6 @@ class SettingsWindow(QDialog):
         self.meeting_self_name.setText(conf["meeting_self_name"])
         self.meeting_other_name.setText(conf["meeting_other_name"])
         self.meeting_participants.setPlainText(conf["meeting_participants"])
-        self.meeting_model.setCurrentText(conf["meeting_model"])
-        self._select_data(self.meeting_reasoning, conf["meeting_reasoning"])
         self._select_data(self.meeting_language, conf["meeting_language"])
         self.meeting_cleanup.setChecked(conf["meeting_cleanup"])
         self.meeting_max_minutes.setValue(max(5, int(conf["meeting_max_seconds"]) // 60))
@@ -1002,17 +1082,32 @@ class SettingsWindow(QDialog):
 
         conf["openai_api_key"] = self.openai_key.text().strip()
         conf["openrouter_api_key"] = self.openrouter_key.text().strip()
+        conf["deepseek_api_key"] = self.deepseek_key.text().strip()
 
-        provider = self.transcribe_provider.currentData() or "openai"
-        self._models[provider] = self.transcribe_model.currentText().strip()
+        provider = self.transcribe_provider.currentData() or "local"
+        self._models[provider] = self._current_model()
         conf["transcribe_provider"] = provider
-        for key, name in (("openai", "transcribe_model"),
+        for key, name in (("local", "local_model"),
+                          ("openai", "transcribe_model"),
                           ("openrouter", "openrouter_transcribe_model")):
             conf[name] = self._models[key].strip() or cfg.DEFAULTS[name]
+        conf["local_gpu"] = self.local_gpu.isChecked()
+        conf["local_preload"] = self.local_preload.isChecked()
+        conf["local_threads"] = self.local_threads.value()
 
         conf["cleanup_enabled"] = self.cleanup_enabled.isChecked()
-        conf["cleanup_model"] = self.cleanup_model.currentText().strip()
-        conf["cleanup_reasoning"] = self.cleanup_reasoning.currentData() or ""
+        cleanup_provider = self.cleanup_provider.currentData() or "openrouter"
+        self._stash_cleanup(cleanup_provider)
+        conf["cleanup_provider"] = cleanup_provider
+        # The two meeting boxes are saved here too, because the cleanup
+        # provider is what decides which of its two values they were showing.
+        for name, openrouter_key, deepseek_key in self._CLEANUP_FIELDS:
+            values = self._cleanup_values[name]
+            for provider, key in (("openrouter", openrouter_key),
+                                  ("deepseek", deepseek_key)):
+                stored = (values[provider] or "").strip()
+                conf[key] = (stored if stored or name.endswith("_reasoning")
+                             else cfg.DEFAULTS[key])
 
         # Store an empty prompt when it matches the default, so switching the
         # interface language also switches the prompt language.
@@ -1056,9 +1151,6 @@ class SettingsWindow(QDialog):
         conf["meeting_self_name"] = self.meeting_self_name.text().strip()
         conf["meeting_other_name"] = self.meeting_other_name.text().strip()
         conf["meeting_participants"] = self.meeting_participants.toPlainText().strip()
-        conf["meeting_model"] = (self.meeting_model.currentText().strip()
-                                 or cfg.DEFAULTS["meeting_model"])
-        conf["meeting_reasoning"] = self.meeting_reasoning.currentData() or ""
         conf["meeting_language"] = self.meeting_language.currentData() or ""
         conf["meeting_cleanup"] = self.meeting_cleanup.isChecked()
         conf["meeting_max_seconds"] = self.meeting_max_minutes.value() * 60
@@ -1091,20 +1183,224 @@ class SettingsWindow(QDialog):
 
     # ---- api helpers -----------------------------------------------------
 
+    def _current_model(self):
+        """The chosen model id.
+
+        The hosted providers take any id the user types, so their box is a
+        free text field. The local one can only run a file it has, so its box
+        is a fixed list and the id travels as the item's data, leaving the
+        label free to say how big the download is.
+        """
+        if self._shown_provider == "local":
+            return self.transcribe_model.currentData() or whispercpp.DEFAULT_MODEL
+        return self.transcribe_model.currentText().strip()
+
     def _provider_changed(self):
         """Swap the model box over to the newly chosen provider's own model."""
         if self._shown_provider:
-            self._models[self._shown_provider] = self.transcribe_model.currentText().strip()
-        provider = self.transcribe_provider.currentData() or "openai"
-        self._shown_provider = provider
+            self._models[self._shown_provider] = self._current_model()
+        provider = self.transcribe_provider.currentData() or "local"
+        local = provider == "local"
+
+        # Blocked because filling the box fires currentIndexChanged for every
+        # item, and _model_changed would read a half-built list.
+        self.transcribe_model.blockSignals(True)
         self.transcribe_model.clear()
-        self.transcribe_model.addItems(TRANSCRIBE_MODELS[provider])
-        self.transcribe_model.setCurrentText(self._models[provider])
-        self.transcribe_status.setText("")
+        self.transcribe_model.setEditable(not local)
+        if local:
+            self._fill_local_models()
+            self._select_data(self.transcribe_model,
+                              self._models["local"] or whispercpp.DEFAULT_MODEL)
+        else:
+            self.transcribe_model.addItems(TRANSCRIBE_MODELS[provider])
+            self.transcribe_model.setCurrentText(self._models[provider])
+        self.transcribe_model.blockSignals(False)
+
+        # Assigned only now: _current_model() above still had to read the box
+        # the way the previous provider filled it.
+        self._shown_provider = provider
+        self.refresh_transcribe_models.setVisible(not local)
+        self.download_model.setVisible(local)
+        self.local_box.setVisible(local)
+        if local:
+            self._refresh_local_status()
+        else:
+            self.transcribe_status.setText("")
+
+    def _fill_local_models(self):
+        """The catalogue, each line saying whether it is here or what it weighs."""
+        for model in whispercpp.MODELS:
+            note = (t("downloaded") if whispercpp.installed(model.id)
+                    else whispercpp.human_size(model.size))
+            self.transcribe_model.addItem(f"{model.label} — {note}", model.id)
+
+    def _model_changed(self):
+        if self._shown_provider == "local" and not self._downloading:
+            self._refresh_local_status()
+
+    @property
+    def _downloading(self):
+        return self._download_thread is not None and self._download_thread.is_alive()
+
+    def _refresh_local_status(self):
+        model_id = self._current_model()
+        self.transcribe_status.setText(
+            whispercpp.status(model_id, self.conf["local_binary"])
+        )
+        # Nothing to fetch for a model that is already on disk; re-downloading
+        # gigabytes by a stray click is not worth the one case it would fix.
+        self.download_model.setEnabled(
+            whispercpp.find(model_id) is not None and not whispercpp.installed(model_id)
+        )
+        self.download_model.setText(t("Download"))
+
+    def _toggle_download(self):
+        if self._downloading:
+            self._download_stop.set()
+            self.download_model.setEnabled(False)
+            self.download_model.setText(t("Stopping…"))
+            return
+
+        model_id = self._current_model()
+        model = whispercpp.find(model_id)
+        if model is None:
+            return
+        self._download_stop.clear()
+        self.download_model.setText(t("Stop"))
+        self.transcribe_status.setText(t("Downloading {model} ({size})…",
+                                         model=model.label,
+                                         size=whispercpp.human_size(model.size)))
+
+        def work():
+            try:
+                landed = whispercpp.download(
+                    model_id,
+                    on_progress=self._report_download,
+                    should_stop=self._download_stop.is_set,
+                )
+                self._download_done.emit(model_id, "" if landed else t("Stopped."))
+            except whispercpp.LocalWhisperError as exc:
+                self._download_done.emit(model_id, str(exc))
+
+        self._download_thread = threading.Thread(target=work, daemon=True)
+        self._download_thread.start()
+
+    def _report_download(self, done, total):
+        self._download_progress.emit(done, total)
+
+    def _on_download_progress(self, done, total):
+        if total:
+            self.transcribe_status.setText(
+                t("Downloading… {percent}% ({done} of {total})",
+                  percent=int(done * 100 / total),
+                  done=whispercpp.human_size(done), total=whispercpp.human_size(total))
+            )
+        else:
+            self.transcribe_status.setText(
+                t("Downloading… {done}", done=whispercpp.human_size(done))
+            )
+
+    def _on_download_done(self, model_id, error):
+        self.download_model.setEnabled(True)
+        if self._shown_provider == "local":
+            # The list carries "downloaded" against each model, so it is now out
+            # of date for the one that just landed.
+            chosen = self._current_model()
+            self.transcribe_model.blockSignals(True)
+            self.transcribe_model.clear()
+            self._fill_local_models()
+            self._select_data(self.transcribe_model, chosen)
+            self.transcribe_model.blockSignals(False)
+            self._refresh_local_status()
+        if error:
+            self.transcribe_status.setText(error)
+        elif whispercpp.installed(model_id):
+            self.transcribe_status.setText(
+                t("{model} downloaded. Press Save to use it.",
+                  model=whispercpp.label(model_id))
+            )
+
+    # ---- cleanup provider ------------------------------------------------
+
+    # The cleanup provider also writes the minutes, so the two model boxes and
+    # the two thinking boxes move together with it. Each provider keeps its own
+    # values, the way the transcription models already do.
+    _CLEANUP_FIELDS = (
+        ("cleanup_model", "cleanup_model", "deepseek_cleanup_model"),
+        ("cleanup_reasoning", "cleanup_reasoning", "deepseek_cleanup_reasoning"),
+        ("meeting_model", "meeting_model", "deepseek_meeting_model"),
+        ("meeting_reasoning", "meeting_reasoning", "deepseek_meeting_reasoning"),
+    )
+
+    def _cleanup_boxes(self):
+        """[(widget, per-provider stash)] for the fields the provider owns."""
+        return [(getattr(self, name), self._cleanup_values[name])
+                for name, _, _ in self._CLEANUP_FIELDS]
+
+    def _stash_cleanup(self, provider):
+        for widget, values in self._cleanup_boxes():
+            values[provider] = (widget.currentData() if not widget.isEditable()
+                                else widget.currentText().strip())
+
+    def _cleanup_provider_changed(self):
+        if self._shown_cleanup_provider:
+            self._stash_cleanup(self._shown_cleanup_provider)
+        provider = self.cleanup_provider.currentData() or "openrouter"
+        deepseek = provider == "deepseek"
+
+        self.cleanup_model.blockSignals(True)
+        self.cleanup_model.clear()
+        self.cleanup_model.addItems(DEEPSEEK_MODELS if deepseek else CLEANUP_MODELS)
+        self.cleanup_model.setCurrentText(self._cleanup_values["cleanup_model"][provider])
+        self.cleanup_model.blockSignals(False)
+
+        self.meeting_model.blockSignals(True)
+        self.meeting_model.clear()
+        self.meeting_model.addItems(DEEPSEEK_MODELS if deepseek else MEETING_MODELS)
+        self.meeting_model.setCurrentText(self._cleanup_values["meeting_model"][provider])
+        self.meeting_model.blockSignals(False)
+
+        for name in ("cleanup_reasoning", "meeting_reasoning"):
+            self._select_data(getattr(self, name), self._cleanup_values[name][provider])
+
+        self._shown_cleanup_provider = provider
+        tip = (t("DeepSeek thinks unless it is told not to, and cleanup is not a "
+                 "job worth thinking about: it costs seconds and can come back "
+                 "with the whole reply spent on the thinking. “Off” is the "
+                 "setting you want here. Minutes are the other way round.")
+               if deepseek else
+               t("How long a thinking model may reason before it answers. Cleanup "
+                 "is a light job, so more thinking mostly costs time and tokens. "
+                 "Models that cannot think ignore this."))
+        self.cleanup_reasoning.setToolTip(tip)
+        self.models_label.setText(
+            t("Cleanup and the meeting minutes both run on {service}.",
+              service="DeepSeek" if deepseek else "OpenRouter")
+        )
+
+    def _test_deepseek(self):
+        key = self.deepseek_key.text().strip() or self.conf.deepseek_key()
+        base = self.conf["deepseek_base_url"]
+        self.ds_test_button.setEnabled(False)
+        self.ds_test_label.setText(t("Trying…"))
+
+        def work():
+            try:
+                self._ds_test_done.emit(True, api.deepseek_key_status(key, base))
+            except api.ApiError as exc:
+                self._ds_test_done.emit(False, str(exc))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _on_ds_test_done(self, ok, message):
+        self.ds_test_button.setEnabled(True)
+        self.ds_test_label.setText(message)
 
     def _load_transcribe_models(self):
         """The model list of whichever provider is selected."""
         provider = self.transcribe_provider.currentData() or "openai"
+        if provider == "local":
+            return
         self.refresh_transcribe_models.setEnabled(False)
         self.transcribe_status.setText(t("Fetching model list…"))
         openai_key = self.openai_key.text().strip() or self.conf.openai_key()
@@ -1136,11 +1432,17 @@ class SettingsWindow(QDialog):
     def _load_models(self):
         self.refresh_models.setEnabled(False)
         self.models_label.setText(t("Fetching model list…"))
-        key = self.openrouter_key.text().strip() or self.conf.openrouter_key()
+        deepseek = self.cleanup_provider.currentData() == "deepseek"
+        key = ((self.deepseek_key.text().strip() or self.conf.deepseek_key())
+               if deepseek else
+               (self.openrouter_key.text().strip() or self.conf.openrouter_key()))
+        base = self.conf["deepseek_base_url"]
 
         def work():
             try:
-                self._models_loaded.emit(api.openrouter_models(key), "")
+                models = (api.deepseek_models(key, base) if deepseek
+                          else api.openrouter_models(key))
+                self._models_loaded.emit(models, "")
             except api.ApiError as exc:
                 self._models_loaded.emit([], str(exc))
 

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tests for transcript cleanup across its two providers.
+
+No key and no network: a local HTTP server stands in for both OpenRouter and
+DeepSeek, and records what was posted to it. What is worth pinning down is the
+payload — the two providers ask for thinking in different words, and DeepSeek's
+default is the opposite of the one cleanup wants.
+
+    python3 -m unittest test_cleanup -v
+"""
+
+import http.server
+import json
+import os
+import threading
+import unittest
+import unittest.mock
+
+import api
+import config as cfg
+
+
+class FakeChat:
+    """Answers /chat/completions and keeps every request body it was sent."""
+
+    def __init__(self, reply=None, status=200):
+        self.requests = []
+        outer = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_POST(self):
+                body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+                outer.requests.append({
+                    "path": self.path,
+                    "payload": json.loads(body.decode("utf-8")),
+                    "auth": self.headers.get("Authorization"),
+                    "headers": {k.lower(): v for k, v in self.headers.items()},
+                })
+                payload = reply if reply is not None else {
+                    "choices": [{"message": {"content": " Temizlenmiş metin. "}}]
+                }
+                raw = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+        self.server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+
+    def last(self):
+        return self.requests[-1]
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        # The messages asserted on below are translated, and building a Config
+        # anywhere in the run switches the language to the system's. Pin it.
+        import i18n
+        self.addCleanup(i18n.set_language, i18n.language())
+        i18n.set_language("en")
+
+    def serve(self, reply=None, status=200):
+        fake = FakeChat(reply, status)
+        self.addCleanup(fake.close)
+        return fake
+
+    def target(self, provider, url, model="m", reasoning="", key="k"):
+        service = "DeepSeek" if provider == "deepseek" else "OpenRouter"
+        return api.Target(provider, service, key, url, model, reasoning)
+
+
+class Payload(Base):
+    def test_the_transcript_is_wrapped_and_the_prompt_is_the_system_message(self):
+        fake = self.serve()
+        out = api.cleanup(self.target("openrouter", fake.url), "ham metin", "kurallar")
+        self.assertEqual(out, "Temizlenmiş metin.")
+        sent = fake.last()
+        self.assertEqual(sent["path"], "/chat/completions")
+        self.assertEqual(sent["payload"]["messages"][0],
+                         {"role": "system", "content": "kurallar"})
+        self.assertIn("<transcript>\nham metin\n</transcript>",
+                      sent["payload"]["messages"][1]["content"])
+        self.assertEqual(sent["payload"]["temperature"], 0)
+        self.assertEqual(sent["auth"], "Bearer k")
+
+    def test_the_model_id_is_the_target_s(self):
+        fake = self.serve()
+        api.cleanup(self.target("deepseek", fake.url, model="deepseek-v4-flash"),
+                    "x", "y")
+        self.assertEqual(fake.last()["payload"]["model"], "deepseek-v4-flash")
+
+    def test_openrouter_gets_its_attribution_headers_and_deepseek_does_not(self):
+        fake = self.serve()
+        api.cleanup(self.target("openrouter", fake.url), "x", "y")
+        self.assertIn("x-title", fake.last()["headers"])
+        api.cleanup(self.target("deepseek", fake.url), "x", "y")
+        self.assertNotIn("x-title", fake.last()["headers"])
+
+
+class Thinking(Base):
+    def test_an_empty_level_asks_for_nothing_either_way(self):
+        fake = self.serve()
+        api.cleanup(self.target("openrouter", fake.url, reasoning=""), "x", "y")
+        self.assertNotIn("reasoning", fake.last()["payload"])
+        api.cleanup(self.target("deepseek", fake.url, reasoning=""), "x", "y")
+        self.assertNotIn("thinking", fake.last()["payload"])
+
+    def test_openrouter_keeps_the_level_as_it_is_and_hides_the_thinking(self):
+        fake = self.serve()
+        api.cleanup(self.target("openrouter", fake.url, reasoning="medium"), "x", "y")
+        self.assertEqual(fake.last()["payload"]["reasoning"],
+                         {"effort": "medium", "exclude": True})
+        self.assertNotIn("thinking", fake.last()["payload"])
+
+    def test_off_turns_deepseek_s_thinking_off_rather_than_down(self):
+        fake = self.serve()
+        api.cleanup(self.target("deepseek", fake.url, reasoning="none"), "x", "y")
+        self.assertEqual(fake.last()["payload"]["thinking"], {"type": "disabled"})
+        self.assertNotIn("reasoning", fake.last()["payload"])
+
+    def test_deepseek_s_two_rungs_take_the_seven_levels(self):
+        # The mapping DeepSeek documents for its own API: low and medium land
+        # on high, xhigh lands on max.
+        fake = self.serve()
+        for level, expected in (("minimal", "high"), ("low", "high"),
+                                ("medium", "high"), ("high", "high"),
+                                ("xhigh", "max"), ("max", "max")):
+            api.cleanup(self.target("deepseek", fake.url, reasoning=level), "x", "y")
+            self.assertEqual(fake.last()["payload"]["thinking"],
+                             {"type": "enabled", "reasoning_effort": expected},
+                             level)
+
+    def test_a_level_nobody_recognises_still_asks_for_thinking(self):
+        fake = self.serve()
+        api.cleanup(self.target("deepseek", fake.url, reasoning="enormous"), "x", "y")
+        self.assertEqual(fake.last()["payload"]["thinking"],
+                         {"type": "enabled", "reasoning_effort": "high"})
+
+
+class Failures(Base):
+    def test_a_missing_key_names_the_provider_that_wants_one(self):
+        with self.assertRaises(api.ApiError) as caught:
+            api.cleanup(self.target("deepseek", "http://x", key=""), "x", "y")
+        self.assertIn("DeepSeek", str(caught.exception))
+
+    def test_an_empty_reply_is_an_error_rather_than_an_empty_paste(self):
+        fake = self.serve({"choices": [{"message": {"content": "  "}}]})
+        with self.assertRaises(api.ApiError):
+            api.cleanup(self.target("deepseek", fake.url), "x", "y")
+
+    def test_a_reply_spent_entirely_on_thinking_says_so(self):
+        # Measured against the real API: with thinking on, deepseek-v4-flash
+        # sometimes returns nothing but reasoning_content. The fix is a
+        # setting, so the message has to point at the setting.
+        fake = self.serve({"choices": [{"message": {
+            "content": "", "reasoning_content": "Önce ıı sesini silerim…"}}]})
+        with self.assertRaises(api.ApiError) as caught:
+            api.cleanup(self.target("deepseek", fake.url, reasoning=""), "x", "y")
+        self.assertIn("Off", str(caught.exception))
+
+    def test_an_http_error_arrives_named(self):
+        fake = self.serve({"error": {"message": "nope"}}, status=401)
+        with self.assertRaises(api.ApiError) as caught:
+            api.cleanup(self.target("deepseek", fake.url), "x", "y")
+        self.assertIn("DeepSeek", str(caught.exception))
+
+
+class Targets(unittest.TestCase):
+    """config picks the provider once; cleanup and the minutes both follow it."""
+
+    def setUp(self):
+        self.conf = cfg.Config()
+        self.conf["openrouter_api_key"] = "or-key"
+        self.conf["deepseek_api_key"] = "ds-key"
+
+    def test_openrouter_is_the_default_and_carries_its_own_models(self):
+        self.conf["cleanup_provider"] = "openrouter"
+        cleanup = self.conf.cleanup_target()
+        minutes = self.conf.minutes_target()
+        self.assertEqual(cleanup.provider, "openrouter")
+        self.assertEqual(cleanup.api_key, "or-key")
+        self.assertEqual(cleanup.model, self.conf["cleanup_model"])
+        self.assertEqual(minutes.model, self.conf["meeting_model"])
+
+    def test_deepseek_swaps_both_jobs_over_together(self):
+        self.conf["cleanup_provider"] = "deepseek"
+        cleanup = self.conf.cleanup_target()
+        minutes = self.conf.minutes_target()
+        for target in (cleanup, minutes):
+            self.assertEqual(target.provider, "deepseek")
+            self.assertEqual(target.api_key, "ds-key")
+            self.assertEqual(target.base_url, "https://api.deepseek.com")
+        self.assertEqual(cleanup.model, "deepseek-v4-flash")
+
+    def test_dictation_is_shipped_with_deepseek_s_thinking_off(self):
+        # Not a preference: with thinking on, cleanup takes seconds instead of
+        # about one, and can come back empty.
+        self.conf["cleanup_provider"] = "deepseek"
+        self.assertEqual(self.conf.cleanup_target().reasoning, "none")
+
+    def test_minutes_are_left_to_think(self):
+        self.conf["cleanup_provider"] = "deepseek"
+        self.assertEqual(self.conf.minutes_target().reasoning, "")
+
+    def test_the_key_falls_back_to_the_environment(self):
+        self.conf["deepseek_api_key"] = ""
+        with unittest.mock.patch.dict(os.environ, {"DEEPSEEK_API_KEY": "env-key"}):
+            self.assertEqual(self.conf.deepseek_key(), "env-key")
+
+    def test_transcription_targets_carry_no_thinking_level(self):
+        self.assertEqual(self.conf.transcribe_target().reasoning, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_whispercpp.py
+++ b/test_whispercpp.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Tests for the local whisper.cpp provider.
+
+Nothing here needs whisper.cpp installed. The download tests serve the bytes
+from a local HTTP server, and the process tests run a stand-in for
+whisper-server: a script that takes the same arguments, opens its port only
+after a pause the way loading a model does, and answers on the inference path.
+That covers the two things that can actually go wrong — the arguments Dikte
+builds, and what it does while and after the process is up.
+
+    python3 -m unittest test_whispercpp -v
+"""
+
+import contextlib
+import http.server
+import json
+import os
+import pathlib
+import re
+import shutil
+import socket
+import tempfile
+import threading
+import time
+import unittest
+import unittest.mock
+
+import api
+import whispercpp
+
+# A stand-in for whisper-server. It records its argv and every request body so
+# the tests can check what Dikte sent, and it binds its port late, which is
+# what makes "the port is open" a real signal rather than one that is true
+# immediately.
+FAKE_SERVER = '''#!/usr/bin/env python3
+import http.server, json, os, re, sys, time
+
+argv = sys.argv[1:]
+record = os.environ["FAKE_RECORD"]
+delay = float(os.environ.get("FAKE_DELAY", "0.2"))
+die = os.environ.get("FAKE_DIE", "")
+
+with open(record + ".attempts", "a") as fh:
+    fh.write("x")
+
+if die:
+    sys.stderr.write("whisper_init_from_file: %s\\n" % die)
+    sys.stderr.flush()
+    sys.exit(1)
+
+def flag(name, default=None):
+    return argv[argv.index(name) + 1] if name in argv else default
+
+port = int(flag("--port"))
+path = flag("--inference-path")
+state = {"argv": argv, "bodies": []}
+
+def save():
+    with open(record, "w") as fh:
+        json.dump(state, fh)
+
+save()
+sys.stderr.write("loading model\\n")
+sys.stderr.flush()
+time.sleep(delay)          # the model load, which happens before the bind
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        text = body.decode("utf-8", "replace")
+        state["bodies"].append({"path": self.path, "body": text})
+        save()
+        if self.path != path:
+            self.send_response(404)
+            self.end_headers()
+            return
+        match = re.search(r'name="response_format"\\r\\n\\r\\n([^\\r]*)', text)
+        fmt = match.group(1) if match else "json"
+        if fmt == "verbose_json":
+            payload = {
+                "task": "transcribe", "language": "turkish", "duration": 3.0,
+                "text": " bir iki uc",
+                "segments": [
+                    {"id": 0, "start": 0.0, "end": 1.5, "text": " bir iki"},
+                    {"id": 1, "start": 1.5, "end": 3.0, "text": " uc"},
+                ],
+            }
+        else:
+            payload = {"text": " bir iki uc"}
+        raw = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+http.server.HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+'''
+
+
+def write_script(directory, body):
+    path = pathlib.Path(directory) / "fake-whisper-server"
+    path.write_text(body)
+    path.chmod(0o755)
+    return str(path)
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="dikte-test-")
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.models = pathlib.Path(self.tmp) / "models"
+        self.models.mkdir()
+        self._real_models_dir = whispercpp.MODELS_DIR
+        whispercpp.MODELS_DIR = self.models
+        self.addCleanup(setattr, whispercpp, "MODELS_DIR", self._real_models_dir)
+        self.addCleanup(whispercpp.stop)
+        # Leave the singleton the way the next test expects to find it.
+        self.addCleanup(whispercpp.configure,
+                        model=whispercpp.DEFAULT_MODEL, threads=0, gpu=True, binary="")
+
+    def make_model(self, model_id, content=b"ggml"):
+        path = whispercpp.model_path(model_id)
+        path.write_bytes(content)
+        return path
+
+
+class Catalogue(Base):
+    def test_ids_are_unique(self):
+        ids = [m.id for m in whispercpp.MODELS]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_default_is_in_the_catalogue(self):
+        self.assertIsNotNone(whispercpp.find(whispercpp.DEFAULT_MODEL))
+
+    def test_every_entry_has_a_label_and_a_size(self):
+        for model in whispercpp.MODELS:
+            self.assertTrue(model.label, model.id)
+            self.assertGreater(model.size, 1_000_000, model.id)
+
+    def test_unknown_id_is_not_found(self):
+        self.assertIsNone(whispercpp.find("large-v9"))
+
+    def test_model_path_is_under_the_models_directory(self):
+        path = whispercpp.model_path("small")
+        self.assertEqual(path.parent, self.models)
+        self.assertEqual(path.name, "ggml-small.bin")
+
+    def test_installed_follows_the_file(self):
+        self.assertFalse(whispercpp.installed("small"))
+        self.make_model("small")
+        self.assertTrue(whispercpp.installed("small"))
+        self.assertEqual(whispercpp.installed_ids(), ["small"])
+
+    def test_an_empty_file_is_not_a_model(self):
+        whispercpp.model_path("small").write_bytes(b"")
+        self.assertFalse(whispercpp.installed("small"))
+
+    def test_human_size(self):
+        self.assertEqual(whispercpp.human_size(512), "512 B")
+        self.assertEqual(whispercpp.human_size(1536), "1.5 KB")
+        self.assertEqual(whispercpp.human_size(3 * 1024 ** 3), "3.0 GB")
+
+    def test_url_points_at_the_ggml_file(self):
+        self.assertTrue(whispercpp.model_url("tiny").endswith("/ggml-tiny.bin"))
+
+
+class Downloads(Base):
+    """The bytes come from a local server, so nothing here touches the network."""
+
+    def serve(self, body, length=None, status=200):
+        payload = body
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                self.send_response(status)
+                self.send_header("Content-Length",
+                                 str(len(payload) if length is None else length))
+                self.end_headers()
+                if status == 200:
+                    # The tests that stop or refuse a download hang up while
+                    # this is still writing, which is not a failure here.
+                    with contextlib.suppress(OSError):
+                        self.wfile.write(payload)
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.shutdown)
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        real = whispercpp.HF_BASE
+        whispercpp.HF_BASE = base
+        self.addCleanup(setattr, whispercpp, "HF_BASE", real)
+        return base
+
+    def test_a_download_lands_and_reports_progress(self):
+        payload = os.urandom(3 * whispercpp.DOWNLOAD_CHUNK + 17)
+        self.serve(payload)
+        seen = []
+        self.assertTrue(
+            whispercpp.download("tiny", on_progress=lambda d, t: seen.append((d, t)))
+        )
+        self.assertEqual(whispercpp.model_path("tiny").read_bytes(), payload)
+        self.assertTrue(seen)
+        self.assertEqual(seen[-1], (len(payload), len(payload)))
+        # Monotonic, and every step reports the same expected total.
+        self.assertEqual([d for d, _ in seen], sorted(d for d, _ in seen))
+
+    def test_stopping_leaves_no_model_and_no_part_file(self):
+        self.serve(os.urandom(4 * whispercpp.DOWNLOAD_CHUNK))
+        self.assertFalse(whispercpp.download("tiny", should_stop=lambda: True))
+        self.assertFalse(whispercpp.installed("tiny"))
+        self.assertEqual(list(self.models.iterdir()), [])
+
+    def test_a_short_body_is_not_renamed_into_place(self):
+        # What a proxy cutting the connection halfway looks like: the length
+        # header promises more than arrives.
+        self.serve(b"only the start", length=10_000_000)
+        with self.assertRaises(whispercpp.LocalWhisperError):
+            whispercpp.download("tiny")
+        self.assertFalse(whispercpp.installed("tiny"))
+        self.assertEqual(list(self.models.iterdir()), [])
+
+    def test_an_http_error_is_reported(self):
+        self.serve(b"", status=404)
+        with self.assertRaises(whispercpp.LocalWhisperError) as caught:
+            whispercpp.download("tiny")
+        self.assertIn("404", str(caught.exception))
+        self.assertFalse(whispercpp.installed("tiny"))
+
+    def test_an_unknown_model_is_refused_before_any_request(self):
+        with self.assertRaises(whispercpp.LocalWhisperError):
+            whispercpp.download("large-v9")
+
+
+class ServerProcess(Base):
+    def setUp(self):
+        super().setUp()
+        self.record = os.path.join(self.tmp, "record.json")
+        os.environ["FAKE_RECORD"] = self.record
+        self.addCleanup(os.environ.pop, "FAKE_RECORD", None)
+        self.addCleanup(os.environ.pop, "FAKE_DELAY", None)
+        self.addCleanup(os.environ.pop, "FAKE_DIE", None)
+        self.binary = write_script(self.tmp, FAKE_SERVER)
+        self.make_model("small")
+        whispercpp.configure(model="small", binary=self.binary, gpu=True, threads=0)
+
+    def recorded(self):
+        with open(self.record) as fh:
+            return json.load(fh)
+
+    def attempts(self):
+        try:
+            with open(self.record + ".attempts") as fh:
+                return len(fh.read())
+        except FileNotFoundError:
+            return 0
+
+    def test_missing_binary_names_the_package(self):
+        whispercpp.configure(binary=os.path.join(self.tmp, "nope"))
+        with self.assertRaises(whispercpp.LocalWhisperError) as caught:
+            whispercpp.serve()
+        self.assertIn("whisper-cpp", str(caught.exception))
+
+    def test_missing_model_points_at_the_settings(self):
+        whispercpp.configure(model="medium")
+        with self.assertRaises(whispercpp.LocalWhisperError) as caught:
+            whispercpp.serve()
+        self.assertIn("medium", str(caught.exception))
+        self.assertFalse(whispercpp.running())
+
+    def test_a_process_that_dies_reports_what_it_printed(self):
+        os.environ["FAKE_DIE"] = "invalid model file"
+        with self.assertRaises(whispercpp.LocalWhisperError) as caught:
+            whispercpp.serve()
+        self.assertIn("invalid model file", str(caught.exception))
+        self.assertFalse(whispercpp.running())
+        # A corrupt model fails the same way every time; retrying only makes
+        # the user wait longer for the same message.
+        self.assertEqual(self.attempts(), 1)
+
+    def test_a_taken_port_is_retried(self):
+        # The wording whisper.cpp uses when bind_to_port fails, which is the
+        # one failure another go can fix: something grabbed the port between
+        # Dikte probing it and the server binding it.
+        os.environ["FAKE_DIE"] = "couldn't bind to server socket: hostname=127.0.0.1"
+        with self.assertRaises(whispercpp.LocalWhisperError):
+            whispercpp.serve()
+        self.assertEqual(self.attempts(), 3)
+
+    def test_serve_starts_it_and_hands_back_a_reachable_url(self):
+        url = whispercpp.serve()
+        self.assertTrue(whispercpp.running())
+        self.assertRegex(url, r"^http://127\.0\.0\.1:\d+/v1$")
+        port = int(url.rsplit(":", 1)[1].split("/")[0])
+        with contextlib.closing(socket.create_connection(("127.0.0.1", port), 2)):
+            pass
+
+    def test_the_arguments_are_the_ones_the_design_relies_on(self):
+        whispercpp.serve()
+        argv = self.recorded()["argv"]
+        self.assertIn("--inference-path", argv)
+        self.assertEqual(argv[argv.index("--inference-path") + 1],
+                         "/v1/audio/transcriptions")
+        self.assertEqual(argv[argv.index("-m") + 1],
+                         str(whispercpp.model_path("small")))
+        self.assertEqual(argv[argv.index("--host") + 1], "127.0.0.1")
+        # "auto" rather than the server's own English default, because api.py
+        # leaves the language field out when it is set to detect.
+        self.assertEqual(argv[argv.index("-l") + 1], "auto")
+        self.assertIn("-sns", argv)
+        self.assertIn("-nlp", argv)
+        self.assertNotIn("-ng", argv)      # the GPU is on
+        self.assertNotIn("-t", argv)       # threads left automatic
+
+    def test_gpu_off_and_a_thread_count_reach_the_command_line(self):
+        whispercpp.configure(gpu=False, threads=6)
+        whispercpp.serve()
+        argv = self.recorded()["argv"]
+        self.assertIn("-ng", argv)
+        self.assertEqual(argv[argv.index("-t") + 1], "6")
+
+    def test_serving_twice_reuses_the_same_process(self):
+        first = whispercpp.serve()
+        started = os.path.getmtime(self.record)
+        time.sleep(0.05)
+        self.assertEqual(whispercpp.serve(), first)
+        self.assertEqual(os.path.getmtime(self.record), started)
+
+    def test_changing_the_model_stops_the_running_server(self):
+        whispercpp.serve()
+        self.make_model("base")
+        whispercpp.configure(model="base")
+        self.assertFalse(whispercpp.running())
+        self.assertEqual(whispercpp.base_url(), "")
+        whispercpp.serve()
+        self.assertEqual(self.recorded()["argv"][1], str(whispercpp.model_path("base")))
+
+    def test_changing_nothing_leaves_it_alone(self):
+        url = whispercpp.serve()
+        whispercpp.configure(model="small", gpu=True, threads=0)
+        self.assertTrue(whispercpp.running())
+        self.assertEqual(whispercpp.base_url(), url)
+
+    def test_stop_is_safe_to_call_twice(self):
+        whispercpp.serve()
+        whispercpp.stop()
+        whispercpp.stop()
+        self.assertFalse(whispercpp.running())
+
+    def test_serve_restarts_a_server_that_went_away(self):
+        whispercpp.serve()
+        whispercpp._SERVER._proc.kill()
+        whispercpp._SERVER._proc.wait(timeout=5)
+        self.assertFalse(whispercpp.running())
+        self.assertTrue(whispercpp.serve())
+        self.assertTrue(whispercpp.running())
+
+    def test_startup_that_never_finishes_times_out(self):
+        os.environ["FAKE_DELAY"] = "30"
+        real = whispercpp.STARTUP_TIMEOUT
+        whispercpp.STARTUP_TIMEOUT = 0.5
+        self.addCleanup(setattr, whispercpp, "STARTUP_TIMEOUT", real)
+        with self.assertRaises(whispercpp.LocalWhisperError):
+            whispercpp.serve()
+        self.assertFalse(whispercpp.running())
+
+    def test_ready_and_status_follow_the_binary_and_the_file(self):
+        self.assertTrue(whispercpp.ready("small", self.binary))
+        self.assertFalse(whispercpp.ready("medium", self.binary))
+        self.assertIn("medium", whispercpp.status("medium", self.binary))
+        self.assertIn("small", whispercpp.status("small", self.binary))
+        self.assertIn("whisper-cpp",
+                      whispercpp.status("small", os.path.join(self.tmp, "nope")))
+
+
+class ThroughApi(Base):
+    """api.py's side: a local target reaches the server and parses its replies."""
+
+    def setUp(self):
+        super().setUp()
+        self.record = os.path.join(self.tmp, "record.json")
+        os.environ["FAKE_RECORD"] = self.record
+        self.addCleanup(os.environ.pop, "FAKE_RECORD", None)
+        self.binary = write_script(self.tmp, FAKE_SERVER)
+        self.make_model("small")
+        whispercpp.configure(model="small", binary=self.binary)
+        self.wav = os.path.join(self.tmp, "clip.wav")
+        with open(self.wav, "wb") as fh:
+            fh.write(b"RIFF----WAVEfmt ")
+        self.target = api.Target("local", "Local Whisper", "local", "", "small")
+
+    def bodies(self):
+        with open(self.record) as fh:
+            return json.load(fh)["bodies"]
+
+    def test_transcribe_fills_in_the_base_url_and_returns_the_text(self):
+        text = api.transcribe(self.target, self.wav, language="tr", prompt="Kubernetes")
+        self.assertEqual(text, "bir iki uc")
+        sent = self.bodies()[-1]
+        self.assertEqual(sent["path"], "/v1/audio/transcriptions")
+        self.assertIn('name="language"\r\n\r\ntr', sent["body"])
+        self.assertIn('name="prompt"\r\n\r\nKubernetes', sent["body"])
+        self.assertIn('name="response_format"\r\n\r\njson', sent["body"])
+
+    def test_auto_leaves_the_language_out_so_the_server_detects(self):
+        api.transcribe(self.target, self.wav, language="auto")
+        self.assertNotIn('name="language"', self.bodies()[-1]["body"])
+
+    def test_segments_come_back_with_their_times(self):
+        segments = api.transcribe_segments(self.target, self.wav, language="tr")
+        self.assertEqual(segments,
+                         [(0.0, 1.5, "bir iki"), (1.5, 3.0, "uc")])
+        self.assertIn('name="response_format"\r\n\r\nverbose_json',
+                      self.bodies()[-1]["body"])
+
+    def test_the_loaded_model_is_not_swapped_out_for_whisper_1(self):
+        # The hosted providers move to whisper-1 for timestamps; the local
+        # server only has the file it was started with.
+        self.assertEqual(api.timestamp_model("local", "small"), "small")
+        api.transcribe_segments(self.target, self.wav)
+        self.assertIn('name="model"\r\n\r\nsmall', self.bodies()[-1]["body"])
+
+    def test_a_missing_model_surfaces_as_an_api_error(self):
+        whispercpp.configure(model="medium")
+        with self.assertRaises(api.ApiError):
+            api.transcribe(self.target._replace(model="medium"), self.wav)
+
+    def test_a_local_target_needs_no_api_key(self):
+        keyless = self.target._replace(api_key="")
+        self.assertEqual(api.transcribe(keyless, self.wav), "bir iki uc")
+
+
+class WordSplits(unittest.TestCase):
+    """whisper.cpp cuts segments on tokens, which lands inside words.
+
+    All of these are the shape the real server returned for a Turkish clip:
+    "akraba değ" and "iller." as two segments, and a plain text where the only
+    thing between them is the newline whisper.cpp puts after every segment.
+    """
+
+    def test_the_line_breaks_come_out_with_nothing_in_their_place(self):
+        raw = ("Tom ve Mary'nin soyadları aynı olmasına rağmen akraba değ\n"
+               "iller.\n Sorun, kamuoyunda tartışmalara yol açtı.")
+        self.assertEqual(
+            api._local_text(raw),
+            "Tom ve Mary'nin soyadları aynı olmasına rağmen akraba değiller."
+            " Sorun, kamuoyunda tartışmalara yol açtı.",
+        )
+
+    def test_a_split_word_is_folded_back_into_one_segment(self):
+        merged = api._merge_word_splits([
+            {"start": 0.0, "end": 3.64, "text": " akraba değ"},
+            {"start": 3.64, "end": 4.08, "text": "iller."},
+            {"start": 5.38, "end": 7.96, "text": " Sorun, yol açtı."},
+        ])
+        self.assertEqual([s["text"] for s in merged],
+                         [" akraba değiller.", " Sorun, yol açtı."])
+        # The merged segment covers both halves of the word.
+        self.assertEqual((merged[0]["start"], merged[0]["end"]), (0.0, 4.08))
+
+    def test_a_segment_that_starts_a_word_is_left_alone(self):
+        segments = [{"start": 0.0, "end": 1.0, "text": " bir"},
+                    {"start": 1.0, "end": 2.0, "text": " iki"}]
+        self.assertEqual(len(api._merge_word_splits(segments)), 2)
+
+    def test_three_pieces_of_one_word_all_fold_together(self):
+        merged = api._merge_word_splits([
+            {"start": 0.0, "end": 1.0, "text": " kar"},
+            {"start": 1.0, "end": 2.0, "text": "şı"},
+            {"start": 2.0, "end": 3.0, "text": "laştırma."},
+        ])
+        self.assertEqual([s["text"] for s in merged], [" karşılaştırma."])
+        self.assertEqual(merged[0]["end"], 3.0)
+
+    def test_hosted_transcripts_keep_their_line_breaks(self):
+        # Only the local branch touches the text; a provider that means its
+        # newlines gets to keep them.
+        self.assertTrue(api._continues_a_word("değ", "iller"))
+        self.assertFalse(api._continues_a_word("değil", " mi"))
+        self.assertFalse(api._continues_a_word("", "iller"))
+
+
+class StaleServers(Base):
+    """A Dikte killed outright leaves the model sitting in graphics memory."""
+
+    def setUp(self):
+        super().setUp()
+        self.record = os.path.join(self.tmp, "record.json")
+        os.environ["FAKE_RECORD"] = self.record
+        self.addCleanup(os.environ.pop, "FAKE_RECORD", None)
+        self.binary = write_script(self.tmp, FAKE_SERVER)
+        self.make_model("small")
+        whispercpp.configure(model="small", binary=self.binary)
+
+    def test_the_pid_is_written_down_while_the_server_runs(self):
+        whispercpp.serve()
+        pid = int(whispercpp._pid_file().read_text())
+        self.assertEqual(pid, whispercpp._SERVER._proc.pid)
+
+    def test_a_clean_stop_takes_the_note_away(self):
+        whispercpp.serve()
+        whispercpp.stop()
+        self.assertFalse(whispercpp._pid_file().exists())
+
+    def test_a_leaked_server_is_swept_on_the_next_start(self):
+        whispercpp.serve()
+        proc = whispercpp._SERVER._proc
+        self.addCleanup(proc.wait)
+        self.addCleanup(proc.kill)
+        # What a SIGKILL on Dikte leaves behind: the process is still running
+        # and nothing in this interpreter knows about it any more.
+        whispercpp._SERVER._proc = None
+        self.assertIsNone(proc.poll())
+
+        self.assertTrue(whispercpp.sweep())
+        proc.wait(timeout=10)
+        self.assertIsNotNone(proc.poll())
+        self.assertFalse(whispercpp._pid_file().exists())
+
+    def test_a_reused_pid_belonging_to_something_else_is_left_alone(self):
+        # pids come round again; killing whatever holds the number now would be
+        # a good deal worse than the leak.
+        whispercpp._pid_file().parent.mkdir(parents=True, exist_ok=True)
+        whispercpp._pid_file().write_text(str(os.getpid()))
+        self.assertFalse(whispercpp.sweep())
+        self.assertFalse(whispercpp._pid_file().exists())
+
+    def test_no_note_means_nothing_to_sweep(self):
+        self.assertFalse(whispercpp.sweep())
+
+    def test_a_pid_that_is_gone_is_not_an_error(self):
+        whispercpp._pid_file().parent.mkdir(parents=True, exist_ok=True)
+        whispercpp._pid_file().write_text("999999")
+        self.assertFalse(whispercpp.sweep())
+
+
+class ConfigWiring(Base):
+    def test_the_target_is_local_and_carries_no_base_url(self):
+        import config as cfg
+        conf = cfg.Config()
+        conf["transcribe_provider"] = "local"
+        conf["local_model"] = "small"
+        target = conf.transcribe_target()
+        self.assertEqual(target.provider, "local")
+        self.assertEqual(target.model, "small")
+        # api.py fills this in when the server is actually needed; reading the
+        # settings must not start a process.
+        self.assertEqual(target.base_url, "")
+        self.assertFalse(whispercpp.running())
+
+    def test_readiness_asks_about_the_model_not_a_key(self):
+        import config as cfg
+        conf = cfg.Config()
+        conf["transcribe_provider"] = "local"
+        conf["local_model"] = "small"
+        conf["local_binary"] = write_script(self.tmp, FAKE_SERVER)
+        self.assertFalse(conf.transcribe_ready())
+        self.make_model("small")
+        self.assertTrue(conf.transcribe_ready())
+
+    def test_hosted_providers_still_go_by_the_key(self):
+        import config as cfg
+        conf = cfg.Config()
+        conf["transcribe_provider"] = "openai"
+        conf["openai_api_key"] = ""
+        with unittest.mock.patch.dict(os.environ, {"OPENAI_API_KEY": ""}):
+            self.assertFalse(conf.transcribe_ready())
+        conf["openai_api_key"] = "sk-test"
+        self.assertTrue(conf.transcribe_ready())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/whispercpp.py
+++ b/whispercpp.py
@@ -1,0 +1,512 @@
+"""Local speech to text: the whisper.cpp server, kept alive next to Dikte.
+
+The point of running a server rather than `whisper-cli` once per dictation is
+the model: whisper-cli loads it from scratch every time, which on a large model
+costs a second or two before a word is transcribed, while a dictation of a few
+seconds is otherwise over almost as soon as it is spoken.
+
+The server is started on `--inference-path /v1/audio/transcriptions`, which is
+exactly the path api.py builds for the hosted providers, so a local run is one
+more base URL rather than a second transcription code path. It also accepts the
+same `language`, `prompt` and `response_format` fields, and its `verbose_json`
+carries OpenAI's segment shape, so timestamps come back unchanged too.
+
+Nothing here imports the rest of Dikte apart from the string table: this module
+knows how to fetch a model and how to run a process, and nothing about
+dictation. Its errors leave as LocalWhisperError and api.py turns them into the
+ApiError the interface already knows how to show.
+"""
+
+import atexit
+import collections
+import http.client
+import os
+import pathlib
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from i18n import t
+
+BINARY = "whisper-server"
+HOST = "127.0.0.1"
+# The path api.py asks for, so its URL and the server's line up.
+INFERENCE_PATH = "/v1/audio/transcriptions"
+HF_BASE = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main"
+DEFAULT_MODEL = "large-v3-turbo"
+
+# Loading a large model onto the GPU is the slow part of a start; a minute is
+# far past that even on a cold page cache.
+STARTUP_TIMEOUT = 60.0
+DOWNLOAD_CHUNK = 1 << 20
+
+MODELS_DIR = (pathlib.Path(os.environ.get("XDG_DATA_HOME")
+                           or os.path.expanduser("~/.local/share"))
+              / "dikte" / "models")
+
+# `size` is what the download is expected to weigh, used to warn before it
+# starts and to draw the progress bar before the first response header arrives.
+Model = collections.namedtuple("Model", "id label size")
+
+MODELS = [
+    Model("large-v3-turbo", "large-v3-turbo", 1_624_555_275),
+    Model("large-v3-turbo-q5_0", "large-v3-turbo (q5_0)", 574_041_195),
+    Model("large-v3", "large-v3", 3_095_033_483),
+    Model("large-v3-q5_0", "large-v3 (q5_0)", 1_080_732_493),
+    Model("medium", "medium", 1_533_763_059),
+    Model("medium-q5_0", "medium (q5_0)", 539_212_467),
+    Model("small", "small", 487_601_967),
+    Model("base", "base", 147_951_465),
+    Model("tiny", "tiny", 77_691_713),
+]
+
+MODEL_IDS = [m.id for m in MODELS]
+
+
+class LocalWhisperError(Exception):
+    pass
+
+
+def find(model_id):
+    for model in MODELS:
+        if model.id == model_id:
+            return model
+    return None
+
+
+def label(model_id):
+    model = find(model_id)
+    return model.label if model else model_id
+
+
+def human_size(count):
+    for unit in ("B", "KB", "MB", "GB"):
+        if count < 1024 or unit == "GB":
+            return f"{count:.0f} {unit}" if unit == "B" else f"{count:.1f} {unit}"
+        count /= 1024.0
+    return f"{count:.1f} GB"
+
+
+def binary_path(custom=""):
+    """The whisper-server to run, or "" when there is none."""
+    custom = (custom or "").strip()
+    if custom:
+        return custom if os.path.isfile(custom) and os.access(custom, os.X_OK) else ""
+    return shutil.which(BINARY) or ""
+
+
+def available(custom=""):
+    return bool(binary_path(custom))
+
+
+def models_dir():
+    return MODELS_DIR
+
+
+def model_path(model_id):
+    return MODELS_DIR / f"ggml-{model_id}.bin"
+
+
+def installed(model_id):
+    path = model_path(model_id)
+    return path.is_file() and path.stat().st_size > 0
+
+
+def installed_ids():
+    return [m.id for m in MODELS if installed(m.id)]
+
+
+def model_url(model_id):
+    return f"{HF_BASE}/ggml-{model_id}.bin"
+
+
+def delete(model_id):
+    try:
+        model_path(model_id).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        raise LocalWhisperError(
+            t("Could not delete the model: {error}", error=exc)) from exc
+
+
+def download(model_id, on_progress=None, should_stop=None):
+    """Fetch a model into the models directory. True when it landed.
+
+    The bytes go to a `.part` file that is only renamed once the whole download
+    has arrived, so an interrupted one can never be mistaken for a model: a
+    truncated .bin would be found by installed() and fail much later, inside the
+    server, with a message about a corrupt file.
+    """
+    if find(model_id) is None:
+        raise LocalWhisperError(t("Unknown model: {model}", model=model_id))
+    target = model_path(model_id)
+    part = target.with_name(target.name + ".part")
+    try:
+        MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise LocalWhisperError(
+            t("Could not create the model directory: {error}", error=exc)) from exc
+
+    request = urllib.request.Request(
+        model_url(model_id), headers={"User-Agent": "dikte/1.0"})
+    done = 0
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            total = int(response.headers.get("Content-Length") or 0)
+            with open(part, "wb") as out:
+                while True:
+                    if should_stop is not None and should_stop():
+                        part.unlink(missing_ok=True)
+                        return False
+                    block = response.read(DOWNLOAD_CHUNK)
+                    if not block:
+                        break
+                    out.write(block)
+                    done += len(block)
+                    if on_progress is not None:
+                        on_progress(done, total)
+        # A proxy or an error page that came back as 200 would otherwise be
+        # renamed into place and only fail when the server tries to read it.
+        if total and done != total:
+            part.unlink(missing_ok=True)
+            raise LocalWhisperError(
+                t("The download stopped early ({done} of {total}).",
+                  done=human_size(done), total=human_size(total)))
+        part.replace(target)
+        return True
+    except urllib.error.HTTPError as exc:
+        part.unlink(missing_ok=True)
+        exc.close()   # it holds the response body open until it is collected
+        raise LocalWhisperError(
+            t("Could not download the model: HTTP {code}", code=exc.code)) from exc
+    except urllib.error.URLError as exc:
+        part.unlink(missing_ok=True)
+        raise LocalWhisperError(
+            t("Could not download the model: {error}", error=exc.reason)) from exc
+    except http.client.HTTPException as exc:
+        # A connection cut mid-body: not an OSError, and gigabytes in it is
+        # exactly where that happens.
+        part.unlink(missing_ok=True)
+        raise LocalWhisperError(
+            t("Could not download the model: {error}", error=exc)) from exc
+    except OSError as exc:
+        part.unlink(missing_ok=True)
+        raise LocalWhisperError(
+            t("Could not write the model: {error}", error=exc)) from exc
+
+
+def _free_port():
+    """A port nothing is listening on, handed straight to the server.
+
+    Between closing this socket and the server binding it, something else could
+    take it; that is why start() retries rather than trusting the number.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((HOST, 0))
+        return sock.getsockname()[1]
+
+
+def _listening(port):
+    try:
+        with socket.create_connection((HOST, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def _pid_file():
+    return MODELS_DIR.parent / "whisper-server.pid"
+
+
+def _remember(pid):
+    try:
+        path = _pid_file()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(pid))
+    except OSError:
+        pass       # the sweep is a safety net, not something to fail a run over
+
+
+def _forget():
+    try:
+        _pid_file().unlink()
+    except OSError:
+        pass
+
+
+def _is_our_server(pid):
+    """Whether that pid is still the whisper-server this Dikte started.
+
+    Asked because pids are handed out again: by the time anyone looks, the
+    number could belong to something else entirely, and killing it would be a
+    good deal worse than the leak being cleaned up.
+    """
+    try:
+        blob = pathlib.Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return False
+    # All three together, rather than the program name alone: the name could
+    # belong to a whisper-server somebody else is running, while the model
+    # directory and the path Dikte alone asks the server to listen on could
+    # not. Matching on the whole command line rather than argv[0] also covers
+    # a binary setting that points at a wrapper script.
+    return all(part in blob for part in
+               (BINARY.encode(), INFERENCE_PATH.encode(), str(MODELS_DIR).encode()))
+
+
+def sweep():
+    """Kill a server a previous Dikte left behind. True when one was found.
+
+    stop() and atexit cover every exit that gets to run code. A SIGKILL does
+    not, and neither does the session being torn down from under it, and
+    whisper-server would then sit there holding a gigabyte and a half of
+    graphics memory with nothing left alive to ask it anything.
+    """
+    try:
+        pid = int(_pid_file().read_text().strip())
+    except (OSError, ValueError):
+        return False
+    _forget()
+    if not _is_our_server(pid):
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return False
+    return True
+
+
+def _tail(path, lines=3):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            found = [line.strip() for line in fh if line.strip()]
+    except OSError:
+        return ""
+    return " | ".join(found[-lines:])
+
+
+class _Server:
+    """The one whisper-server process, started when something needs it."""
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._proc = None
+        self._port = 0
+        self._log = ""
+        self._running_key = None
+        self._settings = {
+            "model": DEFAULT_MODEL,
+            "threads": 0,
+            "gpu": True,
+            "binary": "",
+        }
+
+    # ---- settings --------------------------------------------------------
+
+    def configure(self, **changes):
+        """Apply settings; a running server started on the old ones is stopped."""
+        with self._lock:
+            for key, value in changes.items():
+                if value is not None and key in self._settings:
+                    self._settings[key] = value
+            if self._proc is not None and self._running_key != self._key():
+                self.stop()
+
+    def settings(self):
+        with self._lock:
+            return dict(self._settings)
+
+    def _key(self):
+        settings = self._settings
+        return (str(model_path(settings["model"])), int(settings["threads"]),
+                bool(settings["gpu"]), binary_path(settings["binary"]))
+
+    # ---- process ---------------------------------------------------------
+
+    @property
+    def running(self):
+        with self._lock:
+            return self._proc is not None and self._proc.poll() is None
+
+    def base_url(self):
+        with self._lock:
+            return f"http://{HOST}:{self._port}/v1" if self.running else ""
+
+    def serve(self):
+        """The base URL of a server that is up and running the chosen model."""
+        with self._lock:
+            if self.running and self._running_key == self._key():
+                return self.base_url()
+            self.stop()
+            self._start()
+            return self.base_url()
+
+    def _start(self):
+        settings = self._settings
+        binary = binary_path(settings["binary"])
+        if not binary:
+            raise LocalWhisperError(
+                t("whisper.cpp is not installed. Install it with: "
+                  "sudo pacman -S whisper-cpp"))
+        model = model_path(settings["model"])
+        if not installed(settings["model"]):
+            raise LocalWhisperError(
+                t("The local model “{model}” has not been downloaded. Settings → "
+                  "API and models → Download.", model=label(settings["model"])))
+
+        last = ""
+        for _ in range(3):
+            port = _free_port()
+            log = tempfile.NamedTemporaryFile(
+                prefix="dikte-whisper-", suffix=".log", delete=False)
+            log.close()
+            args = [
+                binary, "-m", str(model),
+                "--host", HOST, "--port", str(port),
+                "--inference-path", INFERENCE_PATH,
+                # Whatever language the request does not name; api.py leaves the
+                # field out when the language is "auto", and the server's own
+                # default is English rather than detection.
+                "-l", "auto",
+                # Stock phrases invented for near-silence come from non-speech
+                # tokens, and verbose_json otherwise pays for a language
+                # probability sweep nothing here reads.
+                "-sns", "-nlp",
+            ]
+            if int(settings["threads"]) > 0:
+                args += ["-t", str(int(settings["threads"]))]
+            if not settings["gpu"]:
+                args.append("-ng")
+
+            try:
+                with open(log.name, "wb") as sink:
+                    proc = subprocess.Popen(
+                        args, stdout=sink, stderr=subprocess.STDOUT,
+                        stdin=subprocess.DEVNULL,
+                    )
+            except OSError as exc:
+                os.unlink(log.name)
+                raise LocalWhisperError(
+                    t("Could not start whisper.cpp: {error}", error=exc)) from exc
+
+            # Written now rather than once it is ready, so that a kill during
+            # the model load leaves something for the sweep to find too.
+            _remember(proc.pid)
+            if self._wait_ready(proc, port):
+                self._proc, self._port, self._log = proc, port, log.name
+                self._running_key = self._key()
+                return
+            last = _tail(log.name)
+            os.unlink(log.name)
+            _forget()
+            # A port taken between the probe and the bind is the one failure
+            # worth another go; anything else will fail the same way again.
+            if "address" not in last.lower() and "bind" not in last.lower():
+                break
+        raise LocalWhisperError(
+            t("whisper.cpp did not start: {error}", error=last or t("no output")))
+
+    def _wait_ready(self, proc, port):
+        """The port opens only after the model is loaded, so it is the signal."""
+        deadline = time.monotonic() + STARTUP_TIMEOUT
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                return False
+            if _listening(port):
+                return True
+            time.sleep(0.1)
+        proc.kill()
+        proc.wait(timeout=5)
+        return False
+
+    def stop(self):
+        with self._lock:
+            proc, log = self._proc, self._log
+            self._proc, self._port, self._log, self._running_key = None, 0, "", None
+        if proc is not None and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        if log:
+            try:
+                os.unlink(log)
+            except OSError:
+                pass
+        if proc is not None:
+            _forget()
+
+    def error(self):
+        """The last thing the server printed, for a failure after it started."""
+        with self._lock:
+            return _tail(self._log) if self._log else ""
+
+
+_SERVER = _Server()
+
+
+def configure(**changes):
+    _SERVER.configure(**changes)
+
+
+def settings():
+    return _SERVER.settings()
+
+
+def serve():
+    return _SERVER.serve()
+
+
+def stop():
+    _SERVER.stop()
+
+
+def running():
+    return _SERVER.running
+
+
+def base_url():
+    return _SERVER.base_url()
+
+
+def error():
+    return _SERVER.error()
+
+
+def ready(model_id=None, binary=""):
+    """Both halves are in place: the program is installed and the model is here."""
+    model_id = model_id or _SERVER.settings()["model"]
+    return available(binary) and installed(model_id)
+
+
+def status(model_id=None, binary=""):
+    """One line for the settings window."""
+    current = _SERVER.settings()
+    model_id = model_id or current["model"]
+    if not available(binary):
+        return t("whisper.cpp is not installed. Install it with: "
+                 "sudo pacman -S whisper-cpp")
+    if not installed(model_id):
+        model = find(model_id)
+        return t("“{model}” has not been downloaded yet ({size}).",
+                 model=label(model_id),
+                 size=human_size(model.size) if model else "?")
+    if _SERVER.running and _SERVER.settings()["model"] == model_id:
+        return t("Running: {model}, {device}.", model=label(model_id),
+                 device=t("GPU") if current["gpu"] else t("CPU"))
+    return t("Ready: {model}, {device}. It loads on the first dictation.",
+             model=label(model_id), device=t("GPU") if current["gpu"] else t("CPU"))
+
+
+# Dikte stops the server itself on quit and on restart; this catches the paths
+# that skip that, such as an unhandled exception on the way out.
+atexit.register(stop)

--- a/worker.py
+++ b/worker.py
@@ -102,20 +102,14 @@ class Pipeline(QObject):
 
             text = raw
             warning = ""
+            cleaner = conf.cleanup_target()
             # Claude reads through “eee” and “hani” without help, so a dictation
             # on its way there is normally sent as it was heard, one API call and
             # a second or two lighter.
             if (conf["assistant_cleanup"] if ask else conf["cleanup_enabled"]):
                 self.stage.emit(t("Cleaning up…"))
                 try:
-                    text = api.cleanup(
-                        raw,
-                        conf.openrouter_key(),
-                        conf["cleanup_model"],
-                        conf.cleanup_prompt(),
-                        reasoning=conf["cleanup_reasoning"],
-                        base_url=conf["openrouter_base_url"],
-                    )
+                    text = api.cleanup(cleaner, raw, conf.cleanup_prompt())
                 except api.ApiError as exc:
                     # Keep the transcript, but never let the failure pass unseen:
                     # a rejected key would otherwise look like working dictation.
@@ -151,7 +145,7 @@ class Pipeline(QObject):
                 "duration": round(duration, 1),
                 "elapsed": round(time.monotonic() - started, 1),
                 "model": target.model,
-                "cleanup_model": conf["cleanup_model"] if conf["cleanup_enabled"] else "",
+                "cleanup_model": cleaner.model if conf["cleanup_enabled"] else "",
                 "cleanup_error": warning,
                 "mode": "ask" if ask else "",
                 "question": question,


### PR DESCRIPTION
Two providers, one at each end of the chain. Both are additions: the existing OpenAI and OpenRouter paths are untouched, and either can be switched back to from Settings.

## Speech to text on whisper.cpp

The server is started on `--inference-path /v1/audio/transcriptions`, which is exactly the path `api.py` already builds for the hosted providers. That makes a local run one more base URL rather than a second transcription code path — `worker.py`, `filetranscribe.py` and `meeting.py` are not touched, and dictation, file transcription, subtitles and meetings all work locally on the first try. The server also takes the same `language`, `prompt` and `response_format` fields, and its `verbose_json` carries OpenAI's segment shape, so timestamps come back unchanged too.

`whisper-server` loads the model before it binds its port, so the port opening *is* the readiness signal; no health endpoint needed. The model is loaded while Dikte starts rather than on the first dictation, which is the point of a server over `whisper-cli`: on an RTX 4060, loading `large-v3-turbo` takes ~1.4 s while transcribing 2.6 s of speech takes 0.15 s. Loading is the slow part, not transcribing. There is a checkbox for the machine whose graphics memory is wanted elsewhere.

Models are downloaded from Settings into `~/.local/share/dikte/models`, via a `.part` file that is only renamed once the whole thing has arrived — a truncated `.bin` would otherwise be found by `installed()` and fail much later, inside the server.

`whisper-cpp` is in the Arch repos, and the `ggml` package provides the CUDA backend, so this stays within "system packages, stdlib and PyQt6". `whispercpp.py` imports nothing from the rest of Dikte except the string table.

## Cleanup on DeepSeek

`api.cleanup()` now takes a target the way transcription does, and the provider it names also writes the meeting minutes. DeepSeek's own API rather than OpenRouter's copy: no middleman's cut, one more key instead of one more account.

Worth knowing, and the reason the thinking level is kept per provider: **DeepSeek thinks unless it is told not to**, and cleanup is not a job worth thinking about. Measured on the README's own example:

| | time | result |
|---|---|---|
| `deepseek-v4-flash`, thinking off | 1.33 s | matches the README's expected output exactly |
| `deepseek-v4-flash`, model default | — | came back empty |
| `deepseek-v4-pro`, thinking off | 1.68 s | same output |
| `deepseek-v4-pro`, model default | 7.93 s | same output |

With thinking on, 359 of 379 completion tokens went on reasoning about punctuation. So DeepSeek ships with cleanup at **Thinking: Off** and the minutes, which are worth thinking about, left to think. `DEEPSEEK_EFFORT` follows the same shape as `assistant.py`'s `CLAUDE_EFFORT` and `CODEX_EFFORT`.

## Four bugs found on the way, none in the new code

- **whisper.cpp cuts segments on tokens**, which in Turkish lands inside a word about as often as between two, and joins them with newlines. Pasted raw that gave `akraba değ\niller.`; in a subtitle it gave a cue reading `değ`. Whisper marks the start of a word with a leading space, so a piece that does not begin with one continues the word above it: the line breaks come out with nothing in their place, and a segment beginning mid-word is folded into the one before it. Local provider only.
- **`whisper-server` outlived SIGTERM and SIGKILL**, holding the model in graphics memory with nothing left to ask it anything. `shutdown()` and `atexit` cover every exit that runs code; a logout runs none. Signals are now turned into an event Qt delivers (`set_wakeup_fd` + `QSocketNotifier`, since Qt blocks in C where a Python handler never runs), and a pid file lets the next start sweep a server a SIGKILL left behind.
- **Those handlers have to be installed before `Dikte` is built**, because building it is what starts the server. Installing them after left a window where a signal took the default action and leaked the server — measured, then fixed.
- **The built-in shortcut listener was only ever started from the settings window**, so `evdev_hotkey` did not survive a restart — including the tray's own Restart and the autostart on login.

## Testing

`test_whispercpp.py` (48) and `test_cleanup.py` (18) — stdlib `unittest`, no network, no key, and whisper.cpp not required: a stand-in script takes the same arguments and opens its port late, and a local HTTP server answers `/chat/completions`. Both suites pass clean under `-W error::ResourceWarning`.

Verified against the real thing on an RTX 4060 with `whisper-cpp` 1.9.1 and `cuda` 13.3.1: six Turkish sentences transcribed character-for-character against their known text, correct SRT cues, English sample exact, language auto-detection working, and the full dictation chain through `worker.py` ending in the clipboard.

## One default changes

`transcribe_provider` now defaults to `local`. Anyone with an existing `config.json` keeps whatever they had — the stored value wins — so this only affects a fresh install, where the settings window now opens when the binary or the model is missing rather than when a key is.