### PR TITLE
A key for discarding a recording, plus uninstall.sh and update.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ dikte                        # the settings window opens on first run
 ```
 
 `install.sh` adds the `dikte` command, a menu entry, an autostart entry and the
-two KDE shortcuts, whose keys are its two arguments.
+two KDE shortcuts, whose keys are its two arguments. `./update.sh` pulls and puts
+all of that back, keeping the keys you chose rather than the defaults, and
+restarts Dikte if it was running. `./uninstall.sh` takes it all away again and
+leaves your settings and dictations alone unless you pass `--purge`.
 
 Two keys go in the settings window: **OpenAI** and **OpenRouter**. Speech to text
 runs on either one (`gpt-4o-transcribe` by default), cleanup always on

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ just the Python standard library and PyQt6.
 sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6
 systemctl --user enable --now ydotool     # needed for auto-paste
 
-./install.sh                 # or:  ./install.sh "Ctrl+Alt+Space"
+./install.sh                 # or:  ./install.sh "Meta+Space" "Meta+Shift+Space"
 dikte                        # the settings window opens on first run
 ```
 
 `install.sh` adds the `dikte` command, a menu entry, an autostart entry and the
-KDE shortcut.
+two KDE shortcuts, whose keys are its two arguments.
 
 Two keys go in the settings window: **OpenAI** and **OpenRouter**. Speech to text
 runs on either one (`gpt-4o-transcribe` by default), cleanup always on
@@ -45,7 +45,7 @@ set next to it.
 | What | How |
 | --- | --- |
 | Start / stop recording | `Ctrl+Space`, or click the tray icon |
-| Cancel a recording | Tray menu → *Cancel recording*, or `dikte cancel` |
+| Throw the recording away | `Ctrl+Alt+Space`, tray menu → *Cancel recording*, or `dikte cancel` |
 | Speak a command to an agent | Tray menu → *Ask Claude*, or `dikte ask` |
 | Start / end a meeting | Tray menu → *Record a meeting*, or `dikte meeting` |
 | Settings | Tray menu → *Settings*, or `dikte settings` |
@@ -58,6 +58,13 @@ elapsed time, then the stage it is on. It never takes focus. Pressing
 A dictation and a command to the agent do wait on each other for the microphone,
 which is one device, but for nothing else: each has its own indicator, and the
 second one stacks above the first while both are up.
+
+Stopping is the step there is no taking back: it sends the audio off, and a
+moment later the sentence you did not mean to dictate is in your clipboard and
+pasted. So throwing a recording away has a key of its own, one modifier along
+from the key that started it, and it works on whichever of the two is running.
+Escape would have been the obvious choice and is the wrong one: it belongs to
+whatever window has focus, and something else is usually focused while you talk.
 
 ## What it does
 
@@ -112,9 +119,9 @@ second one stacks above the first while both are up.
   right-click to delete.
 - **Turkish and English interface**, following the system locale by default.
 
-## The global shortcut needs one logout
+## The global shortcuts need one logout
 
-KWin only reads `kglobalshortcutsrc` at startup, so the shortcut `install.sh`
+KWin only reads `kglobalshortcutsrc` at startup, so the shortcuts `install.sh`
 writes will not fire until you log out and back in. Until then, Settings →
 Shortcut → **built-in listener** reads `/dev/input` and catches the combination
 itself. The difference: it does not swallow the key, so `Ctrl+Space` also reaches

--- a/README.tr.md
+++ b/README.tr.md
@@ -30,7 +30,11 @@ dikte                        # ilk açılışta ayarlar penceresi gelir
 ```
 
 `install.sh` `dikte` komutunu, menü girdisini, oturum açılışında otomatik
-başlatmayı ve iki KDE kısayolunu kurar; tuşları da iki argümanı.
+başlatmayı ve iki KDE kısayolunu kurar; tuşları da iki argümanı. `./update.sh`
+son sürümü çeker, bütün bunları yerine koyar — varsayılanları değil senin
+seçtiğin tuşları koruyarak — ve çalışıyorsa dikteyi yeniden başlatır.
+`./uninstall.sh` hepsini geri alır; `--purge` demedikçe ayarlarına ve
+diktelerine dokunmaz.
 
 Ayarlar penceresinde iki anahtar istenir: **OpenAI** ve **OpenRouter**. Sesi
 yazıya çevirme ikisinden birinde çalışır (varsayılan `gpt-4o-transcribe`),

--- a/README.tr.md
+++ b/README.tr.md
@@ -25,12 +25,12 @@ sadece Python standart kütüphanesi ve PyQt6.
 sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6
 systemctl --user enable --now ydotool     # otomatik yapıştırma için
 
-./install.sh                 # ya da:  ./install.sh "Ctrl+Alt+Space"
+./install.sh                 # ya da:  ./install.sh "Meta+Space" "Meta+Shift+Space"
 dikte                        # ilk açılışta ayarlar penceresi gelir
 ```
 
 `install.sh` `dikte` komutunu, menü girdisini, oturum açılışında otomatik
-başlatmayı ve KDE kısayolunu kurar.
+başlatmayı ve iki KDE kısayolunu kurar; tuşları da iki argümanı.
 
 Ayarlar penceresinde iki anahtar istenir: **OpenAI** ve **OpenRouter**. Sesi
 yazıya çevirme ikisinden birinde çalışır (varsayılan `gpt-4o-transcribe`),
@@ -45,7 +45,7 @@ yapıştırılır; modelin yanındaki kutudan düşünme seviyesini de seçebili
 | Ne | Nasıl |
 | --- | --- |
 | Kaydı başlat / bitir | `Ctrl+Space`, ya da tepsi simgesine tıkla |
-| Kaydı iptal et | Tepsi menüsü → *Kaydı iptal et*, ya da `dikte cancel` |
+| Kaydı çöpe at | `Ctrl+Alt+Space`, tepsi menüsü → *Kaydı iptal et*, ya da `dikte cancel` |
 | Ajana sesle komut ver | Tepsi menüsü → *Claude'a sor*, ya da `dikte ask` |
 | Toplantıyı başlat / bitir | Tepsi menüsü → *Toplantı kaydet*, ya da `dikte meeting` |
 | Ayarlar | Tepsi menüsü → *Ayarlar*, ya da `dikte settings` |
@@ -58,6 +58,13 @@ süreyi, ardından hangi aşamada olduğunu gösterir. Odak almaz. Dikte çalı�
 verilen komut yalnızca mikrofon için birbirini bekler, o da tek aygıt olduğu
 için; başka hiçbir şeyde beklemezler. Her birinin kendi göstergesi var, ikisi
 birden ekrandayken ikincisi birincinin üstüne yerleşir.
+
+Geri dönüşü olmayan adım kaydı bitirmek: ses o anda yola çıkar, biraz sonra da
+söylemek istemediğin cümle panoda ve yapıştırılmış olur. Bu yüzden kaydı çöpe
+atmanın kendi tuşu var — başlatan tuşun bir değiştirici ötesi — ve hangisi
+çalışıyorsa ona işler. Akla ilk gelen Escape olurdu ve yanlış olan da o:
+Escape odaktaki pencereye aittir, sen konuşurken de genelde başka bir şey
+odaktadır.
 
 ## Neler yapıyor
 
@@ -110,10 +117,10 @@ birden ekrandayken ikincisi birincinin üstüne yerleşir.
   silebilirsin.
 - **Türkçe ve İngilizce arayüz**, varsayılan olarak sistem dilini izler.
 
-## Global kısayol için bir kez oturum kapatmak gerekir
+## Global kısayollar için bir kez oturum kapatmak gerekir
 
 KWin `kglobalshortcutsrc` dosyasını yalnızca açılışta okur, yani `install.sh`'ın
-yazdığı kısayol oturumu yeniden açana kadar tetiklenmez. O zamana kadar Ayarlar →
+yazdığı kısayollar oturumu yeniden açana kadar tetiklenmez. O zamana kadar Ayarlar →
 Kısayol → **yerleşik dinleyici** `/dev/input` üzerinden kombinasyonu kendisi
 yakalar. Tek farkı: tuşu yutmaz, yani `Ctrl+Space` odaktaki uygulamaya da iletilir
 (bazı editörlerde otomatik tamamlama açılabilir). Dinleyici kullanıcının `input`

--- a/config.py
+++ b/config.py
@@ -385,6 +385,10 @@ DEFAULTS = {
     "min_voiced_seconds": 0.3,
     "filter_hallucinations": True,
     "shortcut": "Ctrl+Space",
+    # Ctrl+Alt+Space rather than Escape: the combination the recording started
+    # with, one modifier along. Escape belongs to whatever window has focus, and
+    # a dictation is usually running while something else is focused.
+    "cancel_shortcut": "Ctrl+Alt+Space",
     "evdev_hotkey": False,
     "overlay_corner": "bottom-left",
     "keep_audio": False,

--- a/dikte.py
+++ b/dikte.py
@@ -148,7 +148,7 @@ class Dikte:
         self.menu.addAction(self.ask_cancel_action)
 
         self.cancel_action = QAction(t("Cancel recording"), self.menu)
-        self.cancel_action.triggered.connect(self.cancel)
+        self.cancel_action.triggered.connect(self._cancel)
         self.cancel_action.setEnabled(False)
         self.menu.addAction(self.cancel_action)
         self.menu.addSeparator()
@@ -301,6 +301,9 @@ class Dikte:
     def toggle_meeting(self):
         self._external("meeting", self._toggle_meeting)
 
+    def cancel(self):
+        self._external("cancel", self._cancel)
+
     def _external(self, name, handler):
         # The built-in listener sees the key press the instant it happens, so a
         # toggle arriving right behind one is the KDE shortcut catching up on
@@ -318,7 +321,8 @@ class Dikte:
         if timer is None:
             timer = self.last_evdev[name] = QElapsedTimer()
         timer.restart()
-        handlers = {"meeting": self._toggle_meeting, "ask": self._toggle_ask}
+        handlers = {"meeting": self._toggle_meeting, "ask": self._toggle_ask,
+                    "cancel": self._cancel}
         handlers.get(name, self._toggle)()
 
     def _retire_listener(self):
@@ -394,7 +398,7 @@ class Dikte:
         self.ask_overlay.show_busy(t("Transcribing…"))
         self.recorder.stop()
 
-    def cancel(self):
+    def _cancel(self):
         """Throw away whichever recording is running."""
         if not self.recording:
             return
@@ -412,7 +416,7 @@ class Dikte:
     def cancel_ask(self):
         """Call off the agent, whether it is still recording or already working."""
         if self.ask_state == RECORDING:
-            self.cancel()
+            self._cancel()
         elif self.ask_state == BUSY:
             self.ask_overlay.show_busy(t("Stopping…"))
             self.ask_pipeline.cancel()
@@ -643,7 +647,7 @@ class Dikte:
         if self.settings_window is None:
             self.settings_window = SettingsWindow(
                 self.conf, launch_command(), meeting_command(), self.meetings,
-                ask_command(),
+                ask_command(), cancel_command(),
             )
             self.settings_window.applied.connect(self._apply_settings)
             self.settings_window.finished.connect(self._settings_closed)
@@ -662,6 +666,7 @@ class Dikte:
         self._refresh_tray()
         if self.conf["evdev_hotkey"]:
             self.evdev.start({"toggle": self.conf["shortcut"],
+                              "cancel": self.conf["cancel_shortcut"],
                               "ask": self.conf["assistant_shortcut"],
                               "meeting": self.conf["meeting_shortcut"]})
         else:
@@ -714,6 +719,10 @@ def meeting_command():
 
 def ask_command():
     return f"{sys.executable} {os.path.realpath(__file__)} ask"
+
+
+def cancel_command():
+    return f"{sys.executable} {os.path.realpath(__file__)} cancel"
 
 
 def send_command(command, timeout=800):

--- a/hotkey.py
+++ b/hotkey.py
@@ -16,6 +16,7 @@ from i18n import t
 DESKTOP_ID = "dikte-toggle.desktop"
 MEETING_DESKTOP_ID = "dikte-meeting.desktop"
 ASK_DESKTOP_ID = "dikte-ask.desktop"
+CANCEL_DESKTOP_ID = "dikte-cancel.desktop"
 APPLICATIONS_DIR = pathlib.Path.home() / ".local/share/applications"
 DESKTOP_FILE = APPLICATIONS_DIR / DESKTOP_ID
 SHORTCUTS_FILE = pathlib.Path.home() / ".config/kglobalshortcutsrc"

--- a/i18n.py
+++ b/i18n.py
@@ -268,6 +268,15 @@ TR = {
     "Remove": "Kaldır",
     "Registered in KDE: {shortcut}": "KDE'de kayıtlı: {shortcut}",
     "No KDE shortcut installed.": "KDE kısayolu kurulu değil.",
+    "Shortcuts": "Kısayollar",
+    "Start and stop": "Başlat ve bitir",
+    "Discard the recording": "Kaydı çöpe at",
+    "Throws the recording away without transcribing it. Works on a dictation "
+    "and on a command for the agent alike, whichever is running.":
+        "Kaydı yazıya dökmeden atar. Hangisi çalışıyorsa ona işler: dikteye de, "
+        "ajana verilen komuta da.",
+    "No KDE shortcut installed. The tray menu discards it too.":
+        "KDE kısayolu kurulu değil. Tepsi menüsü de kaydı atabilir.",
     "Use the built-in listener (/dev/input), for when the KDE shortcut is not active yet":
         "Yerleşik dinleyici kullan (/dev/input), KDE kısayolu henüz etkin değilken",
     "Works immediately, no session restart. The only difference: the key "

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ BIN_DIR="$HOME/.local/bin"
 APP_DIR="$HOME/.local/share/applications"
 AUTOSTART_DIR="$HOME/.config/autostart"
 SHORTCUT="${1:-Ctrl+Space}"
+CANCEL_SHORTCUT="${2:-Ctrl+Alt+Space}"
 
 say()  { printf '  %s\n' "$1"; }
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
@@ -76,11 +77,24 @@ StartupNotify=false
 EOF
 ok "Will start automatically on login"
 
-# 4. KDE global shortcut ---------------------------------------------------
+# 4. KDE global shortcuts --------------------------------------------------
+# Two of them: one to start and stop, one to throw the recording away. The
+# second is worth a key of its own because stopping is what sends the audio
+# off, and that is the step there is no taking back.
 cat > "$APP_DIR/dikte-toggle.desktop" <<EOF
 [Desktop Entry]
 Exec=$PY $DIR/dikte.py toggle
 Name=Dikte: start/stop recording
+NoDisplay=true
+StartupNotify=false
+Type=Application
+X-KDE-GlobalAccel-CommandShortcut=true
+EOF
+
+cat > "$APP_DIR/dikte-cancel.desktop" <<EOF
+[Desktop Entry]
+Exec=$PY $DIR/dikte.py cancel
+Name=Dikte: discard the recording
 NoDisplay=true
 StartupNotify=false
 Type=Application
@@ -92,11 +106,15 @@ if command -v kwriteconfig6 >/dev/null; then
     --group services --group dikte-toggle.desktop \
     --key _launch "$SHORTCUT"
   ok "KDE shortcut registered: $SHORTCUT"
-  warn "KWin only reads this at startup, so the shortcut goes live after your"
+  kwriteconfig6 --notify --file kglobalshortcutsrc \
+    --group services --group dikte-cancel.desktop \
+    --key _launch "$CANCEL_SHORTCUT"
+  ok "Discard shortcut registered: $CANCEL_SHORTCUT"
+  warn "KWin only reads this at startup, so the shortcuts go live after your"
   say  "next login. Until then open Settings → Shortcut and turn on the"
-  say  "built-in listener to use it right away."
+  say  "built-in listener to use them right away."
 else
-  warn "kwriteconfig6 not found. Add the shortcut via System Settings > Shortcuts"
+  warn "kwriteconfig6 not found. Add the shortcuts via System Settings > Shortcuts"
 fi
 
 echo

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -90,8 +90,8 @@ REASONING_LEVELS = [
     ("Very high", "xhigh"), ("Maximum", "max"),
 ]
 PASTE_SHORTCUTS = ["ctrl+v", "ctrl+shift+v", "shift+insert"]
-# Offered for all three global shortcuts, which keeps them one kind of field
-# rather than three. The boxes stay editable: this is a shortlist of
+# Offered for all four global shortcuts, which keeps them one kind of field
+# rather than four. The boxes stay editable: this is a shortlist of
 # combinations that are usually free, not the set of ones that work.
 SHORTCUTS = [
     "Ctrl+Space", "Ctrl+Alt+Space", "Ctrl+Shift+Space", "Meta+Space",
@@ -112,12 +112,14 @@ class SettingsWindow(QDialog):
     _or_test_done = pyqtSignal(bool, str)
 
     def __init__(self, conf, launch_command, meeting_command=None,
-                 meetings=None, ask_command=None, parent=None):
+                 meetings=None, ask_command=None, cancel_command=None,
+                 parent=None):
         super().__init__(parent)
         self.conf = conf
         self.launch_command = launch_command
         self.meeting_command = meeting_command or launch_command
         self.ask_command = ask_command or launch_command
+        self.cancel_command = cancel_command or launch_command
         self.meetings = meetings
         # Each provider keeps its own transcription model, so switching the
         # provider back and forth never overwrites the other one's.
@@ -135,7 +137,7 @@ class SettingsWindow(QDialog):
         tabs.addTab(self._meeting_tab(), t("Meeting"))
         tabs.addTab(self._minutes_tab(), t("Minutes"))
         tabs.addTab(self._file_tab(), t("Audio file"))
-        tabs.addTab(self._shortcut_tab(), t("Shortcut"))
+        tabs.addTab(self._shortcut_tab(), t("Shortcuts"))
         tabs.addTab(self._history_tab(), t("History"))
 
         # Save keeps the window open, so the window is closed with the titlebar
@@ -779,24 +781,43 @@ class SettingsWindow(QDialog):
     def _shortcut_tab(self):
         page = QWidget()
         layout = QVBoxLayout(page)
+        # Both keys in one form, the way the Meeting and Agent tabs already lay
+        # theirs out: two forms would give the two rows label columns of their
+        # own, and two combo boxes starting at different places read as two
+        # unrelated settings rather than the pair they are.
         form = QFormLayout()
-        self.shortcut = self._shortcut_box("Ctrl+Space")
-        form.addRow(t("Shortcut"), self.shortcut)
-        layout.addLayout(form)
 
+        self.shortcut = self._shortcut_box("Ctrl+Space")
         install = QPushButton(t("Install as a KDE shortcut"))
         install.clicked.connect(self._install_shortcut)
         remove = QPushButton(t("Remove"))
         remove.clicked.connect(self._remove_shortcut)
-        row = QHBoxLayout()
-        row.addWidget(install)
-        row.addWidget(remove)
-        row.addStretch(1)
-        layout.addLayout(row)
-
+        form.addRow(t("Start and stop"),
+                    self._row(self.shortcut, install, remove))
         self.shortcut_status = QLabel("")
         self.shortcut_status.setWordWrap(True)
-        layout.addWidget(self.shortcut_status)
+        form.addRow(self.shortcut_status)
+
+        # Stopping a recording sends it off to be transcribed, which is the one
+        # thing you cannot take back. Cancelling needs a key of its own for the
+        # same reason it needs to be quick: by the time the tray menu is open,
+        # the sentence you did not mean to dictate is halfway to the model.
+        self.cancel_shortcut = self._shortcut_box(t("none"))
+        self.cancel_shortcut.setToolTip(t(
+            "Throws the recording away without transcribing it. Works on a "
+            "dictation and on a command for the agent alike, whichever is running."
+        ))
+        cancel_install = QPushButton(t("Install as a KDE shortcut"))
+        cancel_install.clicked.connect(self._install_cancel_shortcut)
+        cancel_remove = QPushButton(t("Remove"))
+        cancel_remove.clicked.connect(self._remove_cancel_shortcut)
+        form.addRow(t("Discard the recording"),
+                    self._row(self.cancel_shortcut, cancel_install, cancel_remove))
+        self.cancel_shortcut_status = QLabel("")
+        self.cancel_shortcut_status.setWordWrap(True)
+        form.addRow(self.cancel_shortcut_status)
+
+        layout.addLayout(form)
 
         self.evdev_enabled = QCheckBox(t(
             "Use the built-in listener (/dev/input), for when the KDE shortcut is "
@@ -974,11 +995,13 @@ class SettingsWindow(QDialog):
         self.file_path = ""
 
         self.shortcut.setCurrentText(conf["shortcut"])
+        self.cancel_shortcut.setCurrentText(conf["cancel_shortcut"])
         self.evdev_enabled.setChecked(conf["evdev_hotkey"])
 
         self.history_limit.setValue(max(0, int(conf["history_limit"])))
 
         self._refresh_shortcut_status()
+        self._refresh_cancel_shortcut_status()
         self._refresh_meeting_shortcut_status()
         self._refresh_ask_shortcut_status()
         self._refresh_assistant_status()
@@ -1072,6 +1095,9 @@ class SettingsWindow(QDialog):
         conf["file_cleanup"] = self.file_cleanup.isChecked()
 
         conf["shortcut"] = self.shortcut.currentText().strip() or "Ctrl+Space"
+        # Left empty this one stays empty, unlike the dictation shortcut: a
+        # recording can always be thrown away from the tray menu.
+        conf["cancel_shortcut"] = self.cancel_shortcut.currentText().strip()
         conf["evdev_hotkey"] = self.evdev_enabled.isChecked()
         conf["history_limit"] = self.history_limit.value()
         conf.save()
@@ -1305,6 +1331,42 @@ class SettingsWindow(QDialog):
         self.shortcut_status.setText(
             t("Registered in KDE: {shortcut}", shortcut=current) if current
             else t("No KDE shortcut installed.")
+        )
+
+    def _install_cancel_shortcut(self):
+        combo = self.cancel_shortcut.currentText().strip()
+        if not combo:
+            QMessageBox.information(self, t("Shortcut"),
+                                    t("Type a key combination first."))
+            return
+        clashes = hotkey.conflicting_shortcuts(combo, hotkey.CANCEL_DESKTOP_ID)
+        if clashes:
+            answer = QMessageBox.question(
+                self, t("Shortcut conflict"),
+                t("{shortcut} is also used by:\n\n{list}\n\nInstall anyway?",
+                  shortcut=combo, list="\n".join(clashes[:6])),
+            )
+            if answer != QMessageBox.StandardButton.Yes:
+                return
+        ok, message = hotkey.install_kde_shortcut(
+            combo, self.cancel_command, name="Dikte: discard the recording",
+            desktop_id=hotkey.CANCEL_DESKTOP_ID,
+        )
+        QMessageBox.information(self, t("Shortcut"), message)
+        if ok:
+            self.conf["cancel_shortcut"] = combo
+            self.conf.save()
+        self._refresh_cancel_shortcut_status()
+
+    def _remove_cancel_shortcut(self):
+        hotkey.remove_kde_shortcut(hotkey.CANCEL_DESKTOP_ID)
+        self._refresh_cancel_shortcut_status()
+
+    def _refresh_cancel_shortcut_status(self):
+        current = hotkey.kde_shortcut_status(hotkey.CANCEL_DESKTOP_ID)
+        self.cancel_shortcut_status.setText(
+            t("Registered in KDE: {shortcut}", shortcut=current) if current
+            else t("No KDE shortcut installed. The tray menu discards it too.")
         )
 
     def _install_meeting_shortcut(self):

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Dikte uninstaller: takes back what install.sh put down, and nothing else
+# unless asked. Your settings and your dictations survive a plain run; --purge
+# is what deletes them.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$HOME/.local/bin"
+APP_DIR="$HOME/.local/share/applications"
+AUTOSTART_DIR="$HOME/.config/autostart"
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/dikte"
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/dikte"
+# One per global shortcut: install.sh writes the first two, the settings window
+# writes the other two when you ask it to.
+DESKTOP_IDS=(dikte-toggle.desktop dikte-cancel.desktop dikte-meeting.desktop
+             dikte-ask.desktop)
+
+PURGE=0
+ASSUME_YES=0
+
+say()  { printf '  %s\n' "$1"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+gone() { printf '  \033[90m·\033[0m %s\n' "$1"; }
+# "1 dictation", "3 dictations": how many is the point of printing it at all.
+count() { (( $1 == 1 )) && printf '%s %s' "$1" "$2" || printf '%s %s' "$1" "$3"; }
+
+usage() {
+  cat <<EOF
+Usage: ./uninstall.sh [--purge] [--yes]
+
+  --purge   also delete the settings ($CONFIG_DIR)
+            and the dictations, meetings and recordings ($DATA_DIR)
+  --yes     do not ask before deleting those
+
+Without --purge nothing you have written is touched, and the source directory
+is left alone either way.
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --purge) PURGE=1 ;;
+    --yes|-y) ASSUME_YES=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) printf 'uninstall.sh: unknown option: %s\n' "$arg" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# A symlink whose target is gone is still a file to remove, hence -L.
+remove() {
+  if [[ -e "$1" || -L "$1" ]]; then
+    rm -f "$1"
+    ok "Removed $1"
+  else
+    gone "Was not there: $1"
+  fi
+}
+
+echo
+echo "Uninstalling Dikte"
+echo "──────────────────"
+
+# 1. The running instance --------------------------------------------------
+# It holds a tray icon and the global shortcuts; asking it to quit is tidier
+# than pulling its launchers out from under it.
+if pgrep -u "$USER" -f 'dikte\.py' >/dev/null 2>&1; then
+  python3 "$DIR/dikte.py" quit >/dev/null 2>&1 || true
+  sleep 0.5
+  if pgrep -u "$USER" -f 'dikte\.py' >/dev/null 2>&1; then
+    warn "Dikte is still running; close it from the tray icon"
+  else
+    ok "Stopped the running instance"
+  fi
+fi
+
+# 2. Launchers -------------------------------------------------------------
+# Only our own symlink goes: a file of the same name that somebody else put
+# there is not ours to delete.
+if [[ -L "$BIN_DIR/dikte" ]]; then
+  remove "$BIN_DIR/dikte"
+elif [[ -e "$BIN_DIR/dikte" ]]; then
+  warn "$BIN_DIR/dikte is not our symlink, leaving it alone"
+else
+  gone "Was not there: $BIN_DIR/dikte"
+fi
+remove "$APP_DIR/dikte.desktop"
+remove "$AUTOSTART_DIR/dikte.desktop"
+
+# 3. KDE global shortcuts --------------------------------------------------
+for id in "${DESKTOP_IDS[@]}"; do
+  remove "$APP_DIR/$id"
+done
+
+if command -v kwriteconfig6 >/dev/null; then
+  for id in "${DESKTOP_IDS[@]}"; do
+    # kwriteconfig6 deletes keys, not groups, so both of the ones KDE keeps in
+    # there go and the empty group is left behind harmlessly.
+    for key in _launch _k_friendly_name; do
+      kwriteconfig6 --notify --file kglobalshortcutsrc \
+        --group services --group "$id" --key "$key" --delete 2>/dev/null || true
+    done
+  done
+  ok "KDE shortcuts unregistered"
+  say "KWin reads that file at startup, so the keys are free after your next login."
+else
+  warn "kwriteconfig6 not found. Remove the shortcuts in System Settings > Shortcuts"
+fi
+
+# 4. Settings and dictations -----------------------------------------------
+echo
+if ((PURGE)); then
+  warn "--purge also deletes:"
+  if [[ -f "$CONFIG_DIR/config.json" ]]; then
+    say "$CONFIG_DIR/config.json  (your API keys and every setting)"
+  fi
+  if [[ -f "$DATA_DIR/history.jsonl" ]]; then
+    say "$DATA_DIR/history.jsonl  ($(count "$(wc -l < "$DATA_DIR/history.jsonl")" dictation dictations))"
+  fi
+  if [[ -d "$DATA_DIR/meetings" ]]; then
+    say "$DATA_DIR/meetings  ($(count "$(find "$DATA_DIR/meetings" -name '*.md' | wc -l)" meeting meetings))"
+  fi
+  if [[ -d "$DATA_DIR/recordings" ]]; then
+    say "$DATA_DIR/recordings  ($(du -sh "$DATA_DIR/recordings" | cut -f1) of audio)"
+  fi
+
+  if ((!ASSUME_YES)); then
+    if [[ -t 0 ]]; then
+      printf '  Type yes to delete them: '
+      read -r reply
+      [[ "$reply" == "yes" ]] || { PURGE=0; say "Kept."; }
+    else
+      PURGE=0
+      warn "Not a terminal, so nothing was deleted. Pass --yes if you meant it."
+    fi
+  fi
+fi
+
+if ((PURGE)); then
+  rm -rf "$CONFIG_DIR" "$DATA_DIR"
+  ok "Settings and dictations deleted"
+else
+  say "Settings kept:     $CONFIG_DIR"
+  say "Dictations kept:   $DATA_DIR"
+  say "Delete them too with:  ./uninstall.sh --purge"
+fi
+
+echo
+ok "Done."
+say "The source directory is untouched: $DIR"
+echo

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Dikte updater: pull, put the launchers back, restart what was running.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+say()  { printf '  %s\n' "$1"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+die()  { printf '  \033[31m✗\033[0m %s\n' "$1"; echo; exit 1; }
+
+# What the shortcut is registered under right now. The stored value is
+# "Ctrl+Space,none,Dikte: …"; the first field is the key that is live.
+registered() {
+  command -v kreadconfig6 >/dev/null || return 0
+  kreadconfig6 --file kglobalshortcutsrc --group services \
+    --group "$1" --key _launch 2>/dev/null | cut -d, -f1
+}
+
+echo
+echo "Updating Dikte"
+echo "──────────────"
+
+cd "$DIR"
+
+# 1. Somewhere there is something to pull ----------------------------------
+command -v git >/dev/null || die "git not found; update by downloading the source again"
+git rev-parse --git-dir >/dev/null 2>&1 \
+  || die "$DIR is not a git checkout; update by downloading the source again"
+
+before="$(git rev-parse HEAD)"
+
+# 2. Is there anything to come? ---------------------------------------------
+# Asked before anything else is complained about: an unfinished afternoon in
+# the working tree is nobody's problem on a day when nothing has been
+# published. Fetching leaves the working tree alone.
+git fetch --quiet || die "Could not reach the remote."
+upstream="$(git rev-parse '@{u}' 2>/dev/null)" \
+  || die "This branch is not tracking a remote one; pull by hand."
+
+if [[ "$before" == "$upstream" ]]; then
+  echo
+  ok "Already up to date ($(git log -1 --format=%s))"
+  echo
+  exit 0
+fi
+
+# 3. Only now, your own edits -----------------------------------------------
+# They would be overwritten by a fast-forward or would block it, and either
+# way that is your call to make, not this script's.
+if [[ -n "$(git status --porcelain)" ]]; then
+  warn "There is an update waiting, but you have changes of your own here:"
+  git --no-pager status --short | sed 's/^/    /'
+  say "Commit them, or put them aside with:  git stash"
+  die "Nothing was updated."
+fi
+
+# --ff-only: an update should be somebody else's commits arriving, never a
+# merge this script decided to make on your behalf. The fetch above already
+# brought them, so this touches no network.
+# advice off: git's suggestion is a merge or a rebase, and which of those you
+# want is the sentence below, not a wall of hints.
+if ! merge_log="$(git -c advice.diverging=false merge --ff-only '@{u}' 2>&1)"; then
+  printf '%s\n' "$merge_log" | sed 's/^/    /'
+  say "Your branch has commits the remote does not. To put them on top of the"
+  say "update instead:  git pull --rebase"
+  die "Could not fast-forward."
+fi
+after="$(git rev-parse HEAD)"
+
+echo
+say "What arrived:"
+git --no-pager log --oneline "$before..$after" | sed 's/^/    /'
+echo
+
+# 4. Launchers --------------------------------------------------------------
+# An update can add a dependency or move a file, so the installer runs again.
+# It would otherwise re-register its own default shortcuts over the ones you
+# chose, so it is told which ones are already registered.
+shortcut="$(registered dikte-toggle.desktop)"
+cancel_shortcut="$(registered dikte-cancel.desktop)"
+# Positional, so a chosen cancel key cannot be passed without the other one.
+# Falling back to the installer's default here rather than leaving a gap keeps
+# the two arguments lined up with what they mean.
+"$DIR/install.sh" "${shortcut:-Ctrl+Space}" "${cancel_shortcut:-Ctrl+Alt+Space}"
+
+# 5. The running instance ---------------------------------------------------
+# It is still running the code from before the pull.
+if pgrep -u "$USER" -f 'dikte\.py' >/dev/null 2>&1; then
+  if python3 "$DIR/dikte.py" restart >/dev/null 2>&1; then
+    ok "Restarted, so the new version is the one running"
+  else
+    warn "Could not restart it; use the tray menu → Restart"
+  fi
+else
+  say "Dikte was not running. Start it with:  dikte"
+fi
+echo


### PR DESCRIPTION
Two independent commits, either of which stands on its own if you only want one.

### A key for throwing a recording away

Stopping is the step there is no taking back: it sends the audio off, and a
moment later the sentence you did not mean to dictate is in the clipboard and
pasted. The tray menu was the only way out, and by the time it is open the
recording has already gone.

`Ctrl+Alt+Space` by default — the key the recording started with, one modifier
along. Escape was the obvious choice and the wrong one: it belongs to whichever
window has focus, and something else is usually focused while you talk. It works
on a dictation and on a command for the agent alike, whichever is running.

The key is bound in both places a shortcut can live here — the KDE entry and the
built-in listener — which is why the cancel path now goes through the same
`_external()` echo guard the toggle already had, so the listener catching the
press and the KDE shortcut arriving behind it are one discard rather than two.
The tray action calls the inner method, as it already did for the toggle.

`install.sh` registers it alongside the start/stop key and takes it as a second
argument, since a default nothing has registered is a setting that does nothing.
Left empty in the settings window it stays empty, unlike the dictation shortcut:
a recording can always be discarded from the tray menu.

The Shortcut tab becomes Shortcuts and both keys now sit in one form. Two forms
gave the rows label columns of their own, so the combo boxes started at
different places and read as two unrelated settings; the first row's buttons
also move onto the row with it, which is how the Meeting and Agent tabs have
laid the same control out all along.

### uninstall.sh and update.sh

`install.sh` was the only half of its job written down. Removing meant
remembering a symlink, several desktop files, an autostart entry and a pair of
`kglobalshortcutsrc` keys.

`uninstall.sh` removes what `install.sh` put down and stops there. Settings,
dictations, meetings and recordings survive a plain run; `--purge` deletes them
and prints what that would cost first (how many dictations, how many meetings,
how much audio). Without a terminal to ask, it refuses rather than assuming
`--yes`. Only our own symlink goes — a file of that name somebody else put there
is left alone.

`update.sh` checks whether anything is waiting before complaining about a dirty
working tree, then fast-forwards only (`--ff-only`), re-runs the installer since
an update can add a dependency or move a file, and tells it which shortcuts are
already registered so your keys survive rather than being reset to the defaults.
Finally it restarts the running instance, which is still holding the code from
before the pull.

### Testing

Both scripts were run end to end against a throwaway `HOME` (with
`XDG_CONFIG_HOME` / `XDG_DATA_HOME` pointed at it, so `kwriteconfig6` wrote to a
sandboxed `kglobalshortcutsrc`), and `update.sh` against a local clone acting as
the remote:

- install, plain uninstall, `--purge` without a TTY (refuses), `--purge --yes`,
  unknown option (exit 2)
- update: fast-forward, already-up-to-date, dirty working tree (exit 1)
- shortcuts manually set to `Meta+D` / `Meta+Shift+D` survived an update
- `Ctrl+Space` and `Ctrl+Alt+Space` land on the same evdev key code (57); checked
  that the listener's modifier matching keeps them apart
- settings window opens in both interface languages, new strings translated

Nothing here touches the transcription, cleanup, meeting or agent paths.
