### PR TITLE
Write down what installing on Fedora takes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,15 @@ systemctl --user enable --now ydotool     # needed for auto-paste
 dikte                        # the settings window opens on first run
 ```
 
-On Fedora KDE the packages are named differently, and `ydotool` takes one step
-more:
+On Fedora the packages are named differently, `ffmpeg-free` out of Fedora's own
+repositories is enough because Dikte only ever takes the audio track of a video
+file, and `ydotool` takes one step more: it ships as a system service, whose
+socket stays root-owned and out of your session's reach, so auto-paste fails
+with the daemon running. Point it at the path the client already looks at and
+hand the socket over:
 
 ```sh
 sudo dnf install pipewire-utils wl-clipboard ydotool ffmpeg-free python3-pyqt6
-```
-
-Fedora ships `ydotool` as a system service rather than a user one, and
-`ydotoold` then listens on a root-owned socket your session cannot write to, so
-auto-paste fails with the daemon running. Point it instead at the path the
-`ydotool` client already looks at, and hand the socket over:
-
-```sh
 sudo mkdir -p /etc/systemd/system/ydotool.service.d
 printf '[Service]\nExecStart=\nExecStart=/usr/bin/ydotoold --socket-path=%s/.ydotool_socket --socket-own=%s:%s\n' \
   "$XDG_RUNTIME_DIR" "$(id -u)" "$(id -g)" \
@@ -50,20 +46,6 @@ printf '[Service]\nExecStart=\nExecStart=/usr/bin/ydotoold --socket-path=%s/.ydo
 sudo systemctl daemon-reload
 sudo systemctl enable --now ydotool
 ```
-
-That runtime directory belongs to your login session, so after a reboot the
-service restarts until you are logged in and only then settles. `ffmpeg-free`
-out of Fedora's own repositories is enough, RPM Fusion not needed: what the
-free build leaves out is H.264 and HEVC video decoding, and Dikte only ever
-takes the audio track of a video file, whose AAC, MP3 and Opus decoders are all
-there.
-
-The models that run on this machine need nothing added either. Those releases
-are built on Ubuntu and run here as they are, and KWin links `libvulkan.so.1`
-itself, so a Plasma desktop already has the loader that decides whether
-llama.cpp arrives in its Vulkan build, with the Mesa drivers alongside it.
-whisper.cpp publishes no GPU build for Linux at all and transcribes on the
-processor wherever it runs.
 
 On Ubuntu/GNOME X11, recording uses PulseAudio and clipboard/paste use the X11
 tools instead:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,41 @@ systemctl --user enable --now ydotool     # needed for auto-paste
 dikte                        # the settings window opens on first run
 ```
 
+On Fedora KDE the packages are named differently, and `ydotool` takes one step
+more:
+
+```sh
+sudo dnf install pipewire-utils wl-clipboard ydotool ffmpeg-free python3-pyqt6
+```
+
+Fedora ships `ydotool` as a system service rather than a user one, and
+`ydotoold` then listens on a root-owned socket your session cannot write to, so
+auto-paste fails with the daemon running. Point it instead at the path the
+`ydotool` client already looks at, and hand the socket over:
+
+```sh
+sudo mkdir -p /etc/systemd/system/ydotool.service.d
+printf '[Service]\nExecStart=\nExecStart=/usr/bin/ydotoold --socket-path=%s/.ydotool_socket --socket-own=%s:%s\n' \
+  "$XDG_RUNTIME_DIR" "$(id -u)" "$(id -g)" \
+  | sudo tee /etc/systemd/system/ydotool.service.d/override.conf >/dev/null
+sudo systemctl daemon-reload
+sudo systemctl enable --now ydotool
+```
+
+That runtime directory belongs to your login session, so after a reboot the
+service restarts until you are logged in and only then settles. `ffmpeg-free`
+out of Fedora's own repositories is enough, RPM Fusion not needed: what the
+free build leaves out is H.264 and HEVC video decoding, and Dikte only ever
+takes the audio track of a video file, whose AAC, MP3 and Opus decoders are all
+there.
+
+The models that run on this machine need nothing added either. Those releases
+are built on Ubuntu and run here as they are, and KWin links `libvulkan.so.1`
+itself, so a Plasma desktop already has the loader that decides whether
+llama.cpp arrives in its Vulkan build, with the Mesa drivers alongside it.
+whisper.cpp publishes no GPU build for Linux at all and transcribes on the
+processor wherever it runs.
+
 On Ubuntu/GNOME X11, recording uses PulseAudio and clipboard/paste use the X11
 tools instead:
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -29,18 +29,15 @@ systemctl --user enable --now ydotool     # otomatik yapıştırma için
 dikte                        # ilk açılışta ayarlar penceresi gelir
 ```
 
-Fedora KDE'de paket adları farklı, `ydotool` da bir adım fazla istiyor:
+Fedora'da paket adları farklı, Fedora'nın kendi depolarındaki `ffmpeg-free`
+yetiyor çünkü Dikte video dosyasının yalnızca ses izini alıyor, `ydotool` da
+bir adım fazla istiyor: sistem servisi olarak geliyor, soketi de root'a ait
+kalıp oturumun erişemediği yerde durduğu için servis çalışırken bile otomatik
+yapıştırma tutmuyor. Soketi istemcinin zaten baktığı yola al ve sahipliğini
+devret:
 
 ```sh
 sudo dnf install pipewire-utils wl-clipboard ydotool ffmpeg-free python3-pyqt6
-```
-
-Fedora `ydotool`'u kullanıcı servisi değil sistem servisi olarak kuruyor;
-`ydotoold` de root'a ait bir sokete bağlanıyor, oturumun oraya yazamadığı için
-servis çalışırken bile otomatik yapıştırma tutmuyor. Soketi `ydotool`
-istemcisinin zaten baktığı yola al ve sahipliğini devret:
-
-```sh
 sudo mkdir -p /etc/systemd/system/ydotool.service.d
 printf '[Service]\nExecStart=\nExecStart=/usr/bin/ydotoold --socket-path=%s/.ydotool_socket --socket-own=%s:%s\n' \
   "$XDG_RUNTIME_DIR" "$(id -u)" "$(id -g)" \
@@ -48,19 +45,6 @@ printf '[Service]\nExecStart=\nExecStart=/usr/bin/ydotoold --socket-path=%s/.ydo
 sudo systemctl daemon-reload
 sudo systemctl enable --now ydotool
 ```
-
-O çalışma dizini oturumuna ait olduğu için yeniden başlatmanın ardından servis
-sen giriş yapana kadar kendini yeniden deneyip ondan sonra oturuyor. Fedora'nın
-kendi depolarındaki `ffmpeg-free` yetiyor, RPM Fusion gerekmiyor: özgür yapının
-dışarıda bıraktığı şey H.264 ve HEVC video çözümü, Dikte ise video dosyasının
-yalnızca ses izini alıyor; onun AAC, MP3 ve Opus çözücüleri yapının içinde.
-
-Bu makinede koşan modeller için de eklenecek bir şey yok. O sürümler Ubuntu'da
-derleniyor ve burada olduğu gibi çalışıyor; `libvulkan.so.1`'i KWin'in kendisi
-bağladığı için Plasma masaüstünde llama.cpp'nin Vulkan yapısıyla gelip
-gelmeyeceğini belirleyen yükleyici zaten kurulu, Mesa sürücüleri de onunla
-birlikte geliyor. whisper.cpp ise Linux için hiç GPU yapısı yayımlamıyor,
-nerede çalışırsa çalışsın işlemcide çeviriyor.
 
 Ubuntu/GNOME X11 için kayıt PulseAudio üzerinden, pano ve yapıştırma ise X11
 araçlarıyla çalışır:

--- a/README.tr.md
+++ b/README.tr.md
@@ -29,6 +29,39 @@ systemctl --user enable --now ydotool     # otomatik yapıştırma için
 dikte                        # ilk açılışta ayarlar penceresi gelir
 ```
 
+Fedora KDE'de paket adları farklı, `ydotool` da bir adım fazla istiyor:
+
+```sh
+sudo dnf install pipewire-utils wl-clipboard ydotool ffmpeg-free python3-pyqt6
+```
+
+Fedora `ydotool`'u kullanıcı servisi değil sistem servisi olarak kuruyor;
+`ydotoold` de root'a ait bir sokete bağlanıyor, oturumun oraya yazamadığı için
+servis çalışırken bile otomatik yapıştırma tutmuyor. Soketi `ydotool`
+istemcisinin zaten baktığı yola al ve sahipliğini devret:
+
+```sh
+sudo mkdir -p /etc/systemd/system/ydotool.service.d
+printf '[Service]\nExecStart=\nExecStart=/usr/bin/ydotoold --socket-path=%s/.ydotool_socket --socket-own=%s:%s\n' \
+  "$XDG_RUNTIME_DIR" "$(id -u)" "$(id -g)" \
+  | sudo tee /etc/systemd/system/ydotool.service.d/override.conf >/dev/null
+sudo systemctl daemon-reload
+sudo systemctl enable --now ydotool
+```
+
+O çalışma dizini oturumuna ait olduğu için yeniden başlatmanın ardından servis
+sen giriş yapana kadar kendini yeniden deneyip ondan sonra oturuyor. Fedora'nın
+kendi depolarındaki `ffmpeg-free` yetiyor, RPM Fusion gerekmiyor: özgür yapının
+dışarıda bıraktığı şey H.264 ve HEVC video çözümü, Dikte ise video dosyasının
+yalnızca ses izini alıyor; onun AAC, MP3 ve Opus çözücüleri yapının içinde.
+
+Bu makinede koşan modeller için de eklenecek bir şey yok. O sürümler Ubuntu'da
+derleniyor ve burada olduğu gibi çalışıyor; `libvulkan.so.1`'i KWin'in kendisi
+bağladığı için Plasma masaüstünde llama.cpp'nin Vulkan yapısıyla gelip
+gelmeyeceğini belirleyen yükleyici zaten kurulu, Mesa sürücüleri de onunla
+birlikte geliyor. whisper.cpp ise Linux için hiç GPU yapısı yayımlamıyor,
+nerede çalışırsa çalışsın işlemcide çeviriyor.
+
 Ubuntu/GNOME X11 için kayıt PulseAudio üzerinden, pano ve yapıştırma ise X11
 araçlarıyla çalışır:
 

--- a/install.sh
+++ b/install.sh
@@ -52,21 +52,17 @@ fi
 # What auto-paste needs is a socket it may write to, which is not the same
 # question as whether the unit is up: Fedora ships ydotool as a system service
 # only, and its socket stays root-owned at mode 600, so there the daemon can be
-# running while every paste is refused.
+# running while every paste is refused. The socket file outlives the daemon,
+# though, so the process has to be there as well for the answer to be yes.
 if [[ "${XDG_SESSION_TYPE:-}" != "x11" ]] && command -v ydotool >/dev/null; then
   socket="${YDOTOOL_SOCKET:-${XDG_RUNTIME_DIR:-/tmp}/.ydotool_socket}"
-  if [[ -w "$socket" ]]; then
+  alive() { pgrep -x ydotoold >/dev/null 2>&1; }
+  if [[ -w "$socket" ]] && alive; then
     ok "ydotoold is running (auto-paste ready)"
   elif systemctl is-active --quiet ydotool 2>/dev/null; then
-    warn "ydotoold runs as a system service, whose socket is not yours to"
-    say  "write to. Hand it over in /etc/systemd/system/ydotool.service.d/"
-    say  "override.conf, which is what the README's Fedora section does:"
-    say  "  [Service]"
-    say  "  ExecStart="
-    say  "  ExecStart=/usr/bin/ydotoold --socket-path=$socket --socket-own=$(id -u):$(id -g)"
-    say  "then sudo systemctl daemon-reload && sudo systemctl restart ydotool"
-  elif systemctl --user is-active --quiet ydotool 2>/dev/null \
-       || systemctl --user is-active --quiet ydotoold 2>/dev/null; then
+    warn "ydotoold's socket is not yours to write to, so auto-paste will fail"
+    say  "Hand it over with the drop-in in the README's Fedora section."
+  elif alive; then
     warn "ydotoold is running, but it did not put its socket at $socket"
     say  "Point Dikte at the one it did make: export YDOTOOL_SOCKET=..."
   else

--- a/install.sh
+++ b/install.sh
@@ -40,21 +40,38 @@ python3 -c 'import PyQt6.QtWidgets' 2>/dev/null || missing+=("python-pyqt6")
 
 if ((${#missing[@]})); then
   warn "Missing: ${missing[*]}"
-  say  "Ubuntu X11:    sudo apt install pulseaudio-utils xclip xdotool ffmpeg"
-  say  "Arch Wayland:  sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6"
+  say  "Ubuntu X11:     sudo apt install pulseaudio-utils xclip xdotool ffmpeg"
+  say  "Arch Wayland:   sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6"
+  say  "Fedora Wayland: sudo dnf install pipewire-utils wl-clipboard ydotool ffmpeg-free python3-pyqt6"
   echo
 else
   ok "All dependencies present"
 fi
 
 # 2. ydotoold --------------------------------------------------------------
+# What auto-paste needs is a socket it may write to, which is not the same
+# question as whether the unit is up: Fedora ships ydotool as a system service
+# only, and its socket stays root-owned at mode 600, so there the daemon can be
+# running while every paste is refused.
 if [[ "${XDG_SESSION_TYPE:-}" != "x11" ]] && command -v ydotool >/dev/null; then
-  if systemctl --user is-active --quiet ydotool 2>/dev/null \
-     || systemctl --user is-active --quiet ydotoold 2>/dev/null; then
+  socket="${YDOTOOL_SOCKET:-${XDG_RUNTIME_DIR:-/tmp}/.ydotool_socket}"
+  if [[ -w "$socket" ]]; then
     ok "ydotoold is running (auto-paste ready)"
+  elif systemctl is-active --quiet ydotool 2>/dev/null; then
+    warn "ydotoold runs as a system service, whose socket is not yours to"
+    say  "write to. Hand it over in /etc/systemd/system/ydotool.service.d/"
+    say  "override.conf, which is what the README's Fedora section does:"
+    say  "  [Service]"
+    say  "  ExecStart="
+    say  "  ExecStart=/usr/bin/ydotoold --socket-path=$socket --socket-own=$(id -u):$(id -g)"
+    say  "then sudo systemctl daemon-reload && sudo systemctl restart ydotool"
+  elif systemctl --user is-active --quiet ydotool 2>/dev/null \
+       || systemctl --user is-active --quiet ydotoold 2>/dev/null; then
+    warn "ydotoold is running, but it did not put its socket at $socket"
+    say  "Point Dikte at the one it did make: export YDOTOOL_SOCKET=..."
   else
     warn "ydotoold is not running, auto-paste will not work"
-    say  "systemctl --user enable --now ydotool"
+    say  "systemctl --user enable --now ydotool   (on Fedora: see the README)"
   fi
 fi
 


### PR DESCRIPTION
The README carries Arch and Ubuntu, and on Fedora the two things that differ are
the two that decide whether Dikte works at all. Both READMEs get a Fedora
section, and `install.sh` learns to ask the question that answers correctly
there.

**ydotool.** Fedora ships it as a system service only, with no user unit, so
`systemctl --user enable --now ydotool` has nothing to enable. That service runs
`ydotoold` as root and its socket stays root-owned at mode 600, which means the
unit is green, the daemon is up, and every paste is refused. The README now
gives the drop-in that points `ydotoold` at `$XDG_RUNTIME_DIR/.ydotool_socket`
and hands it over by uid. That is the path the client already looks at
(`$YDOTOOL_SOCKET`, then `$XDG_RUNTIME_DIR/.ydotool_socket`, then `/tmp`), so
nothing has to carry an environment variable. Red Hat closed the same report as
NOTABUG ([rhbz#2250692](https://bugzilla.redhat.com/show_bug.cgi?id=2250692)),
so it stays a step the user takes.

**install.sh.** It checked whether the unit was up, which is exactly the check
that misleads on Fedora. It now checks whether the socket is one this user may
write to, and names which of the three ways it failed: a socket handed to
nobody, a daemon that put its socket elsewhere, or no daemon at all. Behaviour
on Arch and elsewhere is unchanged: a user service whose socket sits in the
runtime dir still reports ready. All four branches were exercised, the last two
with a `systemctl` shim.

**ffmpeg-free is enough**, against the usual advice to reach for RPM Fusion.
Fedora's build disables four video decoders (`h264`, `hevc`, `vc1`, `vvc`) and
keeps every audio decoder including AAC, while Dikte only ever asks a video file
for its audio track (`-vn` in `filetranscribe.py`) and records meetings through
`-f pulse` to `pcm_s16le`. Read out of the `configuration:` line of the
`ffmpeg-free` 8.1.2 build on Fedora 44.

Package names were checked with `rpm -qf` against the binaries Dikte calls:
`pw-record` from `pipewire-utils`, `wl-copy` from `wl-clipboard`, and
`PyQt6.QtWidgets`/`QtNetwork` from `python3-pyqt6`, which pulls in the `xcb`
platform plugin the corner indicator needs.

**The local models need nothing added**, which matters now that they are the
default. Both releases are Ubuntu builds and ran on Fedora 44 unchanged:
`whisper-server` started and transcribed a clip with no package added and no
missing library, and `llama-server` came down in its Vulkan build and listed the
card (`Vulkan0: NVIDIA GeForce RTX 3060`). That is not luck about this machine:
`kwin-libs` requires `libvulkan.so.1`, so the loader is on every Plasma desktop
by way of the compositor, and `vulkan-loader` recommends `mesa-vulkan-drivers`
alongside itself. whisper.cpp publishes no GPU asset for Linux at all, so
transcription runs on the processor there regardless.

No Python changed. `python -m unittest discover` is green here, 807 tests.
