### PR TITLE
Document an Android companion workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ history and the meetings are there beside them. `dikte --help` lists them, they
 all take `--json`, and only the ones needing the microphone need the application
 running.
 
+### Android companion pattern
+
+Dikte's CLI can also be used as the processing side of an Android voice inbox.
+The phone records with an Android-native speech input, sends the reviewed text
+to a signed-in `codex` session on the Dikte computer over a private Tailscale SSH
+connection, and lets the user choose the final destination. The reference DAAK
+NODE integration routes a capture to daakREMEMBER, Obsidian, both, or a plain
+Codex session without embedding an API key in the phone. See
+[the Android companion guide](docs/android-companion.md).
+
+This is a companion architecture, not a claim that the PyQt desktop interface
+runs natively on Android.
+
 ## What it does
 
 - **It all runs on this machine by default.** Speech to text on whisper.cpp and

--- a/README.tr.md
+++ b/README.tr.md
@@ -78,6 +78,19 @@ geçmiş ve toplantılar da yanlarında durur. Hepsini `dikte --help` sayar, hep
 `--json` kabul eder, yalnızca mikrofona ihtiyacı olanlar uygulamanın açık
 olmasını ister.
 
+### Android eşlikçi modeli
+
+Dikte'nin CLI katmanı bir Android sesli gelen kutusunun işlem tarafı olarak da
+kullanılabilir. Telefon Android'e yerel bir ses girişiyle kaydeder, onaylanan
+metni özel bir Tailscale SSH bağlantısı üzerinden Dikte bilgisayarındaki giriş
+yapılmış `codex` oturumuna gönderir ve son hedefi kullanıcıya seçtirir. DAAK NODE
+referans entegrasyonu telefona API anahtarı gömmeden kaydı daakREMEMBER'a,
+Obsidian'a, ikisine birden veya düz bir Codex oturumuna yönlendirir. Ayrıntılar
+için [Android eşlikçi rehberine](docs/android-companion.md) bakın.
+
+Bu bir eşlikçi mimarisidir; PyQt masaüstü arayüzünün Android'de yerel olarak
+çalıştığı anlamına gelmez.
+
 ## Neler yapıyor
 
 - **Her şey varsayılan olarak bu makinede çalışır.** Sesi yazıya çevirme

--- a/docs/android-companion.md
+++ b/docs/android-companion.md
@@ -1,0 +1,40 @@
+# Android companion integration
+
+Dikte is a Linux desktop application, but its CLI and agent workflow can be the
+processing side of a lightweight Android voice inbox. Keeping audio capture
+native to Android preserves microphone, power-management and accessibility
+integration while the existing computer runs Codex CLI and project-aware tools.
+
+## Reference flow
+
+1. An Android speech-recognition service produces a transcript on the phone.
+2. The phone shows the raw transcript before taking any action.
+3. A small SSH command sends the text to a signed-in Codex CLI on the user's
+   Dikte computer over Tailscale.
+4. Codex returns a cleaned title, text, suggested destination and explanation.
+5. The phone asks the user to choose a destination before writing anything.
+
+DAAK NODE implements this pattern with four destinations: daakREMEMBER,
+Obsidian, both stores, or an interactive Codex CLI session. The Android side can
+queue a confirmed daakREMEMBER capture while the computer is offline.
+
+## Why use the desktop CLI
+
+- The phone contains no OpenAI API key.
+- The existing signed-in Codex CLI session, tools and project directories stay
+  on the computer.
+- Tailscale SSH avoids exposing a shell to the public internet.
+- Android handles the microphone and confirmation UI, so the PyQt desktop app
+  does not need to be ported or kept alive on the phone.
+
+## Security checklist
+
+- Restrict SSH to the tailnet and use key-based authentication.
+- Allow only a small launcher script with explicit working-directory choices.
+- Base64 is transport encoding, not encryption; rely on SSH for confidentiality.
+- Validate decoded paths against an allowlist.
+- Never write or send on the user's behalf before showing the final destination.
+- Keep offline queues private to the Android app and retry with bounded backoff.
+
+The companion is deliberately separate from Dikte's desktop runtime. It is an
+integration example for contributors, not an Android build artifact.


### PR DESCRIPTION
## Summary
- document how Dikte CLI and Codex can process an Android-native voice inbox
- describe a reviewed routing flow to notes/tasks without storing an API key on the phone
- make clear that this is a companion architecture, not a PyQt-on-Android port

## Verification
- `git diff --check`
- documentation links resolve in-tree
- test discovery ran 459 tests: 402 passed, 49 skipped, and 8 modules could not import because PyQt6 is not installed in this macOS test environment; this change contains documentation only