### PR TITLE
Run on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,18 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python: ["3.11", "3.12", "3.13"]
+        # One macOS run rather than three: what it covers is the platform half
+        # (avfoundation, pbcopy, osascript, Carbon), and that half does not
+        # change from one Python version to the next.
+        include:
+          - os: macos-latest
+            python: "3.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +30,9 @@ jobs:
       # PyQt6 ships Qt itself, but Qt still loads these from the system, even
       # for the offscreen platform the tests run on. QtNetwork wants the Kerberos
       # library, and the widgets want fontconfig, whether or not anything is
-      # ever drawn.
+      # ever drawn. macOS needs none of it: the frameworks are already there.
       - name: Install the Qt runtime libraries
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ worker.py         transcribe → clean up → clipboard → paste
 vad.py            deciding whether a recording holds speech at all
 filetranscribe.py file transcription: ffmpeg, chunking, timestamps
 overlay.py        the corner indicator
+macos.py          the four things macOS has to be told, through ctypes
 settings_ui.py    settings window
 hotkey.py         KDE and GNOME shortcuts, the evdev listener, Carbon
 paste.py          wl-clipboard, xclip, pbcopy, and the key press beside each
@@ -205,8 +206,8 @@ The indicator is drawn through XWayland, because a Wayland client cannot place a
 window in a screen corner; `dikte.py` sets `QT_QPA_PLATFORM=xcb` for that. macOS
 needs no such thing, and the line is skipped there.
 
-Three platforms, and the platform-specific half is four files: `audio.py`,
-`paste.py`, `hotkey.py` and the asset names in `ggml.py`. Each holds a group per
+Three platforms, and the platform-specific half is five files: `audio.py`,
+`paste.py`, `hotkey.py`, `macos.py` and the asset names in `ggml.py`. Each holds a group per
 platform and one line that chooses between them, rather than a branch inside
 every function. `tests/support.py` has `linux_only` and `macos_only` for the
 tests that pin one of those halves; everything else is expected to pass

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ first paste asks. And the **default shortcut is `Ctrl+Alt+Space`** rather than
 combination one of its own shortcuts already uses and then never delivers it,
 so a key that does nothing is a key to change rather than a bug.
 
+There is a second way for the transcript to arrive, under Settings → General:
+**type it out** instead of pasting it. The characters go out as key events
+carrying the text, so the clipboard is never borrowed — what you had copied
+stays copied — and no combination has to mean paste in the window receiving it,
+which a terminal, a remote desktop or a virtual machine may not agree on. It is
+slower on a long transcript, which is why pasting is still the default. Works on
+all three platforms.
+
 **Recording a meeting is Linux-only.** It needs what comes out of the speakers,
 and macOS hands that to nobody. Everything else works: dictation, the agent,
 audio and video files, and writing up a recording made elsewhere.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ to it.
 
 | What | How |
 | --- | --- |
-| Start / stop recording | `Ctrl+Space`, or click the tray icon |
+| Start / stop recording | `Ctrl+Space`, or click the tray icon (on macOS the icon opens the menu instead) |
 | Discard the recording | `Ctrl+Alt+Space`, tray menu, or `dikte cancel` |
 | Speak a command to an agent | Tray menu → *Ask Claude*, or `dikte ask` |
 | Start / end a meeting | Tray menu → *Record a meeting*, or `dikte meeting` |

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ machine by default, a model cleans it up (dropping the *uh*s, the restarts, the
 missing punctuation), and the result lands in your clipboard and is pasted into
 whatever window you were typing in.
 
-Built for KDE Plasma 6 on Wayland. No dependencies beyond system packages:
-just the Python standard library and PyQt6.
+Built for KDE Plasma 6 on Wayland, and it runs on macOS too. No dependencies
+beyond system packages: just the Python standard library and PyQt6.
 
 *[Türkçe README](README.tr.md)*
 
@@ -37,10 +37,35 @@ tools instead:
 sudo apt install pulseaudio-utils xclip xdotool ffmpeg
 ```
 
+On macOS:
+
+```sh
+brew install ffmpeg whisper-cpp python@3.13
+python3.13 -m pip install PyQt6
+
+./install.sh                 # or:  ./install.sh "Ctrl+Alt+Space" "Ctrl+Alt+D"
+dikte
+```
+
 `install.sh` adds the `dikte` command, a menu entry, an autostart entry and the
 two global shortcuts, whose keys are its two arguments. `./update.sh` pulls and
 puts all of that back, keeping the keys you chose; `./uninstall.sh` takes it away
 again and leaves your settings and dictations alone unless you pass `--purge`.
+On macOS the menu entry is `~/Applications/Dikte.app` and the autostart entry a
+launch agent; if PyQt6 lives in a virtualenv, point `DIKTE_PYTHON` at its
+`python3` before running any of the three.
+
+Two things on macOS need a word. **Auto-paste** presses Cmd+V through System
+Events, so the application running Dikte has to be allowed to control the
+computer, under System Settings → Privacy & Security → Accessibility — the
+first paste asks. And the **default shortcut is `Ctrl+Alt+Space`** rather than
+`Ctrl+Space`, which belongs to the input source switcher there; macOS accepts a
+combination one of its own shortcuts already uses and then never delivers it,
+so a key that does nothing is a key to change rather than a bug.
+
+**Recording a meeting is Linux-only.** It needs what comes out of the speakers,
+and macOS hands that to nobody. Everything else works: dictation, the agent,
+audio and video files, and writing up a recording made elsewhere.
 
 Speech to text and cleanup each pick a provider in the settings window, and both
 run here by default, on models of your own. The cloud is the other option:
@@ -84,8 +109,10 @@ running.
   cleanup on llama.cpp, neither installed beforehand: the settings window fetches
   the program and the model, verifies the sha256 and refuses a download published
   without one, then keeps a server alive while you dictate. The graphics card is
-  reached through CUDA, ROCm or Vulkan where the build allows. No key, no
-  account, nothing leaving the machine.
+  reached through CUDA, ROCm or Vulkan where the build allows, and through
+  Metal on a Mac. No key, no account, nothing leaving the machine.
+  (whisper.cpp publishes no macOS build, so there it comes from Homebrew:
+  `brew install whisper-cpp`. llama.cpp is downloaded as everywhere else.)
 - **Silence never reaches the API.** Handed near-silence, a transcription model
   invents a sentence instead of returning nothing ("Thanks for watching", or in
   Turkish "Altyazı M.K."). A recording is dropped when nothing rose 10 dB above
@@ -120,7 +147,7 @@ running.
   for a machine with neither CLI on it. Provider, model, permissions and working
   directory are under Settings → Agent, and commands close together stay in one
   conversation.
-- **Meetings** are recorded from the microphone and the speaker output at the
+- **Meetings** (Linux only) are recorded from the microphone and the speaker output at the
   same time, which settles who said what by the channel a voice arrived on
   instead of guessing at it. The two sides are transcribed separately and
   interleaved into one timestamped transcript, and a second model, configured
@@ -137,7 +164,7 @@ running.
   right-click to delete.
 - **Turkish and English interface**, following the system locale by default.
 
-## The global shortcuts need one logout
+## The global shortcuts need one logout, on Linux
 
 KWin only reads `kglobalshortcutsrc` at startup, so the shortcuts `install.sh`
 writes will not fire until you log out and back in. Until then, Settings →
@@ -146,13 +173,18 @@ itself. The difference: it does not swallow the key, so `Ctrl+Space` also reache
 the focused application (some editors will pop up autocomplete). The listener
 needs your user in the `input` group: `sudo usermod -aG input $USER`.
 
+None of which applies on macOS: Carbon binds the combination to the running
+application, it is live the moment Dikte starts, it swallows the key, and it
+asks for no permission at all. There is nothing to wait for and no listener to
+turn on, so that box is not on the tab there.
+
 ## Layout
 
 ```
 dikte.py          entry point, tray icon, state machine
 cli.py            the command line: every verb, and what it answers with
 ipc.py            one request and one reply over the local socket
-audio.py          PCM capture: pw-record for dictation, ffmpeg for a meeting
+audio.py          PCM capture: pw-record or avfoundation, ffmpeg for a meeting
 meeting.py        channel split, speaker labelling, cleanup, minutes
 assistant.py      running a dictation through Claude Code, Codex or OpenRouter
 api.py            transcription and cleanup requests (stdlib only)
@@ -164,13 +196,21 @@ vad.py            deciding whether a recording holds speech at all
 filetranscribe.py file transcription: ffmpeg, chunking, timestamps
 overlay.py        the corner indicator
 settings_ui.py    settings window
-hotkey.py         KDE shortcut installation and the evdev listener
-paste.py          wl-clipboard and ydotool wrappers
+hotkey.py         KDE and GNOME shortcuts, the evdev listener, Carbon
+paste.py          wl-clipboard, xclip, pbcopy, and the key press beside each
 i18n.py           the string table
 ```
 
 The indicator is drawn through XWayland, because a Wayland client cannot place a
-window in a screen corner; `dikte.py` sets `QT_QPA_PLATFORM=xcb` for that.
+window in a screen corner; `dikte.py` sets `QT_QPA_PLATFORM=xcb` for that. macOS
+needs no such thing, and the line is skipped there.
+
+Three platforms, and the platform-specific half is four files: `audio.py`,
+`paste.py`, `hotkey.py` and the asset names in `ggml.py`. Each holds a group per
+platform and one line that chooses between them, rather than a branch inside
+every function. `tests/support.py` has `linux_only` and `macos_only` for the
+tests that pin one of those halves; everything else is expected to pass
+everywhere.
 
 ## License
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -4,8 +4,8 @@
 çevrilir, bir model transkripti temizler (ıı'lar, tekrarlar, eksik noktalama),
 sonuç panoya kopyalanır ve o an yazdığın pencereye yapıştırılır.
 
-KDE Plasma 6 / Wayland için yazıldı. Sistem paketleri dışında bağımlılığı yok:
-sadece Python standart kütüphanesi ve PyQt6.
+KDE Plasma 6 / Wayland için yazıldı, macOS'ta da çalışır. Sistem paketleri
+dışında bağımlılığı yok: sadece Python standart kütüphanesi ve PyQt6.
 
 *[English README](README.md)*
 
@@ -36,11 +36,36 @@ araçlarıyla çalışır:
 sudo apt install pulseaudio-utils xclip xdotool ffmpeg
 ```
 
+macOS için:
+
+```sh
+brew install ffmpeg whisper-cpp python@3.13
+python3.13 -m pip install PyQt6
+
+./install.sh                 # ya da:  ./install.sh "Ctrl+Alt+Space" "Ctrl+Alt+D"
+dikte
+```
+
 `install.sh` `dikte` komutunu, menü girdisini, oturum açılışında otomatik
 başlatmayı ve iki global kısayolu kurar; tuşları da iki argümanı. `./update.sh`
 son sürümü çeker ve bunları senin seçtiğin tuşlarla yerine koyar;
 `./uninstall.sh` hepsini geri alır, `--purge` demedikçe ayarlarına ve
-diktelerine dokunmaz.
+diktelerine dokunmaz. macOS'ta menü girdisi `~/Applications/Dikte.app`, otomatik
+başlatma ise bir launch agent; PyQt6 bir sanal ortamdaysa üçünü de çalıştırmadan
+önce `DIKTE_PYTHON` değişkenini o ortamın `python3`'üne yönlendir.
+
+macOS'ta iki noktanın söylenmesi gerekiyor. **Otomatik yapıştırma** Cmd+V'yi
+System Events üzerinden basar, bu yüzden Dikte'yi çalıştıran uygulamanın
+bilgisayarı kontrol etme izni olmalı: Sistem Ayarları → Gizlilik ve Güvenlik →
+Erişilebilirlik — ilk yapıştırmada zaten sorulur. Ve **varsayılan kısayol
+`Ctrl+Space` değil `Ctrl+Alt+Space`**, çünkü orada `Ctrl+Space` girdi kaynağı
+değiştirmeye ait; macOS kendi kısayollarından birinin kullandığı bir
+kombinasyonu kabul eder ama hiç iletmez, yani hiçbir şey yapmayan bir tuş hata
+değil, değiştirilecek bir tuştur.
+
+**Toplantı kaydı yalnızca Linux'ta.** Hoparlörden çıkan sesi gerektiriyor ve
+macOS bunu kimseye vermiyor. Geri kalan her şey çalışır: dikte, ajan, ses ve
+video dosyaları, başka yerde alınmış bir kaydın yazıya dökülmesi.
 
 Sesi yazıya çevirme ve temizleme, ayarlar penceresinde ayrı ayrı sağlayıcı
 seçer; ikisi de varsayılan olarak burada, kendi modellerinle çalışır. Bulutu
@@ -84,7 +109,7 @@ olmasını ister.
   whisper.cpp, temizleme llama.cpp üzerinde; ikisini de önceden kurman gerekmez:
   ayarlar penceresi programı ve modeli indirir, sha256'sını doğrular,
   checksum'suz yayınlanmış bir indirmeyi reddeder, sen dikte ettikçe sunucuyu
-  ayakta tutar. Derleme destekliyorsa ekran kartına CUDA, ROCm ya da Vulkan
+  ayakta tutar. Mac'te Metal, başka yerde derleme destekliyorsa CUDA, ROCm ya da Vulkan
   üzerinden ulaşılır. Anahtar yok, hesap yok, makineden çıkan bir şey yok.
 - **Sessizlik API'ye gitmez.** Sessize yakın bir ses verildiğinde model boş dize
   döndürmez, bir cümle uydurur ("Altyazı M.K.", "Thanks for watching"). *O
@@ -118,7 +143,7 @@ olmasını ister.
   OpenRouter ise ikisi de kurulu olmayan bir makinede düz soru cevap için
   duruyor. Sağlayıcı, model, izinler ve çalışma dizini Ayarlar → Ajan
   sekmesinde; arka arkaya verilen komutlar tek bir konuşmada kalır.
-- **Toplantılar** mikrofonla hoparlör çıkışından aynı anda kaydedilir; kimin ne
+- **Toplantılar** (yalnızca Linux) mikrofonla hoparlör çıkışından aynı anda kaydedilir; kimin ne
   dediği tahmin edilmez, sesin hangi kanaldan geldiğiyle belli olur. İki taraf
   ayrı ayrı yazıya çevrilip tek bir zaman damgalı transkriptte birleştirilir,
   ardından Ayarlar → Toplantı sekmesinden seçtiğin ikinci bir model kendi
@@ -144,13 +169,18 @@ yakalar. Tek farkı: tuşu yutmaz, yani `Ctrl+Space` odaktaki uygulamaya da ilet
 (bazı editörlerde otomatik tamamlama açılabilir). Dinleyici kullanıcının `input`
 grubunda olmasını gerektirir: `sudo usermod -aG input $USER`.
 
+macOS'ta bunların hiçbiri geçerli değil: Carbon kombinasyonu çalışan
+uygulamaya bağlar, Dikte açılır açılmaz etkindir, tuşu yutar ve hiçbir izin
+istemez. Beklenecek bir şey ve açılacak bir dinleyici olmadığı için o kutu
+orada sekmede yok.
+
 ## Dosyalar
 
 ```
 dikte.py          giriş noktası, tepsi simgesi, durum makinesi
 cli.py            komut satırı: bütün fiiller ve verdikleri cevap
 ipc.py            yerel sokette bir istek, bir cevap
-audio.py          PCM kaydı: diktede pw-record, toplantıda ffmpeg
+audio.py          PCM kaydı: pw-record ya da avfoundation, toplantıda ffmpeg
 meeting.py        kanal ayırma, konuşmacı etiketi, temizleme, tutanak
 assistant.py      dikteyi Claude Code, Codex ya da OpenRouter'dan geçirme
 api.py            transkript ve temizleme istekleri (yalnız stdlib)
@@ -162,13 +192,21 @@ vad.py            kayıtta gerçekten konuşma var mı kararı
 filetranscribe.py dosyadan transkript: ffmpeg, parçalama, zaman damgaları
 overlay.py        köşedeki gösterge
 settings_ui.py    ayarlar penceresi
-hotkey.py         KDE kısayol kurulumu ve evdev dinleyici
-paste.py          wl-clipboard ve ydotool sarmalayıcıları
+hotkey.py         KDE ve GNOME kısayolları, evdev dinleyici, Carbon
+paste.py          wl-clipboard, xclip, pbcopy ve her birinin tuş basımı
 i18n.py           metin tablosu
 ```
 
 Gösterge XWayland üzerinden çizilir; Wayland'da bir pencereyi belirli bir köşeye
 yerleştirmenin yolu yok, `dikte.py` bu yüzden `QT_QPA_PLATFORM=xcb` ayarlar.
+macOS'ta buna gerek yok, orada o satır atlanır.
+
+Üç platform var ve platforma özgü yarı dört dosyada: `audio.py`, `paste.py`,
+`hotkey.py` ve `ggml.py` içindeki dosya adları. Her biri platform başına bir
+grup ve aralarından seçen tek bir satır tutuyor; her fonksiyonun içinde bir
+dallanma yok. `tests/support.py` içinde bu yarılardan birini sabitleyen
+testler için `linux_only` ve `macos_only` var; geri kalan her testin her
+yerde geçmesi bekleniyor.
 
 ## Lisans
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -63,6 +63,13 @@ değiştirmeye ait; macOS kendi kısayollarından birinin kullandığı bir
 kombinasyonu kabul eder ama hiç iletmez, yani hiçbir şey yapmayan bir tuş hata
 değil, değiştirilecek bir tuştur.
 
+Metnin yerine ulaşmasının ikinci bir yolu daha var, Ayarlar → Genel altında:
+yapıştırmak yerine **yazdırmak**. Karakterler metni taşıyan tuş olayları olarak
+gider; yani pano hiç ödünç alınmaz — kopyaladığın şey kopyalı kalır — ve o
+pencerede herhangi bir kombinasyonun "yapıştır" anlamına gelmesi gerekmez, ki
+terminal, uzak masaüstü ya da sanal makine bunda hemfikir olmayabilir. Uzun
+metinde daha yavaş olduğu için varsayılan hâlâ yapıştırma. Üç platformda da var.
+
 **Toplantı kaydı yalnızca Linux'ta.** Hoparlörden çıkan sesi gerektiriyor ve
 macOS bunu kimseye vermiyor. Geri kalan her şey çalışır: dikte, ajan, ses ve
 video dosyaları, başka yerde alınmış bir kaydın yazıya dökülmesi.

--- a/README.tr.md
+++ b/README.tr.md
@@ -88,7 +88,7 @@ yapıştırılır; modelin yanındaki kutudan düşünme seviyesini de seçebili
 
 | Ne | Nasıl |
 | --- | --- |
-| Kaydı başlat / bitir | `Ctrl+Space`, ya da tepsi simgesine tıkla |
+| Kaydı başlat / bitir | `Ctrl+Space`, ya da tepsi simgesine tıkla (macOS'ta simge menüyü açar) |
 | Kaydı iptal et | `Ctrl+Alt+Space`, tepsi menüsü, ya da `dikte cancel` |
 | Ajana sesle komut ver | Tepsi menüsü → *Claude'a sor*, ya da `dikte ask` |
 | Toplantıyı başlat / bitir | Tepsi menüsü → *Toplantı kaydet*, ya da `dikte meeting` |

--- a/README.tr.md
+++ b/README.tr.md
@@ -191,6 +191,7 @@ worker.py         transkript → temizleme → pano → yapıştırma
 vad.py            kayıtta gerçekten konuşma var mı kararı
 filetranscribe.py dosyadan transkript: ffmpeg, parçalama, zaman damgaları
 overlay.py        köşedeki gösterge
+macos.py          macOS'a söylenmesi gereken şeyler, ctypes ile
 settings_ui.py    ayarlar penceresi
 hotkey.py         KDE ve GNOME kısayolları, evdev dinleyici, Carbon
 paste.py          wl-clipboard, xclip, pbcopy ve her birinin tuş basımı
@@ -201,8 +202,8 @@ Gösterge XWayland üzerinden çizilir; Wayland'da bir pencereyi belirli bir kö
 yerleştirmenin yolu yok, `dikte.py` bu yüzden `QT_QPA_PLATFORM=xcb` ayarlar.
 macOS'ta buna gerek yok, orada o satır atlanır.
 
-Üç platform var ve platforma özgü yarı dört dosyada: `audio.py`, `paste.py`,
-`hotkey.py` ve `ggml.py` içindeki dosya adları. Her biri platform başına bir
+Üç platform var ve platforma özgü yarı beş dosyada: `audio.py`, `paste.py`,
+`hotkey.py`, `macos.py` ve `ggml.py` içindeki dosya adları. Her biri platform başına bir
 grup ve aralarından seçen tek bir satır tutuyor; her fonksiyonun içinde bir
 dallanma yok. `tests/support.py` içinde bu yarılardan birini sabitleyen
 testler için `linux_only` ve `macos_only` var; geri kalan her testin her

--- a/audio.py
+++ b/audio.py
@@ -83,7 +83,7 @@ class Recorder(QObject):
         stdout = proc.stdout
         try:
             while True:
-                chunk = stdout.read(CHUNK_BYTES)
+                chunk = read_exactly(stdout, CHUNK_BYTES)
                 if not chunk:
                     break
                 peak, rms = chunk_levels(chunk)
@@ -162,6 +162,29 @@ class Recorder(QObject):
 
         path = write_wav(pcm)
         self.stopped.emit(path, frames / RATE, rms)
+
+
+def read_exactly(stream, size):
+    """`size` bytes from an unbuffered pipe, or what is left of it at the end.
+
+    `read(n)` hands over what has arrived rather than what was asked for, and
+    how much that is belongs to whoever is on the other end: parec, told the
+    latency to keep, fills a chunk at a time, while a recorder handing its
+    output to a pipe unasked may give over a fraction of one. Both the level
+    meter and the silence check are measured in chunks of one known length —
+    vad.analyse() is given the seconds a chunk lasts and multiplies — so a
+    stream that arrives in pieces is put back together here rather than
+    counted as if each piece were a chunk of its own, which would say a
+    two-second recording held fifteen seconds of speech.
+    """
+    parts, remaining = [], size
+    while remaining > 0:
+        piece = stream.read(remaining)
+        if not piece:
+            break
+        parts.append(piece)
+        remaining -= len(piece)
+    return b"".join(parts)
 
 
 def write_wav(pcm, rate=RATE, channels=CHANNELS, width=SAMPLE_WIDTH):
@@ -299,7 +322,9 @@ class MeetingRecorder(QObject):
         block = CHUNK_FRAMES * SAMPLE_WIDTH * 2
         try:
             while True:
-                chunk = stdout.read(block)
+                # Whole frames, or the stereo split below would read the two
+                # channels the wrong way round for the rest of the meeting.
+                chunk = read_exactly(stdout, block)
                 if not chunk:
                     break
                 mine, theirs = stereo_levels(chunk)

--- a/audio.py
+++ b/audio.py
@@ -1,19 +1,23 @@
 """Raw PCM capture with a live level meter.
 
-Dictation records one source through pw-record. A meeting records two of them at
-once, the microphone and what comes out of the speakers, and for that it goes
-through ffmpeg instead: one process reading both devices and merging them into
-the two channels of a single stream, which is the only way the two stay aligned
-with each other over an hour.
+Dictation records one source through pw-record, or through ffmpeg's
+avfoundation input on a Mac, which has no sound server to ask. A meeting
+records two sources at once, the microphone and what comes out of the speakers,
+and for that it goes through ffmpeg everywhere: one process reading both
+devices and merging them into the two channels of a single stream, which is the
+only way the two stay aligned with each other over an hour. macOS hands out no
+speaker output at all, so a meeting is Linux-only for now.
 """
 
 import array
 import json
 import math
 import os
+import re
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import wave
@@ -57,9 +61,7 @@ class Recorder(QObject):
             return
         cmd = recording_command(target)
         if not cmd:
-            self.failed.emit(t(
-                "No audio recorder found. Install pulseaudio-utils or pipewire-audio."
-            ))
+            self.failed.emit(missing_recorder_message())
             return
 
         try:
@@ -169,13 +171,13 @@ def read_exactly(stream, size):
 
     `read(n)` hands over what has arrived rather than what was asked for, and
     how much that is belongs to whoever is on the other end: parec, told the
-    latency to keep, fills a chunk at a time, while a recorder handing its
-    output to a pipe unasked may give over a fraction of one. Both the level
-    meter and the silence check are measured in chunks of one known length —
-    vad.analyse() is given the seconds a chunk lasts and multiplies — so a
-    stream that arrives in pieces is put back together here rather than
-    counted as if each piece were a chunk of its own, which would say a
-    two-second recording held fifteen seconds of speech.
+    latency to keep, fills a chunk at a time, while ffmpeg's avfoundation input
+    hands over a fraction of one. Both the level meter and the silence check
+    are measured in chunks of one known length — vad.analyse() is given the
+    seconds a chunk lasts and multiplies — so a stream that arrives in pieces is
+    put back together here rather than counted as if each piece were a chunk of
+    its own, which would say a two-second recording held fifteen seconds of
+    speech.
     """
     parts, remaining = [], size
     while remaining > 0:
@@ -197,6 +199,31 @@ def write_wav(pcm, rate=RATE, channels=CHANNELS, width=SAMPLE_WIDTH):
     return path
 
 
+def missing_recorder_message():
+    """What to install, when recording_command() came back with nothing."""
+    if sys.platform == "darwin":
+        return t("ffmpeg not found. Install it with: brew install ffmpeg")
+    return t("No audio recorder found. Install pulseaudio-utils or pipewire-audio.")
+
+
+def _avfoundation_command(target=""):
+    """Capture through ffmpeg, which is the only way in on a Mac.
+
+    There is no sound server to ask and no small recorder beside it, but ffmpeg
+    is already a dependency for the audio-file tab, so this costs nothing extra.
+    `default` is avfoundation's own name for whatever the system input is, and a
+    target is the device name rather than its index: indexes move when a
+    microphone is plugged in, names do not.
+    """
+    if not shutil.which("ffmpeg"):
+        return []
+    return [
+        "ffmpeg", "-hide_banner", "-nostdin", "-loglevel", "error",
+        "-f", "avfoundation", "-i", f":{target or 'default'}",
+        "-ar", str(RATE), "-ac", str(CHANNELS), "-f", "s16le", "-",
+    ]
+
+
 def recording_command(target=""):
     """Return a raw-s16 capture command for the sound server on this desktop.
 
@@ -204,6 +231,8 @@ def recording_command(target=""):
     service, and its source names are the same ones shown by list_sources().
     Keep pw-record as the fallback for minimal native-PipeWire installations.
     """
+    if sys.platform == "darwin":
+        return _avfoundation_command(target)
     if shutil.which("parec"):
         cmd = [
             "parec", "--record", "--raw", f"--rate={RATE}",
@@ -263,6 +292,15 @@ class MeetingRecorder(QObject):
 
     def start(self, path, mic_target="", system_target="", max_seconds=14400):
         if self.active:
+            return
+        if sys.platform == "darwin":
+            # Said here rather than left to default_monitor() returning nothing:
+            # this is a platform that cannot do it at all, not a machine whose
+            # output could not be worked out.
+            self.failed.emit(t(
+                "Recording a meeting needs what comes out of the speakers, which "
+                "macOS does not hand out. Not supported yet."
+            ))
             return
         if not shutil.which("ffmpeg"):
             self.failed.emit(t("ffmpeg not found. Install it to record a meeting."))
@@ -477,8 +515,46 @@ def _sources():
         return []
 
 
+# `[1] MacBook Pro Microphone`, once ffmpeg's own prefix has been taken off.
+_AVFOUNDATION_DEVICE = re.compile(r"\[\d+\]\s+(.+)")
+
+
+def _avfoundation_sources():
+    """[(name, name)] for every audio device avfoundation lists.
+
+    ffmpeg prints the list only when it is asked to open a device it cannot
+    open, so it always ends in an error and the exit code says nothing. The
+    device name is both halves of the pair: macOS has no second, friendlier
+    name to show beside it the way PulseAudio does.
+    """
+    if not shutil.which("ffmpeg"):
+        return []
+    try:
+        res = subprocess.run(
+            ["ffmpeg", "-hide_banner", "-f", "avfoundation",
+             "-list_devices", "true", "-i", ""],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return []
+
+    out, listening = [], False
+    for line in res.stderr.splitlines():
+        _, _, rest = line.partition("] ")
+        if rest.endswith("devices:"):
+            listening = rest.startswith("AVFoundation audio devices")
+            continue
+        match = _AVFOUNDATION_DEVICE.match(rest) if listening else None
+        if match:
+            name = match.group(1).strip()
+            out.append((name, name))
+    return out
+
+
 def list_sources():
     """[(name, description)] for every real input source."""
+    if sys.platform == "darwin":
+        return _avfoundation_sources()
     return [
         (src.get("name", ""), src.get("description") or src.get("name", ""))
         for src in _sources()
@@ -491,7 +567,11 @@ def list_monitors():
 
     Recording a monitor is recording whatever is being played, which in a
     meeting is the other participants and nothing of your own microphone.
+    macOS publishes no such device, so the list is empty there and the meeting
+    tab says so rather than offering a choice that cannot be made.
     """
+    if sys.platform == "darwin":
+        return []
     return [
         (src.get("name", ""), src.get("description") or src.get("name", ""))
         for src in _sources()
@@ -501,7 +581,7 @@ def list_monitors():
 
 def default_monitor():
     """The monitor of the output sound is currently going to, or ''."""
-    if not shutil.which("pactl"):
+    if sys.platform == "darwin" or not shutil.which("pactl"):
         return ""
     try:
         sink = subprocess.run(

--- a/cli.py
+++ b/cli.py
@@ -697,14 +697,20 @@ def cmd_test_key(opts):
 def cmd_shortcut(opts):
     conf = cfg.Config()
     if opts.shortcut == "status":
-        rows = {}
+        # macOS writes no shortcut down. Dikte registers what the settings hold
+        # for as long as it runs, so there is no file here whose absence could
+        # mean "not installed", and saying so would send somebody looking for a
+        # step that does not exist.
+        rows, lines = {}, []
         for name, spec in hotkey.SHORTCUTS.items():
-            rows[name] = {"registered": hotkey.shortcut_status(spec.desktop_id),
-                          "configured": conf[spec.setting]}
-        lines = [f"{name:8} {row['registered'] or '(not installed)':16} "
-                 f"setting: {row['configured'] or '(none)'}"
-                 for name, row in rows.items()]
-        lines.append(f"built-in listener: {'on' if conf['evdev_hotkey'] else 'off'}")
+            registered = hotkey.shortcut_status(spec.desktop_id)
+            configured = conf[spec.setting]
+            rows[name] = {"registered": registered, "configured": configured}
+            shown = (("(while Dikte runs)" if configured else "(none)")
+                     if cfg.MACOS else registered or "(not installed)")
+            lines.append(f"{name:8} {shown:19} setting: {configured or '(none)'}")
+        if not cfg.MACOS:
+            lines.append(f"built-in listener: {'on' if conf['evdev_hotkey'] else 'off'}")
         return out(opts, {"ok": True, "shortcuts": rows,
                           "listener": conf["evdev_hotkey"]}, "\n".join(lines))
 

--- a/cli.py
+++ b/cli.py
@@ -717,7 +717,7 @@ def cmd_shortcut(opts):
     combo = (opts.combo or conf[spec.setting] or spec.fallback).strip()
     if not combo:
         return fail(opts, "no combination given and none stored; pass --combo", 2)
-    if hotkey.parse_shortcut(combo) == (None, None):
+    if not hotkey.understands(combo):
         return fail(opts, f"cannot parse that combination: {combo}", 2)
     clashes = hotkey.conflicting_shortcuts(combo, spec.desktop_id)
     if clashes and not opts.force:
@@ -765,7 +765,12 @@ def cmd_status(opts):
 def cmd_doctor(opts):
     """What the settings window checks behind its buttons, in one pass."""
     conf = cfg.Config()
-    wanted = ["pw-record", "wl-copy", "ydotool", "ffmpeg", "pactl", "kwriteconfig6",
+    # The programs each platform actually reaches for. Naming the other one's
+    # here would report half a dozen things missing that were never wanted.
+    system = (["ffmpeg", "pbcopy", "osascript", "whisper-server"] if cfg.MACOS
+              else ["pw-record", "wl-copy", "ydotool", "ffmpeg", "pactl",
+                    "kwriteconfig6"])
+    wanted = [*system,
               assistant.executable(assistant.provider(conf)) or "claude",
               cleanup.executable(cleanup.provider(conf))]
     programs = {name: shutil.which(name) or "" for name in wanted if name}

--- a/config.py
+++ b/config.py
@@ -421,6 +421,12 @@ DEFAULTS = {
     "local_llm_reasoning": "none",
     "cleanup_prompt": "",           # empty -> language-specific default
     "auto_paste": True,
+    # How the transcript gets there: pressing paste, or typing it out. Typing
+    # leaves the clipboard alone — what you had copied is still there
+    # afterwards — and needs no key combination to mean paste in the window
+    # receiving it. It is slower on a long transcript, which is the only reason
+    # it is not the default.
+    "type_instead_of_pasting": False,
     "paste_shortcut": "cmd+v" if MACOS else "ctrl+v",
     "restore_clipboard": False,
     "mic_target": "",

--- a/config.py
+++ b/config.py
@@ -5,11 +5,17 @@ import hashlib
 import json
 import os
 import pathlib
+import sys
 
 import api
 import ggml
 import i18n
 from i18n import t
+
+# Two of the defaults below differ on a Mac: pasting is done with command
+# rather than control, and Ctrl+Space is taken by the input source switcher,
+# which would leave a first run with a key that does nothing.
+MACOS = sys.platform == "darwin"
 
 
 def _xdg(var, default):
@@ -415,7 +421,7 @@ DEFAULTS = {
     "local_llm_reasoning": "none",
     "cleanup_prompt": "",           # empty -> language-specific default
     "auto_paste": True,
-    "paste_shortcut": "ctrl+v",
+    "paste_shortcut": "cmd+v" if MACOS else "ctrl+v",
     "restore_clipboard": False,
     "mic_target": "",
     "max_seconds": 300,
@@ -424,11 +430,13 @@ DEFAULTS = {
     "speech_margin_db": 10.0,     # how far speech must rise above the noise floor
     "min_voiced_seconds": 0.3,
     "filter_hallucinations": True,
-    "shortcut": "Ctrl+Space",
-    # Ctrl+Alt+Space rather than Escape: the combination the recording started
-    # with, one modifier along. Escape belongs to whatever window has focus, and
-    # while you are dictating something else usually has it.
-    "cancel_shortcut": "Ctrl+Alt+Space",
+    # Ctrl+Space everywhere but on macOS, where it switches the input source and
+    # would be lost to it; Ctrl+Alt+Space is free there and stays in the family.
+    "shortcut": "Ctrl+Alt+Space" if MACOS else "Ctrl+Space",
+    # One modifier along from the key the recording started with. Escape belongs
+    # to whatever window has focus, and while you are dictating something else
+    # usually has it.
+    "cancel_shortcut": "Ctrl+Alt+D" if MACOS else "Ctrl+Alt+Space",
     "evdev_hotkey": False,
     "overlay_corner": "bottom-left",
     "keep_audio": False,

--- a/dikte.py
+++ b/dikte.py
@@ -141,6 +141,11 @@ class Dikte:
         self.tray = QSystemTrayIcon()
         self._apply_settings()
         self.tray.show()
+        # Both indicators go up empty now rather than in the middle of the
+        # first dictation, which is when putting a window on screen would have
+        # taken the keyboard out of whatever was being typed into.
+        for overlay in (self.overlay, self.ask_overlay):
+            overlay.prepare()
         # After the tray icon, since that is where it is said.
         QTimer.singleShot(1200, self._check_permission_to_paste)
 

--- a/dikte.py
+++ b/dikte.py
@@ -35,6 +35,7 @@ import i18n  # noqa: E402
 import ipc  # noqa: E402
 import macos  # noqa: E402
 import meeting  # noqa: E402
+import paste  # noqa: E402
 from i18n import t  # noqa: E402
 from meeting import MeetingPipeline  # noqa: E402
 from overlay import Overlay  # noqa: E402
@@ -140,6 +141,8 @@ class Dikte:
         self.tray = QSystemTrayIcon()
         self._apply_settings()
         self.tray.show()
+        # After the tray icon, since that is where it is said.
+        QTimer.singleShot(1200, self._check_permission_to_paste)
 
     # ---- tray ----------------------------------------------------------
 
@@ -471,6 +474,10 @@ class Dikte:
             "agent": assistant.display_name(self.conf),
             "provider": assistant.provider(self.conf),
             "listener": self.listener.running,
+            # Whether a paste would land. Asked of the running instance rather
+            # than worked out by whoever is asking: macOS grants this to one
+            # application at a time, and `dikte status` is a different one.
+            "can_paste": paste.paste_ready(),
         }
 
     def reload_settings(self):
@@ -861,6 +868,26 @@ class Dikte:
 
         if wanted:
             threading.Thread(target=warm, daemon=True).start()
+
+    def _check_permission_to_paste(self):
+        """Say, once at startup, if a paste would go nowhere.
+
+        macOS grants the right to press a key per application and answers a
+        press it did not allow by reporting that it went through. Left alone,
+        that is a dictation which transcribes correctly, says it pasted, and
+        puts nothing anywhere — with no error to look up. So it is asked
+        beforehand, and asking with the prompt opens the pane that grants it.
+        """
+        if not cfg.MACOS or not self.conf["auto_paste"] or paste.paste_ready():
+            return
+        macos.trusted_to_type(ask=True)
+        self.tray.showMessage(
+            "Dikte",
+            t("Dikte may not press keys yet, so what you dictate will be copied "
+              "but not pasted. Allow it under System Settings → Privacy & "
+              "Security → Accessibility, then restart Dikte."),
+            QSystemTrayIcon.MessageIcon.Warning, 12000,
+        )
 
     def _apply_settings(self):
         self.overlay.corner = self.conf["overlay_corner"]

--- a/dikte.py
+++ b/dikte.py
@@ -518,6 +518,8 @@ class Dikte:
     def start(self):
         if self.state != IDLE or self.recording:
             return
+        # Before the indicator, which is what costs the keyboard.
+        macos.remember_the_front()
         self.overlay.show_recording()
         self._begin_recording(DICTATION)
         self._set_state(RECORDING)
@@ -525,6 +527,7 @@ class Dikte:
     def start_ask(self):
         if self.ask_state != IDLE or self.recording:
             return
+        macos.remember_the_front()
         self.ask_overlay.show_recording(asking=True)
         self._begin_recording(ASK)
         self._set_ask_state(RECORDING)

--- a/dikte.py
+++ b/dikte.py
@@ -758,7 +758,9 @@ class Dikte:
                 QSystemTrayIcon.MessageIcon.Warning, 10000,
             )
         else:
-            action = t("Pasted") if self.conf["auto_paste"] else t("Copied")
+            action = (t("Copied") if not self.conf["auto_paste"]
+                      else t("Typed") if self.conf["type_instead_of_pasting"]
+                      else t("Pasted"))
             self.overlay.show_done(
                 t("{action}: {preview}", action=action, preview=_preview(text))
             )

--- a/dikte.py
+++ b/dikte.py
@@ -96,7 +96,11 @@ class Dikte:
         self.ask_pipeline = Pipeline(self.conf)
         self.meeting_recorder = audio.MeetingRecorder()
         self.meetings = MeetingPipeline(self.conf)
-        self.evdev = hotkey.EvdevHotkey()
+        # What catches the global shortcuts. On Linux it is the fallback that
+        # covers the wait for KWin, and it is off unless asked for; on macOS
+        # there is nothing to fall back from, so it is how the shortcuts work.
+        self.listener = (hotkey.CarbonHotkey() if cfg.MACOS
+                         else hotkey.EvdevHotkey())
         # Before anything of ours is started: a server from a Dikte that was
         # killed outright is still holding a model in memory.
         ggml.sweep()
@@ -118,13 +122,13 @@ class Dikte:
         self.meetings.progress.connect(self._on_meeting_progress)
         self.meetings.finished.connect(self._on_meeting_finished)
         self.meetings.failed.connect(self._on_meeting_failed)
-        self.evdev.triggered.connect(self._on_evdev)
-        self.evdev.failed.connect(self._on_error)
+        self.listener.triggered.connect(self._on_hotkey)
+        self.listener.failed.connect(self._on_error)
 
         self.elapsed = QElapsedTimer()
         self.meeting_elapsed = QElapsedTimer()
         self.last_toggle = QElapsedTimer()
-        self.last_evdev = {}
+        self.last_press = {}
         self.ticker = QTimer()
         self.ticker.setInterval(100)
         self.ticker.timeout.connect(self._tick)
@@ -325,23 +329,29 @@ class Dikte:
         # that same press. Its lateness is also the proof we were waiting for
         # that the shortcut is live, which leaves the listener with nothing to
         # do but double every press.
-        timer = self.last_evdev.get(name)
-        if self.evdev.running and timer is not None and timer.elapsed() < ECHO_MS:
+        #
+        # None of which is true on macOS: there is no second registration to
+        # wait for, so a toggle arriving close behind a key press is somebody
+        # running `dikte toggle` while the last one is still fresh, and that is
+        # a request rather than an echo.
+        timer = self.last_press.get(name)
+        if (not cfg.MACOS and self.listener.running
+                and timer is not None and timer.elapsed() < ECHO_MS):
             self._retire_listener()
             return
         handler()
 
-    def _on_evdev(self, name):
-        timer = self.last_evdev.get(name)
+    def _on_hotkey(self, name):
+        timer = self.last_press.get(name)
         if timer is None:
-            timer = self.last_evdev[name] = QElapsedTimer()
+            timer = self.last_press[name] = QElapsedTimer()
         timer.restart()
         handlers = {"meeting": self._toggle_meeting, "ask": self._toggle_ask,
                     "cancel": self._cancel}
         handlers.get(name, self._toggle)()
 
     def _retire_listener(self):
-        self.evdev.stop()
+        self.listener.stop()
         self.conf["evdev_hotkey"] = False
         self.conf.save()
         self.tray.showMessage(
@@ -459,7 +469,7 @@ class Dikte:
             "meeting_message": self.meeting_message,
             "agent": assistant.display_name(self.conf),
             "provider": assistant.provider(self.conf),
-            "listener": self.evdev.running,
+            "listener": self.listener.running,
         }
 
     def reload_settings(self):
@@ -853,11 +863,14 @@ class Dikte:
         self._apply_local()
         self._build_tray()
         self._refresh_tray()
-        if self.conf["evdev_hotkey"]:
-            self.evdev.start({name: self.conf[spec.setting]
-                              for name, spec in hotkey.SHORTCUTS.items()})
+        # `evdev_hotkey` is the switch for the Linux fallback, and it is off by
+        # default because the KDE shortcut is what should be doing this. macOS
+        # has no such shortcut to defer to, so it does not read the switch.
+        if cfg.MACOS or self.conf["evdev_hotkey"]:
+            self.listener.start({name: self.conf[spec.setting]
+                                 for name, spec in hotkey.SHORTCUTS.items()})
         else:
-            self.evdev.stop()
+            self.listener.stop()
 
     def restart(self):
         """Replace this process with a fresh one, picking up code and settings."""
@@ -869,7 +882,7 @@ class Dikte:
 
     def shutdown(self):
         self._quitting = True
-        self.evdev.stop()
+        self.listener.stop()
         if self.recording:
             self.recorder.cancel()
         # A meeting in progress is closed properly rather than thrown away: the

--- a/dikte.py
+++ b/dikte.py
@@ -33,6 +33,7 @@ import ggml  # noqa: E402
 import hotkey  # noqa: E402
 import i18n  # noqa: E402
 import ipc  # noqa: E402
+import macos  # noqa: E402
 import meeting  # noqa: E402
 from i18n import t  # noqa: E402
 from meeting import MeetingPipeline  # noqa: E402
@@ -818,6 +819,10 @@ class Dikte:
         self.settings_window.show()
         self.settings_window.raise_()
         self.settings_window.activateWindow()
+        # The one window that is meant to have the keyboard. An accessory
+        # application is not activated by putting a window up — which is what
+        # keeps the indicator from stealing focus — so this one asks.
+        macos.come_to_the_front()
 
     def _settings_closed(self, *_):
         # Don't drop the object while its own signal is still being delivered.
@@ -962,6 +967,11 @@ def run_app(args):
     app.setApplicationName("Dikte")
     app.setDesktopFileName("dikte")
     app.setQuitOnLastWindowClosed(False)
+    # Straight after the QApplication and before any window: Dikte is its tray
+    # icon, and an application macOS thinks otherwise about comes to the front
+    # to show the indicator, taking the keyboard out of whatever was being
+    # typed into. Nothing happens on the other platforms.
+    macos.live_in_the_menu_bar()
     # Before Dikte is built, because building it is what may start a server, and
     # a signal arriving in the middle of that would otherwise take the default
     # action and leave the server behind. A signal this early lands in the

--- a/dikte.py
+++ b/dikte.py
@@ -212,6 +212,13 @@ class Dikte:
     def _tray_clicked(self, reason):
         if reason != QSystemTrayIcon.ActivationReason.Trigger:
             return
+        # A click on a macOS menu bar icon opens the menu, and Qt reports that
+        # same click as a Trigger. Acting on it as well means every trip to
+        # Settings starts a recording nobody asked for. The menu is what the
+        # icon does there; on Linux the click is its own button and the menu is
+        # the right one.
+        if cfg.MACOS:
+            return
         # The icon ends whatever is being recorded rather than only a dictation.
         # The two shortcuts are each tied to their own mode, on purpose, but the
         # icon is one button: having it refuse to stop a recording it can see is

--- a/ggml.py
+++ b/ggml.py
@@ -37,6 +37,7 @@ import shutil
 import signal
 import socket
 import subprocess
+import sys
 import tarfile
 import threading
 import time
@@ -220,8 +221,16 @@ def _has_vulkan():
 
 
 def _wanted_assets(program):
-    """Asset name endings to accept, best first."""
+    """Asset name endings to accept, best first.
+
+    macOS needs no second choice for the graphics card: the one build ggml-org
+    publishes for it is already a Metal build. whisper.cpp publishes no macOS
+    build at all, so there is nothing here to fetch and the settings window
+    says to install it from Homebrew instead.
+    """
     arch = _arch()
+    if sys.platform == "darwin":
+        return () if program is WHISPER else (f"bin-macos-{arch}.tar.gz",)
     if program is LLAMA and _has_vulkan():
         return (f"bin-ubuntu-vulkan-{arch}.tar.gz", f"bin-ubuntu-{arch}.tar.gz")
     return (f"bin-ubuntu-{arch}.tar.gz",)
@@ -311,6 +320,11 @@ def install_program(program, tag="", on_progress=None, should_stop=None,
         if item:
             break
     if item is None:
+        if sys.platform == "darwin" and program is WHISPER:
+            raise LocalError(t(
+                "whisper.cpp publishes no macOS build. Install it with: "
+                "brew install whisper-cpp"
+            ))
         raise LocalError(t("{repo} {tag} has no build for this machine.",
                            repo=program.repo, tag=tag))
 

--- a/hotkey.py
+++ b/hotkey.py
@@ -1,7 +1,18 @@
-"""GNOME/KDE global-shortcut installation plus a built-in evdev listener."""
+"""GNOME/KDE global-shortcut installation, an evdev listener, and Carbon.
+
+Three desktops, and the shape of the problem is different on each. KDE and
+GNOME are asked to run a command when a combination is pressed, which is a file
+written now and read by the desktop later; the evdev listener is what covers
+the gap until KWin has been restarted. macOS has neither the gap nor the file:
+Carbon binds a combination to the running application and it is live at once,
+so there `install_shortcut` is a promise that the application will register it
+and `shortcut_status` has nothing on disk to report.
+"""
 
 import ast
 import collections
+import ctypes
+import ctypes.util
 import glob
 import os
 import pathlib
@@ -10,6 +21,7 @@ import select
 import shutil
 import struct
 import subprocess
+import sys
 import threading
 
 from PyQt6.QtCore import QObject, pyqtSignal
@@ -34,8 +46,13 @@ Shortcut = collections.namedtuple("Shortcut", "verb desktop_id name setting fall
 # empty: only the toggle has one, since it is the key the application is
 # unusable without.
 SHORTCUTS = {
+    # Ctrl+Space is the input source switcher on macOS: registered here it
+    # would be accepted and then never pressed, so the fallback there is the
+    # same combination one modifier along, matching config.DEFAULTS.
     "toggle": Shortcut("toggle", DESKTOP_ID, "Dikte: start/stop recording",
-                       "shortcut", "Ctrl+Space"),
+                       "shortcut",
+                       "Ctrl+Alt+Space" if sys.platform == "darwin"
+                       else "Ctrl+Space"),
     "cancel": Shortcut("cancel", CANCEL_DESKTOP_ID, "Dikte: discard the recording",
                        "cancel_shortcut", ""),
     "ask": Shortcut("ask", ASK_DESKTOP_ID, "Dikte: ask Claude Code",
@@ -62,8 +79,11 @@ KEYS = {
 MODS = {
     "ctrl": (29, 97), "control": (29, 97),
     "shift": (42, 54),
-    "alt": (56, 100),
+    "alt": (56, 100), "option": (56, 100),
+    # One key, two names for it: macOS calls it command, and a settings file
+    # carried over from a Mac says so.
     "meta": (125, 126), "super": (125, 126),
+    "cmd": (125, 126), "command": (125, 126),
 }
 ALL_MOD_CODES = {code for pair in MODS.values() for code in pair}
 
@@ -76,7 +96,9 @@ def parse_shortcut(text):
     mods, key = set(), None
     for part in parts:
         if part in MODS:
-            mods.add("ctrl" if part == "control" else "super" if part == "meta" else part)
+            mods.add("ctrl" if part == "control"
+                     else "alt" if part == "option"
+                     else "super" if part in ("meta", "cmd", "command") else part)
         else:
             key = KEYS.get(part)
             if key is None:
@@ -84,6 +106,16 @@ def parse_shortcut(text):
     if key is None:
         return None, None
     return mods, key
+
+
+def understands(shortcut):
+    """Whether this platform can bind that combination at all.
+
+    Asked before a shortcut is installed, and the two platforms count different
+    keys: there is no F13 on the evdev table below and no Insert on a Mac.
+    """
+    parse = parse_mac_shortcut if sys.platform == "darwin" else parse_shortcut
+    return parse(shortcut) != (None, None)
 
 
 # --- built-in listener ----------------------------------------------------
@@ -321,14 +353,22 @@ def gnome_shortcut_status(desktop_id=DESKTOP_ID):
         return None
 
 
+def _macos():
+    return sys.platform == "darwin"
+
+
 def install_shortcut(shortcut, exec_command, name="Dikte: start/stop recording",
                      desktop_id=DESKTOP_ID):
+    if _macos():
+        return install_macos_shortcut(shortcut)
     if _gnome():
         return install_gnome_shortcut(shortcut, exec_command, name, desktop_id)
     return install_kde_shortcut(shortcut, exec_command, name, desktop_id)
 
 
 def remove_shortcut(desktop_id=DESKTOP_ID):
+    if _macos():
+        return          # nothing on disk to take away
     if _gnome():
         remove_gnome_shortcut(desktop_id)
     else:
@@ -336,11 +376,22 @@ def remove_shortcut(desktop_id=DESKTOP_ID):
 
 
 def shortcut_status(desktop_id=DESKTOP_ID):
+    """The combination the desktop has on file, or None.
+
+    None on macOS, always: Carbon holds a registration for as long as the
+    application runs and writes nothing down, so the setting is not a copy of
+    the binding, it is the binding. Whoever shows this to a person says so
+    there rather than here.
+    """
+    if _macos():
+        return None
     return (gnome_shortcut_status(desktop_id) if _gnome()
             else kde_shortcut_status(desktop_id))
 
 
 def desktop_name():
+    if _macos():
+        return "macOS"
     return "GNOME" if _gnome() else "KDE"
 
 
@@ -425,6 +476,12 @@ def kde_shortcut_status(desktop_id=DESKTOP_ID):
 
 def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
     """Names of other KDE entries bound to the same combination."""
+    if _macos():
+        # macOS keeps its own shortcuts in a binary property list of symbolic
+        # hot key numbers, with no names in it and no promise about the format.
+        # A clash there shows up as RegisterEventHotKey refusing the key, which
+        # is reported when it happens rather than guessed at beforehand.
+        return []
     try:
         text = SHORTCUTS_FILE.read_text(encoding="utf-8")
     except OSError:
@@ -443,3 +500,273 @@ def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
                  for part in re.split(r"[,\t]", value)):
             hits.append(f"{section} → {key}")
     return hits
+
+
+# --- macOS ----------------------------------------------------------------
+#
+# Carbon's RegisterEventHotKey is the one way on a Mac to claim a combination
+# system-wide and have the key not reach the focused window as well. It is
+# reached through ctypes rather than through PyObjC because the whole of Dikte
+# is the standard library and PyQt6, and this is six functions and two structs.
+
+# Virtual key codes (HIToolbox/Events.h). The same list of key names as the
+# evdev table above, minus the ones a Mac keyboard has no key for.
+MAC_KEYS = {
+    "a": 0x00, "s": 0x01, "d": 0x02, "f": 0x03, "h": 0x04, "g": 0x05, "z": 0x06,
+    "x": 0x07, "c": 0x08, "v": 0x09, "b": 0x0B, "q": 0x0C, "w": 0x0D, "e": 0x0E,
+    "r": 0x0F, "y": 0x10, "t": 0x11, "o": 0x1F, "u": 0x20, "i": 0x22, "p": 0x23,
+    "l": 0x25, "j": 0x26, "k": 0x28, "n": 0x2D, "m": 0x2E,
+    "1": 0x12, "2": 0x13, "3": 0x14, "4": 0x15, "6": 0x16, "5": 0x17,
+    "9": 0x19, "7": 0x1A, "8": 0x1C, "0": 0x1D,
+    "enter": 0x24, "return": 0x24, "tab": 0x30, "space": 0x31,
+    "backspace": 0x33, "esc": 0x35, "escape": 0x35,
+    "f1": 0x7A, "f2": 0x78, "f3": 0x63, "f4": 0x76, "f5": 0x60, "f6": 0x61,
+    "f7": 0x62, "f8": 0x64, "f9": 0x65, "f10": 0x6D, "f11": 0x67, "f12": 0x6F,
+    # The function keys past twelve are worth having here: nothing on macOS
+    # claims them, which on a desktop this full is rare.
+    "f13": 0x69, "f14": 0x6B, "f15": 0x71, "f16": 0x6A, "f17": 0x40,
+    "f18": 0x4F, "f19": 0x50,
+    "insert": 0x72, "home": 0x73, "pgup": 0x74, "delete": 0x75, "end": 0x77,
+    "pgdown": 0x79, "left": 0x7B, "right": 0x7C, "down": 0x7D, "up": 0x7E,
+}
+
+# Carbon's modifier bits, which are not the ones Cocoa uses.
+MAC_MODS = {
+    "cmd": 0x0100, "command": 0x0100, "meta": 0x0100, "super": 0x0100,
+    "shift": 0x0200,
+    "alt": 0x0800, "option": 0x0800,
+    "ctrl": 0x1000, "control": 0x1000,
+}
+
+
+def parse_mac_shortcut(text):
+    """'Ctrl+Alt+Space' -> (0x1800, 0x31), or (None, None) when unparsable."""
+    parts = [p.strip().lower() for p in str(text).split("+") if p.strip()]
+    if not parts:
+        return None, None
+    modifiers, key = 0, None
+    for part in parts:
+        if part in MAC_MODS:
+            modifiers |= MAC_MODS[part]
+        elif key is None and part in MAC_KEYS:
+            key = MAC_KEYS[part]
+        else:
+            return None, None
+    if key is None:
+        return None, None
+    return modifiers, key
+
+
+def install_macos_shortcut(shortcut):
+    """There is nothing to write; say whether the combination can be bound.
+
+    The registration itself happens in CarbonHotkey when the application picks
+    the setting up, which the command line asks it to do right after this
+    returns.
+    """
+    if parse_mac_shortcut(shortcut) == (None, None):
+        return False, t("Could not parse the shortcut: {shortcut}", shortcut=shortcut)
+    return True, t("Shortcut saved: {shortcut}", shortcut=shortcut)
+
+
+def _four(text):
+    """'keyb' -> 0x6B657962, which is how Carbon spells its type codes."""
+    return int.from_bytes(text.encode("ascii"), "big")
+
+
+K_EVENT_CLASS_KEYBOARD = _four("keyb")
+K_EVENT_HOTKEY_PRESSED = 5
+K_EVENT_PARAM_DIRECT_OBJECT = _four("----")
+TYPE_EVENT_HOTKEY_ID = _four("hkid")
+DIKTE_SIGNATURE = _four("dikt")
+
+_OSStatus = ctypes.c_int32
+_OSType = ctypes.c_uint32
+
+
+class _EventTypeSpec(ctypes.Structure):
+    _fields_ = [("eventClass", _OSType), ("eventKind", ctypes.c_uint32)]
+
+
+class _EventHotKeyID(ctypes.Structure):
+    _fields_ = [("signature", _OSType), ("id", ctypes.c_uint32)]
+
+
+_HANDLER = ctypes.CFUNCTYPE(_OSStatus, ctypes.c_void_p, ctypes.c_void_p,
+                            ctypes.c_void_p)
+_carbon = None
+
+
+def _load_carbon():
+    """The Carbon framework with its argument types declared, loaded once.
+
+    Declaring them matters more than it looks: a pointer returned as a C int is
+    truncated on a 64-bit build, and the event target would arrive at
+    RegisterEventHotKey as a different address than the one it was given.
+    """
+    global _carbon
+    if _carbon is not None:
+        return _carbon
+    path = ctypes.util.find_library("Carbon")
+    if not path:
+        raise OSError("Carbon framework not found")
+    lib = ctypes.CDLL(path)
+    lib.GetApplicationEventTarget.restype = ctypes.c_void_p
+    lib.GetApplicationEventTarget.argtypes = []
+    lib.InstallEventHandler.restype = _OSStatus
+    lib.InstallEventHandler.argtypes = [
+        ctypes.c_void_p, _HANDLER, ctypes.c_uint32,
+        ctypes.POINTER(_EventTypeSpec), ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.RemoveEventHandler.restype = _OSStatus
+    lib.RemoveEventHandler.argtypes = [ctypes.c_void_p]
+    lib.RegisterEventHotKey.restype = _OSStatus
+    lib.RegisterEventHotKey.argtypes = [
+        ctypes.c_uint32, ctypes.c_uint32, _EventHotKeyID,
+        ctypes.c_void_p, ctypes.c_uint32, ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.UnregisterEventHotKey.restype = _OSStatus
+    lib.UnregisterEventHotKey.argtypes = [ctypes.c_void_p]
+    lib.GetEventParameter.restype = _OSStatus
+    lib.GetEventParameter.argtypes = [
+        ctypes.c_void_p, _OSType, _OSType, ctypes.POINTER(_OSType),
+        ctypes.c_ulong, ctypes.POINTER(ctypes.c_ulong), ctypes.c_void_p,
+    ]
+    _carbon = lib
+    return _carbon
+
+
+class CarbonHotkey(QObject):
+    """Global shortcuts on macOS, through the API every Mac application uses.
+
+    The same signals and the same three methods as EvdevHotkey, so the
+    application binds one or the other and knows no difference. What is not the
+    same is that this is not a fallback: it swallows the key rather than
+    letting the focused window see it too, it asks for no permission and no
+    group membership, and it is live the moment it is registered instead of
+    after the next login.
+
+    Carbon delivers the press on the main run loop, which under Qt on macOS is
+    the one the event loop is already turning, so there is no thread here and
+    `running` means "some combination is registered" rather than "a thread is
+    alive".
+    """
+
+    triggered = pyqtSignal(str)   # the name the binding was registered under
+    failed = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._handler = None       # the installed handler, while one is
+        self._handler_fn = None    # the callback itself: Python's only
+                                   # reference to it, and Carbon holds no other
+        self._hotkeys = []         # [(ref, name)]
+        self._names = {}           # hot key id -> the name it was given
+
+    @property
+    def running(self):
+        return bool(self._hotkeys)
+
+    def start(self, bindings):
+        """`bindings` is {name: 'Ctrl+Alt+Space'}; an empty combination is skipped."""
+        self.stop()
+        try:
+            carbon = _load_carbon()
+        except OSError as exc:
+            self.failed.emit(t("Could not reach the macOS shortcut API: {error}",
+                               error=exc))
+            return False
+
+        wanted = {}
+        for name, shortcut in bindings.items():
+            if not shortcut:
+                continue
+            modifiers, key = parse_mac_shortcut(shortcut)
+            if key is None:
+                self.failed.emit(
+                    t("Could not parse the shortcut: {shortcut}", shortcut=shortcut)
+                )
+                continue
+            wanted[name] = (modifiers, key, shortcut)
+        if not wanted:
+            return False
+
+        if not self._install_handler(carbon):
+            return False
+
+        for index, (name, (modifiers, key, shortcut)) in enumerate(wanted.items(), 1):
+            ref = ctypes.c_void_p()
+            status = carbon.RegisterEventHotKey(
+                key, modifiers, _EventHotKeyID(DIKTE_SIGNATURE, index),
+                carbon.GetApplicationEventTarget(), 0, ctypes.byref(ref),
+            )
+            if status != 0:
+                # -9878, eventHotKeyExistsErr, and in practice it means one of
+                # these four is bound to the combination twice: macOS hands out
+                # a key its own shortcuts already use without complaining, and
+                # the clash only shows up as a press that never arrives,
+                # because a system shortcut sees the key first and stops there.
+                self.failed.emit(t(
+                    "{shortcut} could not be registered; another Dikte shortcut "
+                    "is already on it. Pick another one in Settings → Shortcuts.",
+                    shortcut=shortcut,
+                ))
+                continue
+            self._names[index] = name
+            self._hotkeys.append((ref, name))
+
+        if not self._hotkeys:
+            self._remove_handler()
+        return bool(self._hotkeys)
+
+    def stop(self):
+        carbon = _carbon
+        if carbon is not None:
+            for ref, _name in self._hotkeys:
+                carbon.UnregisterEventHotKey(ref)
+        self._hotkeys = []
+        self._names = {}
+        self._remove_handler()
+
+    def _install_handler(self, carbon):
+        if self._handler is not None:
+            return True
+        # Held on the instance, not passed to Carbon to keep: a callback
+        # collected while the handler is still installed is a crash the next
+        # time the key is pressed.
+        self._handler_fn = _HANDLER(self._on_event)
+        spec = _EventTypeSpec(K_EVENT_CLASS_KEYBOARD, K_EVENT_HOTKEY_PRESSED)
+        ref = ctypes.c_void_p()
+        status = carbon.InstallEventHandler(
+            carbon.GetApplicationEventTarget(), self._handler_fn, 1,
+            ctypes.byref(spec), None, ctypes.byref(ref),
+        )
+        if status != 0:
+            self._handler_fn = None
+            self.failed.emit(t("Could not listen for shortcuts: error {code}",
+                               code=status))
+            return False
+        self._handler = ref
+        return True
+
+    def _remove_handler(self):
+        if self._handler is not None and _carbon is not None:
+            _carbon.RemoveEventHandler(self._handler)
+        self._handler = None
+        self._handler_fn = None
+
+    def _on_event(self, _call_ref, event, _user_data):
+        """Called by Carbon on the main run loop, once per press."""
+        try:
+            got = _EventHotKeyID()
+            _carbon.GetEventParameter(
+                event, K_EVENT_PARAM_DIRECT_OBJECT, TYPE_EVENT_HOTKEY_ID,
+                None, ctypes.sizeof(got), None, ctypes.byref(got),
+            )
+            name = self._names.get(got.id)
+            if name:
+                self.triggered.emit(name)
+        except Exception:   # noqa: BLE001 - an exception thrown across the
+            pass            # ctypes boundary would land inside Carbon
+        return 0            # noErr: handled, and nobody else needs to see it

--- a/i18n.py
+++ b/i18n.py
@@ -104,6 +104,8 @@ TR = {
     "Could not start recording: {error}": "Kayıt başlatılamadı: {error}",
     "No audio recorder found. Install pulseaudio-utils or pipewire-audio.":
         "Ses kayıt aracı bulunamadı. pulseaudio-utils ya da pipewire-audio kur.",
+    "ffmpeg not found. Install it with: brew install ffmpeg":
+        "ffmpeg bulunamadı. Şununla kur: brew install ffmpeg",
     "Audio recorder stopped before receiving sound: {error}":
         "Ses kayıt aracı veri alamadan kapandı: {error}",
     "Could not copy to clipboard: {error}": "Panoya kopyalanamadı: {error}",
@@ -117,6 +119,13 @@ TR = {
     "{tool} failed: {error}": "{tool} hatası: {error}",
     "Is ydotoold running? (systemctl --user status ydotool)":
         "ydotoold çalışıyor mu? (systemctl --user status ydotool)",
+    "the macOS command line tools": "macOS komut satırı araçlarını",
+    "{shortcut} is not one key and its modifiers.":
+        "{shortcut} bir tuş ve değiştiricilerinden oluşmuyor.",
+    "Allow the application running Dikte to control your computer, "
+    "under System Settings → Privacy & Security → Accessibility.":
+        "Sistem Ayarları → Gizlilik ve Güvenlik → Erişilebilirlik altında, "
+        "Dikte'yi çalıştıran uygulamaya bilgisayarı kontrol etme izni ver.",
 
     # --- api errors ----------------------------------------------------
     "{service} API key is empty. Add it in Settings.":
@@ -317,6 +326,16 @@ TR = {
         "KWin, kısayol ayarlarını yalnızca açılışta okur. 'Kur' dedikten sonra kısayol "
         "Sistem Ayarları → Kısayollar altında görünür ama oturumu yeniden açana kadar "
         "tetiklenmez. O zamana kadar yerleşik dinleyiciyi kullanabilirsin.",
+    "Dikte registers these itself and they work at once, for as long as it is "
+    "running. macOS keeps its own shortcuts to itself: a combination one of "
+    "them already uses is accepted here and then never arrives, so pick "
+    "another one if a key does nothing.":
+        "Dikte bu kısayolları kendi kaydeder ve çalıştığı sürece anında "
+        "geçerlidir. macOS kendi kısayollarını kimseye açmaz: onlardan birinin "
+        "kullandığı bir kombinasyon burada kabul edilir ama hiç ulaşmaz; bir "
+        "tuş hiçbir şey yapmıyorsa başka bir kombinasyon seç.",
+    "Active while Dikte runs: {shortcut}":
+        "Dikte çalışırken etkin: {shortcut}",
     "Shortcut conflict": "Kısayol çakışması",
     "{shortcut} is also used by:\n\n{list}\n\nInstall anyway?":
         "{shortcut} şu girdilerde de kullanılıyor:\n\n{list}\n\nYine de kurulsun mu?",
@@ -329,6 +348,14 @@ TR = {
     "Could not write the desktop file: {error}": "Desktop dosyası yazılamadı: {error}",
     "Could not write kglobalshortcutsrc: {error}": "kglobalshortcutsrc yazılamadı: {error}",
     "Could not parse the shortcut: {shortcut}": "Kısayol çözümlenemedi: {shortcut}",
+    "Could not reach the macOS shortcut API: {error}":
+        "macOS kısayol arayüzüne erişilemedi: {error}",
+    "Could not listen for shortcuts: error {code}":
+        "Kısayollar dinlenemedi: hata {code}",
+    "{shortcut} could not be registered; another Dikte shortcut is already on "
+    "it. Pick another one in Settings → Shortcuts.":
+        "{shortcut} kaydedilemedi; başka bir Dikte kısayolu bu tuşta. "
+        "Ayarlar → Kısayollar'dan başka bir kombinasyon seç.",
     "Cannot read /dev/input. Your user needs to be in the 'input' group:\n"
     "  sudo usermod -aG input $USER   (then log out and back in)":
         "/dev/input okunamıyor. Kullanıcının 'input' grubunda olması gerekir:\n"
@@ -523,6 +550,10 @@ TR = {
         "kaydedilen saklanıyor.",
     "ffmpeg not found. Install it to record a meeting.":
         "ffmpeg bulunamadı. Toplantı kaydı için kur.",
+    "Recording a meeting needs what comes out of the speakers, which macOS "
+    "does not hand out. Not supported yet.":
+        "Toplantı kaydı hoparlörden çıkan sesi gerektiriyor, macOS bunu "
+        "vermiyor. Henüz desteklenmiyor.",
     "Could not work out which speaker output to record. Pick one in "
     "Settings → Meeting.":
         "Hangi ses çıkışının kaydedileceği anlaşılamadı. Ayarlar → Toplantı "
@@ -562,6 +593,12 @@ TR = {
         "Yapabiliyorsan kulaklık tak. Hoparlörde mikrofonun karşı tarafı da "
         "duyar; aynı anda iki kanala birden düşen satır ayıklanıyor ama bu "
         "onarım, hiç gerekmemesi kadar temiz olmuyor.",
+    "Recording a meeting needs what comes out of the speakers, and macOS hands "
+    "that to nobody. Everything else on this tab still applies to a recording "
+    "made elsewhere and written up here.":
+        "Toplantı kaydı hoparlörden çıkan sesi gerektiriyor ve macOS bunu "
+        "kimseye vermiyor. Bu sekmedeki diğer her şey, başka yerde alınıp "
+        "burada yazıya dökülen bir kayıt için hâlâ geçerli.",
     "Who is talking": "Kimler konuşuyor",
     "Me": "Ben",
     "Other side": "Karşı taraf",

--- a/i18n.py
+++ b/i18n.py
@@ -68,6 +68,8 @@ TR = {
     "Transcribing…": "Yazıya çevriliyor…",
     "Cleaning up…": "Temizleniyor…",
     "Pasting…": "Yapıştırılıyor…",
+    "Typing…": "Yazılıyor…",
+    "Typed": "Yazıldı",
     "Pasted": "Yapıştırıldı",
     "Copied": "Panoya kopyalandı",
     "{action}: {preview}": "{action}: {preview}",
@@ -124,6 +126,7 @@ TR = {
         "{shortcut} bir tuş ve değiştiricilerinden oluşmuyor.",
     "Dikte is not allowed to press keys.": "Dikte'nin tuşlara basma izni yok.",
     "Could not press {shortcut}.": "{shortcut} basılamadı.",
+    "Could not type the transcript.": "Metin yazılamadı.",
     "Dikte may not press keys yet, so what you dictate will be copied but not "
     "pasted. Allow it under System Settings → Privacy & Security → "
     "Accessibility, then restart Dikte.":
@@ -172,6 +175,14 @@ TR = {
     "Paste key": "Yapıştırma tuşu",
     "Terminals usually want ctrl+shift+v. Change this if pasting does nothing.":
         "Terminaller genelde ctrl+shift+v ister. Yapıştırma çalışmıyorsa bunu değiştir.",
+    "Type it out instead, leaving the clipboard alone":
+        "Bunun yerine metni yaz, panoya dokunma",
+    "The characters are sent as if typed, so whatever you had copied stays "
+    "copied and no paste key has to work in that window. Slower on a long "
+    "transcript.":
+        "Karakterler yazılmış gibi gönderilir; kopyaladığın şey panoda kalır ve "
+        "o pencerede yapıştırma tuşunun çalışması gerekmez. Uzun metinde daha "
+        "yavaştır.",
     "Restore the previous clipboard after pasting":
         "Yapıştırdıktan sonra eski pano içeriğini geri koy",
     "Indicator corner": "Gösterge köşesi",

--- a/i18n.py
+++ b/i18n.py
@@ -122,6 +122,14 @@ TR = {
     "the macOS command line tools": "macOS komut satırı araçlarını",
     "{shortcut} is not one key and its modifiers.":
         "{shortcut} bir tuş ve değiştiricilerinden oluşmuyor.",
+    "Dikte is not allowed to press keys.": "Dikte'nin tuşlara basma izni yok.",
+    "Could not press {shortcut}.": "{shortcut} basılamadı.",
+    "Dikte may not press keys yet, so what you dictate will be copied but not "
+    "pasted. Allow it under System Settings → Privacy & Security → "
+    "Accessibility, then restart Dikte.":
+        "Dikte'nin henüz tuşlara basma izni yok; dikte ettiğin metin panoya "
+        "kopyalanır ama yapıştırılmaz. Sistem Ayarları → Gizlilik ve Güvenlik → "
+        "Erişilebilirlik altından izin ver, sonra Dikte'yi yeniden başlat.",
     "Allow the application running Dikte to control your computer, "
     "under System Settings → Privacy & Security → Accessibility.":
         "Sistem Ayarları → Gizlilik ve Güvenlik → Erişilebilirlik altında, "

--- a/install.sh
+++ b/install.sh
@@ -3,14 +3,46 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PY="$(command -v python3)"
 BIN_DIR="$HOME/.local/bin"
 APP_DIR="$HOME/.local/share/applications"
 AUTOSTART_DIR="$HOME/.config/autostart"
-SHORTCUT="${1:-Ctrl+Space}"
-# Without the colon, so that a second argument given as "" stays empty. That is
-# how update.sh says "this one was turned off", as against not saying anything.
-CANCEL_SHORTCUT="${2-Ctrl+Alt+Space}"
+
+MACOS=0
+[[ "$(uname -s)" == "Darwin" ]] && MACOS=1
+MAC_APP="$HOME/Applications/Dikte.app"
+LAUNCH_AGENT="$HOME/Library/LaunchAgents/com.github.yusufipk.dikte.plist"
+
+# Ctrl+Space belongs to the input source switcher on macOS: a key pressed there
+# never reaches Dikte, so the default is one modifier along.
+if ((MACOS)); then
+  SHORTCUT="${1:-Ctrl+Alt+Space}"
+  CANCEL_SHORTCUT="${2-Ctrl+Alt+D}"
+else
+  SHORTCUT="${1:-Ctrl+Space}"
+  # Without the colon, so that a second argument given as "" stays empty. That
+  # is how update.sh says "this one was turned off", as against not saying
+  # anything.
+  CANCEL_SHORTCUT="${2-Ctrl+Alt+Space}"
+fi
+
+# The interpreter that can actually run this: PyQt6 is a system package on
+# Linux and a pip install on macOS, and on a Mac `python3` is Apple's 3.9 with
+# nothing in it. Asked of each candidate rather than assumed, and $DIKTE_PYTHON
+# wins so that a virtualenv can be pointed at.
+find_python() {
+  local candidate found
+  for candidate in "${DIKTE_PYTHON:-}" "$DIR/.venv/bin/python3" \
+                   python3 python3.13 python3.12 python3.11; do
+    [[ -n "$candidate" ]] || continue
+    found="$(command -v "$candidate" 2>/dev/null)" || continue
+    if "$found" -c 'import PyQt6.QtWidgets' 2>/dev/null; then
+      printf '%s' "$found"
+      return 0
+    fi
+  done
+  command -v python3 || true
+}
+PY="$(find_python)"
 
 say()  { printf '  %s\n' "$1"; }
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
@@ -22,33 +54,59 @@ echo "────────────────"
 
 # 1. Dependencies ----------------------------------------------------------
 missing=()
-audio_cmds=(ffmpeg)
-if command -v parec >/dev/null || command -v pw-record >/dev/null; then
-  :
+if ((MACOS)); then
+  # pbcopy and osascript come with the system; ffmpeg is the recorder as well
+  # as the file reader here, and whisper-cpp is Homebrew's because ggml-org
+  # publishes no macOS build of it.
+  for cmd in ffmpeg whisper-server; do
+    command -v "$cmd" >/dev/null || missing+=("$cmd")
+  done
+  "$PY" -c 'import PyQt6.QtWidgets' 2>/dev/null || missing+=("PyQt6")
+  if ((${#missing[@]})); then
+    warn "Missing: ${missing[*]}"
+    say  "brew install ffmpeg whisper-cpp python@3.13"
+    say  "python3.13 -m pip install PyQt6"
+    say  "A virtualenv works too; point DIKTE_PYTHON at its python3."
+    echo
+  else
+    ok "All dependencies present"
+  fi
 else
-  missing+=("pulseaudio-utils-or-pipewire-audio")
-fi
-if [[ "${XDG_SESSION_TYPE:-}" == "x11" ]]; then
-  desktop_cmds=(xclip xdotool)
-else
-  desktop_cmds=(wl-copy wl-paste ydotool)
-fi
-for cmd in "${audio_cmds[@]}" "${desktop_cmds[@]}"; do
-  command -v "$cmd" >/dev/null || missing+=("$cmd")
-done
-python3 -c 'import PyQt6.QtWidgets' 2>/dev/null || missing+=("python-pyqt6")
+  audio_cmds=(ffmpeg)
+  if command -v parec >/dev/null || command -v pw-record >/dev/null; then
+    :
+  else
+    missing+=("pulseaudio-utils-or-pipewire-audio")
+  fi
+  if [[ "${XDG_SESSION_TYPE:-}" == "x11" ]]; then
+    desktop_cmds=(xclip xdotool)
+  else
+    desktop_cmds=(wl-copy wl-paste ydotool)
+  fi
+  for cmd in "${audio_cmds[@]}" "${desktop_cmds[@]}"; do
+    command -v "$cmd" >/dev/null || missing+=("$cmd")
+  done
+  "$PY" -c 'import PyQt6.QtWidgets' 2>/dev/null || missing+=("python-pyqt6")
 
-if ((${#missing[@]})); then
-  warn "Missing: ${missing[*]}"
-  say  "Ubuntu X11:    sudo apt install pulseaudio-utils xclip xdotool ffmpeg"
-  say  "Arch Wayland:  sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6"
-  echo
-else
-  ok "All dependencies present"
+  if ((${#missing[@]})); then
+    warn "Missing: ${missing[*]}"
+    say  "Ubuntu X11:    sudo apt install pulseaudio-utils xclip xdotool ffmpeg"
+    say  "Arch Wayland:  sudo pacman -S --needed pipewire-audio wl-clipboard ydotool ffmpeg python-pyqt6"
+    echo
+  else
+    ok "All dependencies present"
+  fi
 fi
 
-# 2. ydotoold --------------------------------------------------------------
-if [[ "${XDG_SESSION_TYPE:-}" != "x11" ]] && command -v ydotool >/dev/null; then
+# 2. Permission to type on your behalf --------------------------------------
+# ydotool on Linux needs a daemon running; macOS needs the terminal or the app
+# bundle to have been allowed to control the computer. Neither can be arranged
+# from a script, so both are said out loud.
+if ((MACOS)); then
+  say  "Auto-paste presses Cmd+V through System Events, which needs permission:"
+  say  "System Settings → Privacy & Security → Accessibility → allow Dikte"
+  say  "(or the terminal you start it from). The first paste asks for it."
+elif [[ "${XDG_SESSION_TYPE:-}" != "x11" ]] && command -v ydotool >/dev/null; then
   if systemctl --user is-active --quiet ydotool 2>/dev/null \
      || systemctl --user is-active --quiet ydotoold 2>/dev/null; then
     ok "ydotoold is running (auto-paste ready)"
@@ -59,16 +117,86 @@ if [[ "${XDG_SESSION_TYPE:-}" != "x11" ]] && command -v ydotool >/dev/null; then
 fi
 
 # 3. Launchers -------------------------------------------------------------
-mkdir -p "$BIN_DIR" "$APP_DIR" "$AUTOSTART_DIR"
-ln -sf "$DIR/dikte.py" "$BIN_DIR/dikte"
+mkdir -p "$BIN_DIR"
 chmod +x "$DIR/dikte.py"
+if ((MACOS)); then
+  # A wrapper rather than a symlink: dikte.py's shebang finds `python3`, and on
+  # a Mac that is Apple's 3.9 with no PyQt6 in it. The interpreter that was
+  # found above is written in here instead.
+  cat > "$BIN_DIR/dikte" <<EOF
+#!/bin/sh
+# Written by Dikte's install.sh; re-run it to point this somewhere else.
+exec "$PY" "$DIR/dikte.py" "\$@"
+EOF
+  chmod +x "$BIN_DIR/dikte"
+else
+  mkdir -p "$APP_DIR" "$AUTOSTART_DIR"
+  ln -sf "$DIR/dikte.py" "$BIN_DIR/dikte"
+fi
 ok "Command installed: $BIN_DIR/dikte"
 case ":$PATH:" in
   *":$BIN_DIR:"*) ;;
   *) warn "$BIN_DIR is not on your PATH. For fish: fish_add_path $BIN_DIR" ;;
 esac
 
-cat > "$APP_DIR/dikte.desktop" <<EOF
+if ((MACOS)); then
+  # An .app so that macOS has something to show in Spotlight and in Login
+  # Items, and LSUIElement so that it stays out of the Dock: the tray icon in
+  # the menu bar is the whole of Dikte's presence on screen.
+  mkdir -p "$MAC_APP/Contents/MacOS"
+  cat > "$MAC_APP/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>Dikte</string>
+  <key>CFBundleDisplayName</key><string>Dikte</string>
+  <key>CFBundleIdentifier</key><string>com.github.yusufipk.dikte</string>
+  <key>CFBundleExecutable</key><string>dikte</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>LSMinimumSystemVersion</key><string>11.0</string>
+  <key>LSUIElement</key><true/>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Dikte records what you dictate so it can be transcribed.</string>
+</dict>
+</plist>
+EOF
+  cat > "$MAC_APP/Contents/MacOS/dikte" <<EOF
+#!/bin/sh
+exec "$PY" "$DIR/dikte.py" "\$@"
+EOF
+  chmod +x "$MAC_APP/Contents/MacOS/dikte"
+  ok "Application bundle: $MAC_APP"
+
+  mkdir -p "$(dirname "$LAUNCH_AGENT")"
+  cat > "$LAUNCH_AGENT" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.github.yusufipk.dikte</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$MAC_APP/Contents/MacOS/dikte</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><false/>
+  <key>ProcessType</key><string>Interactive</string>
+</dict>
+</plist>
+EOF
+  # Already loaded from a previous install, most likely; booting it out first
+  # is what makes this re-runnable. Neither step is worth failing over, since
+  # the next login loads it either way.
+  launchctl bootout "gui/$(id -u)/com.github.yusufipk.dikte" 2>/dev/null || true
+  if launchctl bootstrap "gui/$(id -u)" "$LAUNCH_AGENT" 2>/dev/null; then
+    ok "Will start automatically on login (and is starting now)"
+  else
+    warn "Could not load the launch agent; it will start at your next login."
+  fi
+else
+  cat > "$APP_DIR/dikte.desktop" <<EOF
 [Desktop Entry]
 Type=Application
 Name=Dikte
@@ -78,9 +206,9 @@ Icon=audio-input-microphone
 Categories=Utility;AudioVideo;
 StartupNotify=false
 EOF
-ok "Application menu entry added"
+  ok "Application menu entry added"
 
-cat > "$AUTOSTART_DIR/dikte.desktop" <<EOF
+  cat > "$AUTOSTART_DIR/dikte.desktop" <<EOF
 [Desktop Entry]
 Type=Application
 Name=Dikte
@@ -89,7 +217,8 @@ Icon=audio-input-microphone
 X-GNOME-Autostart-enabled=true
 StartupNotify=false
 EOF
-ok "Will start automatically on login"
+  ok "Will start automatically on login"
+fi
 
 # 4. Global shortcuts ------------------------------------------------------
 # Two of them: one to start and stop, one to throw the recording away. The
@@ -115,12 +244,16 @@ register() {   # which  combination  label
   fi
 }
 
-if python3 -c 'import PyQt6.QtWidgets' 2>/dev/null; then
+if "$PY" -c 'import PyQt6.QtWidgets' 2>/dev/null; then
   register toggle "$SHORTCUT" "Start and stop"
   if [[ -n "$CANCEL_SHORTCUT" ]]; then
     register cancel "$CANCEL_SHORTCUT" "Discard the recording"
   fi
-  if [[ "${XDG_CURRENT_DESKTOP:-}" != *[Gg][Nn][Oo][Mm][Ee]* ]]; then
+  if ((MACOS)); then
+    say  "Dikte registers these itself, so they work as soon as it runs. macOS"
+    say  "keeps its own shortcuts to itself: if a key does nothing, something"
+    say  "else already has it — pick another in Settings → Shortcuts."
+  elif [[ "${XDG_CURRENT_DESKTOP:-}" != *[Gg][Nn][Oo][Mm][Ee]* ]]; then
     warn "KWin only reads these at startup, so they go live after your next"
     say  "login. Until then open Settings → Shortcuts and turn on the"
     say  "built-in listener to use them right away."

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ MACOS=0
 [[ "$(uname -s)" == "Darwin" ]] && MACOS=1
 MAC_APP="$HOME/Applications/Dikte.app"
 LAUNCH_AGENT="$HOME/Library/LaunchAgents/com.github.yusufipk.dikte.plist"
+LOG_FILE="${XDG_STATE_HOME:-$HOME/.local/state}/dikte.log"
 
 # Ctrl+Space belongs to the input source switcher on macOS: a key pressed there
 # never reaches Dikte, so the default is one modifier along.
@@ -103,9 +104,10 @@ fi
 # bundle to have been allowed to control the computer. Neither can be arranged
 # from a script, so both are said out loud.
 if ((MACOS)); then
-  say  "Auto-paste presses Cmd+V through System Events, which needs permission:"
+  say  "Auto-paste presses Cmd+V itself, which macOS grants per application:"
   say  "System Settings → Privacy & Security → Accessibility → allow Dikte"
-  say  "(or the terminal you start it from). The first paste asks for it."
+  say  "(or the terminal you start it from). Dikte asks on its first run, and"
+  say  "says so in the menu bar when it has not been allowed."
 elif [[ "${XDG_SESSION_TYPE:-}" != "x11" ]] && command -v ydotool >/dev/null; then
   if systemctl --user is-active --quiet ydotool 2>/dev/null \
      || systemctl --user is-active --quiet ydotoold 2>/dev/null; then
@@ -162,14 +164,16 @@ if ((MACOS)); then
 </dict>
 </plist>
 EOF
+  # --gui, because LaunchServices starts this with no arguments and dikte.py
+  # with none of those is the command line looking for an instance to talk to.
   cat > "$MAC_APP/Contents/MacOS/dikte" <<EOF
 #!/bin/sh
-exec "$PY" "$DIR/dikte.py" "\$@"
+exec "$PY" "$DIR/dikte.py" --gui "\$@"
 EOF
   chmod +x "$MAC_APP/Contents/MacOS/dikte"
   ok "Application bundle: $MAC_APP"
 
-  mkdir -p "$(dirname "$LAUNCH_AGENT")"
+  mkdir -p "$(dirname "$LAUNCH_AGENT")" "$(dirname "$LOG_FILE")"
   cat > "$LAUNCH_AGENT" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -183,6 +187,10 @@ EOF
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><false/>
   <key>ProcessType</key><string>Interactive</string>
+  <!-- Started by launchd, so there is no terminal for it to complain to.
+       Without these, a Dikte that dies on startup does so in silence. -->
+  <key>StandardOutPath</key><string>$LOG_FILE</string>
+  <key>StandardErrorPath</key><string>$LOG_FILE</string>
 </dict>
 </plist>
 EOF

--- a/macos.py
+++ b/macos.py
@@ -29,7 +29,30 @@ NS_ACCESSORY = 1
 NS_CAN_JOIN_ALL_SPACES = 1 << 0
 NS_FULL_SCREEN_AUXILIARY = 1 << 8
 
+# CGEventFlags, which are not the numbers Carbon uses for the same keys.
+CG_FLAGS = {
+    "cmd": 1 << 20, "command": 1 << 20, "meta": 1 << 20, "super": 1 << 20,
+    "shift": 1 << 17,
+    "ctrl": 1 << 18, "control": 1 << 18,
+    "alt": 1 << 19, "option": 1 << 19,
+}
+# kCGHIDEventTap: posted where the hardware would have, so every application
+# sees it the way it sees a real key.
+CG_HID_EVENT_TAP = 0
+
 _objc = None
+_appservices = None
+
+
+def _services():
+    """ApplicationServices, which holds both Quartz and the accessibility check."""
+    global _appservices
+    if _appservices is None:
+        path = ctypes.util.find_library("ApplicationServices")
+        if not path:
+            return None
+        _appservices = ctypes.cdll.LoadLibrary(path)
+    return _appservices
 
 
 def available():
@@ -43,26 +66,59 @@ def available():
     return sys.platform == "darwin" and QApplication.platformName() == "cocoa"
 
 
+def _runtime():
+    """libobjc, loaded once, with the functions used below declared.
+
+    Declaring them matters more than it looks: a pointer returned as a C int is
+    truncated on a 64-bit build, and the class would arrive at objc_msgSend as
+    a different address than the one it was given.
+    """
+    global _objc
+    if _objc is None:
+        lib = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
+        lib.objc_getClass.restype = ctypes.c_void_p
+        lib.objc_getClass.argtypes = [ctypes.c_char_p]
+        lib.sel_registerName.restype = ctypes.c_void_p
+        lib.sel_registerName.argtypes = [ctypes.c_char_p]
+        _objc = lib
+    return _objc
+
+
 def _send(receiver, selector, restype=ctypes.c_void_p, argtypes=(), *args):
     """[receiver selector:args].
 
     objc_msgSend is variadic, and ctypes cannot call a variadic function on
     arm64 without being told the argument types, so every call declares its own.
     """
-    global _objc
-    if _objc is None:
-        _objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
-        _objc.objc_getClass.restype = ctypes.c_void_p
-        _objc.objc_getClass.argtypes = [ctypes.c_char_p]
-        _objc.sel_registerName.restype = ctypes.c_void_p
-        _objc.sel_registerName.argtypes = [ctypes.c_char_p]
-    _objc.objc_msgSend.restype = restype
-    _objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *argtypes]
-    return _objc.objc_msgSend(receiver, _objc.sel_registerName(selector), *args)
+    objc = _runtime()
+    objc.objc_msgSend.restype = restype
+    objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *argtypes]
+    return objc.objc_msgSend(receiver, objc.sel_registerName(selector), *args)
 
 
 def _app():
-    return _send(_objc.objc_getClass(b"NSApplication"), b"sharedApplication")
+    # Through _runtime() rather than the module-level name: Python evaluates
+    # the arguments before the call, so reaching for the library here while
+    # _send() is still the only thing that loads it is an AttributeError — one
+    # the callers below would have caught and turned into a silent "no".
+    return _send(_runtime().objc_getClass(b"NSApplication"), b"sharedApplication")
+
+
+def _try(what, call):
+    """Run one of these and say whether it worked, out loud when it did not.
+
+    Every failure here is a window behaving as if the call had never been
+    written: the indicator hides itself, or takes the keyboard with it. Both
+    look like a bug in the recording rather than in three lines of ctypes, and
+    a caught exception with nothing said is what makes them look that way.
+    """
+    try:
+        call()
+    except (OSError, AttributeError, TypeError, ValueError) as exc:
+        print(f"dikte: macOS refused {what} ({exc}); "
+              f"the indicator may not behave", file=sys.stderr)
+        return False
+    return True
 
 
 def live_in_the_menu_bar():
@@ -78,12 +134,9 @@ def live_in_the_menu_bar():
     """
     if not available():
         return False
-    try:
-        _send(_app(), b"setActivationPolicy:", ctypes.c_bool, [ctypes.c_long],
-              NS_ACCESSORY)
-    except (OSError, AttributeError, TypeError, ValueError):
-        return False
-    return True
+    return _try("setActivationPolicy:", lambda: _send(
+        _app(), b"setActivationPolicy:", ctypes.c_bool, [ctypes.c_long],
+        NS_ACCESSORY))
 
 
 def keep_visible_without_focus(widget):
@@ -99,17 +152,96 @@ def keep_visible_without_focus(widget):
     """
     if not available():
         return False
-    try:
-        window = _send(ctypes.c_void_p(int(widget.winId())), b"window")
-        if not window:
-            return False
-        _send(window, b"setHidesOnDeactivate:", None, [ctypes.c_bool], False)
-        _send(window, b"setCollectionBehavior:", None, [ctypes.c_ulong],
-              NS_CAN_JOIN_ALL_SPACES | NS_FULL_SCREEN_AUXILIARY)
-    except (OSError, AttributeError, TypeError, ValueError):
+
+    def call():
         # A Qt that hands out something other than an NSView, or a macOS that
         # has stopped answering to these. An indicator that hides too eagerly
         # is worth less than one that stays; neither is worth a crash.
+        window = _send(ctypes.c_void_p(int(widget.winId())), b"window")
+        if not window:
+            raise ValueError("no NSWindow behind this widget")
+        _send(window, b"setHidesOnDeactivate:", None, [ctypes.c_bool], False)
+        _send(window, b"setCollectionBehavior:", None, [ctypes.c_ulong],
+              NS_CAN_JOIN_ALL_SPACES | NS_FULL_SCREEN_AUXILIARY)
+
+    return _try("setHidesOnDeactivate:", call)
+
+
+def trusted_to_type(ask=False):
+    """Whether macOS will let this process press a key on your behalf.
+
+    Worth asking rather than finding out: told to press a key it has not been
+    allowed to, macOS answers that it did. osascript exits 0, System Events
+    reports no error, and the key reaches nobody — a dictation that ends in a
+    transcript nothing was ever pasted from, and no reason given anywhere.
+
+    `ask` opens the system's own dialogue, which is the only way to the pane
+    that grants it, and returns the answer as it stands rather than waiting.
+    """
+    if not available():
+        return False
+    services = _services()
+    if services is None:
+        return False
+    try:
+        if not ask:
+            services.AXIsProcessTrusted.restype = ctypes.c_bool
+            return bool(services.AXIsProcessTrusted())
+        core = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreFoundation"))
+        core.CFStringCreateWithCString.restype = ctypes.c_void_p
+        core.CFStringCreateWithCString.argtypes = [ctypes.c_void_p,
+                                                   ctypes.c_char_p, ctypes.c_uint32]
+        core.CFDictionaryCreate.restype = ctypes.c_void_p
+        core.CFDictionaryCreate.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                            ctypes.c_void_p, ctypes.c_long,
+                                            ctypes.c_void_p, ctypes.c_void_p]
+        key = ctypes.c_void_p(core.CFStringCreateWithCString(
+            None, b"AXTrustedCheckOptionPrompt", 0x08000100))   # kCFStringEncodingUTF8
+        true_value = ctypes.c_void_p.in_dll(core, "kCFBooleanTrue")
+        keys = (ctypes.c_void_p * 1)(key)
+        values = (ctypes.c_void_p * 1)(true_value)
+        options = core.CFDictionaryCreate(None, keys, values, 1, None, None)
+        services.AXIsProcessTrustedWithOptions.restype = ctypes.c_bool
+        services.AXIsProcessTrustedWithOptions.argtypes = [ctypes.c_void_p]
+        return bool(services.AXIsProcessTrustedWithOptions(options))
+    except (OSError, AttributeError, TypeError, ValueError) as exc:
+        print(f"dikte: could not ask macOS about accessibility ({exc})",
+              file=sys.stderr)
+        return False
+
+
+def press_keys(modifiers, key_code):
+    """Post one key down and up, with `modifiers` held, as this process.
+
+    Through Quartz rather than by shelling out to osascript: one fewer process
+    on every dictation, and — the reason it matters — the permission belongs to
+    whoever posts the event. osascript is a program of Apple's that Dikte
+    happens to run, and macOS judges it by the application responsible for it,
+    which is not always the one somebody has allowed in the settings.
+    """
+    if not available():
+        return False
+    services = _services()
+    if services is None:
+        return False
+    try:
+        services.CGEventCreateKeyboardEvent.restype = ctypes.c_void_p
+        services.CGEventCreateKeyboardEvent.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint16, ctypes.c_bool]
+        services.CGEventSetFlags.argtypes = [ctypes.c_void_p, ctypes.c_uint64]
+        services.CGEventPost.argtypes = [ctypes.c_uint32, ctypes.c_void_p]
+        core = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreFoundation"))
+        core.CFRelease.argtypes = [ctypes.c_void_p]
+
+        for down in (True, False):
+            event = services.CGEventCreateKeyboardEvent(None, key_code, down)
+            if not event:
+                return False
+            services.CGEventSetFlags(event, modifiers)
+            services.CGEventPost(CG_HID_EVENT_TAP, event)
+            core.CFRelease(event)
+    except (OSError, AttributeError, TypeError, ValueError) as exc:
+        print(f"dikte: could not press the key ({exc})", file=sys.stderr)
         return False
     return True
 
@@ -124,8 +256,5 @@ def come_to_the_front():
     """
     if not available():
         return False
-    try:
-        _send(_app(), b"activateIgnoringOtherApps:", None, [ctypes.c_bool], True)
-    except (OSError, AttributeError, TypeError, ValueError):
-        return False
-    return True
+    return _try("activateIgnoringOtherApps:", lambda: _send(
+        _app(), b"activateIgnoringOtherApps:", None, [ctypes.c_bool], True))

--- a/macos.py
+++ b/macos.py
@@ -1,0 +1,131 @@
+"""The few things macOS has to be told, through the Objective-C runtime.
+
+Three of them, and each is a default that suits an application with a window
+and a Dock icon rather than one that lives in the menu bar:
+
+  * an application that has not said otherwise comes to the front when it puts
+    a window on screen, which for the indicator means taking the keyboard away
+    from whatever was being typed into — the one thing it must never do;
+  * a utility panel is hidden while its application is not the active one,
+    which is every moment the indicator is for;
+  * and a window belongs to the desktop its application started on.
+
+Reached through ctypes rather than PyObjC because the whole of Dikte is the
+standard library and PyQt6, and this is four messages.
+"""
+
+import ctypes
+import ctypes.util
+import sys
+
+from PyQt6.QtWidgets import QApplication
+
+# NSApplicationActivationPolicy: in the menu bar, not in the Dock, and never
+# activated by putting a window up.
+NS_ACCESSORY = 1
+
+# NSWindowCollectionBehavior: on every desktop, and beside a full-screen window
+# rather than replacing it.
+NS_CAN_JOIN_ALL_SPACES = 1 << 0
+NS_FULL_SCREEN_AUXILIARY = 1 << 8
+
+_objc = None
+
+
+def available():
+    """Whether these calls mean anything here.
+
+    The platform is asked for by name and not worked out from the operating
+    system: winId() is an NSView under the cocoa plugin only, and offscreen —
+    which is what the tests run on — hands back a handle that is not an object
+    at all. Sending that a message ends the process.
+    """
+    return sys.platform == "darwin" and QApplication.platformName() == "cocoa"
+
+
+def _send(receiver, selector, restype=ctypes.c_void_p, argtypes=(), *args):
+    """[receiver selector:args].
+
+    objc_msgSend is variadic, and ctypes cannot call a variadic function on
+    arm64 without being told the argument types, so every call declares its own.
+    """
+    global _objc
+    if _objc is None:
+        _objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
+        _objc.objc_getClass.restype = ctypes.c_void_p
+        _objc.objc_getClass.argtypes = [ctypes.c_char_p]
+        _objc.sel_registerName.restype = ctypes.c_void_p
+        _objc.sel_registerName.argtypes = [ctypes.c_char_p]
+    _objc.objc_msgSend.restype = restype
+    _objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *argtypes]
+    return _objc.objc_msgSend(receiver, _objc.sel_registerName(selector), *args)
+
+
+def _app():
+    return _send(_objc.objc_getClass(b"NSApplication"), b"sharedApplication")
+
+
+def live_in_the_menu_bar():
+    """Stop the application coming to the front when it shows a window.
+
+    Dikte is its tray icon: the indicator appears while you are typing
+    somewhere else, and an application that activates to show it takes the
+    keyboard with it — the recording starts, the window you were in loses
+    focus, and the paste at the end goes wherever the focus went instead.
+
+    The .app bundle says the same thing with LSUIElement, but a checkout run
+    straight from the terminal has no bundle to say it in.
+    """
+    if not available():
+        return False
+    try:
+        _send(_app(), b"setActivationPolicy:", ctypes.c_bool, [ctypes.c_long],
+              NS_ACCESSORY)
+    except (OSError, AttributeError, TypeError, ValueError):
+        return False
+    return True
+
+
+def keep_visible_without_focus(widget):
+    """Leave a window on screen while Dikte is in the background.
+
+    Given the Tool flag, Qt asks Cocoa for a utility panel, and a utility panel
+    is hidden the moment its application stops being the active one. The
+    indicator is only ever wanted in that state, so it is told to stay, and to
+    join whichever desktop you are on rather than the one Dikte started on.
+
+    Nothing to do anywhere else: X11 and Wayland hand a window's visibility to
+    the window manager, not to whether its application has focus.
+    """
+    if not available():
+        return False
+    try:
+        window = _send(ctypes.c_void_p(int(widget.winId())), b"window")
+        if not window:
+            return False
+        _send(window, b"setHidesOnDeactivate:", None, [ctypes.c_bool], False)
+        _send(window, b"setCollectionBehavior:", None, [ctypes.c_ulong],
+              NS_CAN_JOIN_ALL_SPACES | NS_FULL_SCREEN_AUXILIARY)
+    except (OSError, AttributeError, TypeError, ValueError):
+        # A Qt that hands out something other than an NSView, or a macOS that
+        # has stopped answering to these. An indicator that hides too eagerly
+        # is worth less than one that stays; neither is worth a crash.
+        return False
+    return True
+
+
+def come_to_the_front():
+    """Ask for the keyboard, for the one window that wants it.
+
+    An accessory application is not activated by showing a window, which is the
+    point of the policy above and wrong for exactly one thing: the settings
+    window is opened deliberately and would otherwise come up behind whatever
+    is in front of it.
+    """
+    if not available():
+        return False
+    try:
+        _send(_app(), b"activateIgnoringOtherApps:", None, [ctypes.c_bool], True)
+    except (OSError, AttributeError, TypeError, ValueError):
+        return False
+    return True

--- a/macos.py
+++ b/macos.py
@@ -17,6 +17,7 @@ standard library and PyQt6, and this is four messages.
 import ctypes
 import ctypes.util
 import sys
+import time
 
 from PyQt6.QtWidgets import QApplication
 
@@ -242,6 +243,57 @@ def press_keys(modifiers, key_code):
             core.CFRelease(event)
     except (OSError, AttributeError, TypeError, ValueError) as exc:
         print(f"dikte: could not press the key ({exc})", file=sys.stderr)
+        return False
+    return True
+
+
+def type_text(text, chunk=16):
+    """Send `text` to whatever has the keyboard, as if it had been typed.
+
+    No clipboard and no Cmd+V: the characters travel in the event itself, so
+    nothing anybody had copied is overwritten and no key combination has to
+    mean paste in the window receiving it.
+
+    A few characters at a time, because a single event carrying a paragraph is
+    dropped by some applications. Each pair is a press and a release of the one
+    key that carries a string, which is how macOS delivers text that has no key
+    of its own.
+    """
+    if not available() or not text:
+        return False
+    services = _services()
+    if services is None:
+        return False
+    try:
+        services.CGEventCreateKeyboardEvent.restype = ctypes.c_void_p
+        services.CGEventCreateKeyboardEvent.argtypes = [
+            ctypes.c_void_p, ctypes.c_uint16, ctypes.c_bool]
+        services.CGEventKeyboardSetUnicodeString.argtypes = [
+            ctypes.c_void_p, ctypes.c_ulong, ctypes.c_void_p]
+        services.CGEventPost.argtypes = [ctypes.c_uint32, ctypes.c_void_p]
+        core = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreFoundation"))
+        core.CFRelease.argtypes = [ctypes.c_void_p]
+
+        for start in range(0, len(text), chunk):
+            piece = text[start:start + chunk]
+            # UTF-16, which is what a UniChar is, and surrogate pairs count as
+            # the two units they are rather than the one character they spell.
+            units = piece.encode("utf-16-le")
+            buffer = ctypes.create_string_buffer(units, len(units))
+            for down in (True, False):
+                event = services.CGEventCreateKeyboardEvent(None, 0, down)
+                if not event:
+                    return False
+                services.CGEventKeyboardSetUnicodeString(
+                    event, len(units) // 2, buffer)
+                services.CGEventPost(CG_HID_EVENT_TAP, event)
+                core.CFRelease(event)
+            # Posted faster than this, a run of events arrives at some
+            # applications with pieces missing: the tail of a sentence, usually,
+            # which is the half nobody notices is gone.
+            time.sleep(0.004)
+    except (OSError, AttributeError, TypeError, ValueError) as exc:
+        print(f"dikte: could not type the text ({exc})", file=sys.stderr)
         return False
     return True
 

--- a/macos.py
+++ b/macos.py
@@ -1,17 +1,29 @@
-"""The few things macOS has to be told, through the Objective-C runtime.
+"""What macOS has to be told, and what it will not tell you.
 
-Three of them, and each is a default that suits an application with a window
-and a Dock icon rather than one that lives in the menu bar:
+Every default here suits an application with a window and a Dock icon rather
+than one that lives in the menu bar and appears while you are typing somewhere
+else:
 
   * an application that has not said otherwise comes to the front when it puts
-    a window on screen, which for the indicator means taking the keyboard away
-    from whatever was being typed into — the one thing it must never do;
+    a window on screen, taking the keyboard with it — the one thing an
+    indicator must never do;
   * a utility panel is hidden while its application is not the active one,
     which is every moment the indicator is for;
-  * and a window belongs to the desktop its application started on.
+  * a window belongs to the desktop its application started on;
+  * and showing any window at all leaves the window that had the keyboard no
+    longer holding it. Not the focus — the application stays frontmost and
+    nothing moves on screen — but the key window, which is where a typed
+    character actually arrives. There is no flag that prevents this: not a
+    panel that cannot become key, not an accessory application, not
+    WA_ShowWithoutActivating, not NSWindowStyleMaskNonactivatingPanel. So the
+    keyboard is noted before and handed back after.
+
+And one thing it lies about: told to press a key it has not been allowed to,
+macOS reports that it did. Nothing fails, nothing is logged, the key reaches
+nobody. Hence trusted_to_type(), asked before rather than after.
 
 Reached through ctypes rather than PyObjC because the whole of Dikte is the
-standard library and PyQt6, and this is four messages.
+standard library and PyQt6, and this is a handful of messages.
 """
 
 import ctypes

--- a/macos.py
+++ b/macos.py
@@ -247,6 +247,58 @@ def press_keys(modifiers, key_code):
     return True
 
 
+_front_before = 0
+
+
+def remember_the_front():
+    """Note which application has the keyboard, before the indicator goes up.
+
+    Putting any window on screen — a panel that cannot become key, belonging
+    to an accessory application, shown without activating — still leaves the
+    window that had the keyboard no longer holding it. The application stays
+    frontmost, so nothing looks different, but a typed character now arrives
+    nowhere. Which is exactly what a dictation ends by doing.
+
+    So who it was is written down here, and give_the_keyboard_back() hands it
+    over again before the transcript is typed.
+    """
+    if not available():
+        return 0
+    global _front_before
+    try:
+        workspace = _send(_runtime().objc_getClass(b"NSWorkspace"),
+                          b"sharedWorkspace")
+        app = _send(workspace, b"frontmostApplication")
+        _front_before = _send(app, b"processIdentifier", ctypes.c_int) if app else 0
+    except (OSError, AttributeError, TypeError, ValueError):
+        _front_before = 0
+    return _front_before
+
+
+def give_the_keyboard_back():
+    """Make that application key again, so what is typed reaches it.
+
+    It is already the frontmost one, so nothing moves on screen and nothing
+    the user did is undone: this only restores the part macOS quietly took
+    when the indicator appeared.
+    """
+    if not available() or not _front_before:
+        return False
+
+    def call():
+        cls = _runtime().objc_getClass(b"NSRunningApplication")
+        app = _send(cls, b"runningApplicationWithProcessIdentifier:",
+                    ctypes.c_void_p, [ctypes.c_int], _front_before)
+        if not app:
+            raise ValueError("that application is gone")
+        # NSApplicationActivateIgnoringOtherApps, so the window that was there
+        # before the indicator gets the keyboard rather than whatever Dikte's
+        # own activation would hand it to.
+        _send(app, b"activateWithOptions:", ctypes.c_bool, [ctypes.c_ulong], 1 << 1)
+
+    return _try("activateWithOptions:", call)
+
+
 def type_text(text, chunk=16):
     """Send `text` to whatever has the keyboard, as if it had been typed.
 

--- a/overlay.py
+++ b/overlay.py
@@ -1,13 +1,12 @@
 """The small recording indicator that appears in a screen corner without taking focus."""
 
-import ctypes
-import ctypes.util
 import math
-import sys
 
 from PyQt6.QtCore import Qt, QTimer, QRectF, QPointF
 from PyQt6.QtGui import QColor, QCursor, QFont, QPainter, QPainterPath, QPen, QFontMetrics
 from PyQt6.QtWidgets import QWidget, QApplication
+
+import macos
 
 BARS = 22
 HEIGHT = 56
@@ -32,62 +31,6 @@ ASK = QColor(150, 140, 255)    # recording a command rather than a dictation
 STATE_COLORS = {"recording": REC, "asking": ASK, "meeting": REC, "busy": BUSY,
                 "done": OK, "warning": WARN, "error": ERR}
 LIVE = ("recording", "asking", "meeting")
-
-# NSWindowCollectionBehavior: on every desktop, and beside a full-screen window
-# rather than being one.
-NS_CAN_JOIN_ALL_SPACES = 1 << 0
-NS_FULL_SCREEN_AUXILIARY = 1 << 8
-_objc = None
-
-
-def _msg_send(receiver, selector, restype=ctypes.c_void_p, argtypes=(), *args):
-    """[receiver selector:args], through the Objective-C runtime.
-
-    objc_msgSend is variadic and ctypes cannot call a variadic function on
-    arm64 without being told the argument types, so each call declares its own.
-    """
-    global _objc
-    if _objc is None:
-        _objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
-        _objc.sel_registerName.restype = ctypes.c_void_p
-        _objc.sel_registerName.argtypes = [ctypes.c_char_p]
-    _objc.objc_msgSend.restype = restype
-    _objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *argtypes]
-    return _objc.objc_msgSend(receiver, _objc.sel_registerName(selector), *args)
-
-
-def keep_visible_off_screen_focus(widget):
-    """Stop macOS from taking the indicator away whenever Dikte is not in front.
-
-    Given the Tool flag, Qt asks Cocoa for a utility panel, and Cocoa hides a
-    utility panel the moment its application stops being the active one — which
-    is every moment that matters here, the indicator's whole job being to be
-    visible while you are typing in some other window. It stays put instead,
-    and joins whichever desktop you are on rather than the one Dikte started
-    on.
-
-    Nothing to do anywhere else: X11 and Wayland hand a window's visibility to
-    the window manager, not to whether its application has focus.
-
-    The platform is asked for by name, not guessed at from the operating
-    system: winId() is an NSView only under the cocoa plugin, and offscreen —
-    which is what the tests run on — hands back a handle that is not an object
-    at all. Sending it a message would take the process with it.
-    """
-    if sys.platform != "darwin" or QApplication.platformName() != "cocoa":
-        return
-    try:
-        window = _msg_send(ctypes.c_void_p(int(widget.winId())), b"window")
-        if not window:
-            return
-        _msg_send(window, b"setHidesOnDeactivate:", None, [ctypes.c_bool], False)
-        _msg_send(window, b"setCollectionBehavior:", None, [ctypes.c_ulong],
-                  NS_CAN_JOIN_ALL_SPACES | NS_FULL_SCREEN_AUXILIARY)
-    except (OSError, AttributeError, TypeError, ValueError):
-        # A Qt that hands out something other than an NSView, or a macOS that
-        # has stopped answering to these. An indicator that hides too eagerly
-        # is worth less than one that is there; neither is worth a crash.
-        pass
 
 
 class Overlay(QWidget):
@@ -228,10 +171,10 @@ class Overlay(QWidget):
         self._reposition()
         if not self.isVisible():
             self.show()
-            # After show(), which is when there is a native window to speak to,
-            # and only then: winId() before it would build one Qt goes on to
-            # replace.
-            keep_visible_off_screen_focus(self)
+            # After show(), which is when there is a native window to speak
+            # to, and only then: winId() before it would build one Qt goes on
+            # to replace.
+            macos.keep_visible_without_focus(self)
         if self._concealed:
             self.raise_()
             self._concealed = False

--- a/overlay.py
+++ b/overlay.py
@@ -1,6 +1,9 @@
 """The small recording indicator that appears in a screen corner without taking focus."""
 
+import ctypes
+import ctypes.util
 import math
+import sys
 
 from PyQt6.QtCore import Qt, QTimer, QRectF, QPointF
 from PyQt6.QtGui import QColor, QCursor, QFont, QPainter, QPainterPath, QPen, QFontMetrics
@@ -29,6 +32,62 @@ ASK = QColor(150, 140, 255)    # recording a command rather than a dictation
 STATE_COLORS = {"recording": REC, "asking": ASK, "meeting": REC, "busy": BUSY,
                 "done": OK, "warning": WARN, "error": ERR}
 LIVE = ("recording", "asking", "meeting")
+
+# NSWindowCollectionBehavior: on every desktop, and beside a full-screen window
+# rather than being one.
+NS_CAN_JOIN_ALL_SPACES = 1 << 0
+NS_FULL_SCREEN_AUXILIARY = 1 << 8
+_objc = None
+
+
+def _msg_send(receiver, selector, restype=ctypes.c_void_p, argtypes=(), *args):
+    """[receiver selector:args], through the Objective-C runtime.
+
+    objc_msgSend is variadic and ctypes cannot call a variadic function on
+    arm64 without being told the argument types, so each call declares its own.
+    """
+    global _objc
+    if _objc is None:
+        _objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
+        _objc.sel_registerName.restype = ctypes.c_void_p
+        _objc.sel_registerName.argtypes = [ctypes.c_char_p]
+    _objc.objc_msgSend.restype = restype
+    _objc.objc_msgSend.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *argtypes]
+    return _objc.objc_msgSend(receiver, _objc.sel_registerName(selector), *args)
+
+
+def keep_visible_off_screen_focus(widget):
+    """Stop macOS from taking the indicator away whenever Dikte is not in front.
+
+    Given the Tool flag, Qt asks Cocoa for a utility panel, and Cocoa hides a
+    utility panel the moment its application stops being the active one — which
+    is every moment that matters here, the indicator's whole job being to be
+    visible while you are typing in some other window. It stays put instead,
+    and joins whichever desktop you are on rather than the one Dikte started
+    on.
+
+    Nothing to do anywhere else: X11 and Wayland hand a window's visibility to
+    the window manager, not to whether its application has focus.
+
+    The platform is asked for by name, not guessed at from the operating
+    system: winId() is an NSView only under the cocoa plugin, and offscreen —
+    which is what the tests run on — hands back a handle that is not an object
+    at all. Sending it a message would take the process with it.
+    """
+    if sys.platform != "darwin" or QApplication.platformName() != "cocoa":
+        return
+    try:
+        window = _msg_send(ctypes.c_void_p(int(widget.winId())), b"window")
+        if not window:
+            return
+        _msg_send(window, b"setHidesOnDeactivate:", None, [ctypes.c_bool], False)
+        _msg_send(window, b"setCollectionBehavior:", None, [ctypes.c_ulong],
+                  NS_CAN_JOIN_ALL_SPACES | NS_FULL_SCREEN_AUXILIARY)
+    except (OSError, AttributeError, TypeError, ValueError):
+        # A Qt that hands out something other than an NSView, or a macOS that
+        # has stopped answering to these. An indicator that hides too eagerly
+        # is worth less than one that is there; neither is worth a crash.
+        pass
 
 
 class Overlay(QWidget):
@@ -169,6 +228,10 @@ class Overlay(QWidget):
         self._reposition()
         if not self.isVisible():
             self.show()
+            # After show(), which is when there is a native window to speak to,
+            # and only then: winId() before it would build one Qt goes on to
+            # replace.
+            keep_visible_off_screen_focus(self)
         if self._concealed:
             self.raise_()
             self._concealed = False

--- a/overlay.py
+++ b/overlay.py
@@ -164,6 +164,26 @@ class Overlay(QWidget):
     def set_seconds(self, seconds):
         self.seconds = seconds
 
+    def prepare(self):
+        """Put the window on screen empty, before anybody is waiting for it.
+
+        The first show() is the one that costs. macOS brings the application
+        forward to put a new window up — even an accessory one, even a panel
+        that does not accept focus — and the whole point of the indicator is
+        that it appears while you are typing somewhere else. So the first
+        dictation was the one that took the keyboard away, and only the first.
+
+        Every later appearance is a repaint of a window that is already mapped,
+        which is what _conceal() deliberately keeps it as. Doing that first
+        show at startup, with nothing painted in it, costs a moment nobody is
+        in the middle of and leaves the rest to be free of it.
+        """
+        self._resize_to_content()
+        self._reposition()
+        self.show()
+        macos.keep_visible_without_focus(self)
+        self._conceal()
+
     # ---- internals -----------------------------------------------------
 
     def _appear(self):

--- a/paste.py
+++ b/paste.py
@@ -1,31 +1,51 @@
 """Clipboard and key injection, through whichever pair of programs is here.
 
 A Wayland session has wl-clipboard and ydotool, an X11 one has xclip and
-xdotool, and a session is one or the other. Which it is gets decided in one
-place, and each desktop is a small group of functions below it: another desktop,
-or another operating system, adds a group and a line to the chooser rather than
-a branch inside every function here.
+xdotool, and a session is one or the other. macOS has pbcopy and osascript and
+is neither. Which it is gets decided in one place, and each desktop is a small
+group of functions below it: another desktop, or another operating system, adds
+a group and a line to the chooser rather than a branch inside every function
+here.
 """
 
 import collections
 import os
 import shutil
 import subprocess
+import sys
 import time
 
 from i18n import t
 
 # Linux input event codes (linux/input-event-codes.h), which is what ydotool
 # takes. They are also the list of keys a paste shortcut may be built from, so
-# xdotool is held to the same table rather than being handed the text as typed.
+# xdotool and osascript are held to the same table rather than being handed the
+# text as typed. "cmd" is in here because it is the name macOS gives the key
+# Linux calls super, not because ydotool has ever been asked for one.
 KEYCODES = {
-    "ctrl": 29, "control": 29, "shift": 42, "alt": 56, "super": 125, "meta": 125,
+    "ctrl": 29, "control": 29, "shift": 42, "alt": 56, "option": 56,
+    "super": 125, "meta": 125, "cmd": 125, "command": 125,
     "v": 47, "insert": 110, "enter": 28, "return": 28,
 }
 
 # xdotool speaks X keysyms, which spell some of those differently.
-KEYSYMS = {"control": "ctrl", "meta": "super", "insert": "Insert",
+KEYSYMS = {"control": "ctrl", "meta": "super", "cmd": "super", "command": "super",
+           "option": "alt", "insert": "Insert",
            "enter": "Return", "return": "Return"}
+
+# AppleScript names the modifiers in a `using {…}` clause, and the same physical
+# key answers to both names: what Linux calls super is what macOS calls command.
+MODIFIER_PHRASES = {
+    "cmd": "command down", "command": "command down",
+    "super": "command down", "meta": "command down",
+    "ctrl": "control down", "control": "control down",
+    "shift": "shift down", "alt": "option down", "option": "option down",
+}
+
+# The keys AppleScript cannot type as a character, by their virtual key code.
+# There is no insert key on a Mac keyboard; the code is the one macOS maps it to
+# when an external keyboard has one.
+MAC_KEY_CODES = {"enter": 36, "return": 36, "insert": 114}
 
 
 class PasteError(Exception):
@@ -52,6 +72,27 @@ def _xdotool_command(shortcut):
     """xdotool takes the whole combination as one argument."""
     keys = [KEYSYMS.get(key, key) for key in _keys(shortcut)]
     return ["xdotool", "key", "--clearmodifiers", "+".join(keys)]
+
+
+def _osascript_command(shortcut):
+    """AppleScript presses the combination as one keystroke with its modifiers.
+
+    There is no press-and-release pair to build here: `keystroke "v" using
+    {command down}` is the whole event, and the modifiers are what it is held
+    down with rather than keys of their own.
+    """
+    keys = _keys(shortcut)
+    modifiers = [MODIFIER_PHRASES[key] for key in keys if key in MODIFIER_PHRASES]
+    rest = [key for key in keys if key not in MODIFIER_PHRASES]
+    if len(rest) != 1:
+        raise PasteError(t("{shortcut} is not one key and its modifiers.",
+                           shortcut=shortcut))
+    key = rest[0]
+    press = (f"key code {MAC_KEY_CODES[key]}" if key in MAC_KEY_CODES
+             else f'keystroke "{key}"')
+    using = f" using {{{', '.join(modifiers)}}}" if modifiers else ""
+    return ["osascript", "-e",
+            f'tell application "System Events" to {press}{using}']
 
 
 Desktop = collections.namedtuple(
@@ -81,6 +122,20 @@ X11 = Desktop(
     key_hint="",
 )
 
+# Both of these ship with macOS, so `packages` names no package: there is
+# nothing to install, and a missing one means something is wrong with the
+# system rather than with the setup.
+MACOS = Desktop(
+    clipboard="pbcopy",
+    keyboard="osascript",
+    packages="the macOS command line tools",
+    read_command=["pbpaste"],
+    copy_command=["pbcopy"],
+    key_command=_osascript_command,
+    key_hint="Allow the application running Dikte to control your computer, "
+             "under System Settings → Privacy & Security → Accessibility.",
+)
+
 
 def desktop():
     """The pair of programs this session's clipboard and keyboard go through.
@@ -89,6 +144,8 @@ def desktop():
     display server was up would otherwise be stuck with the wrong answer, and a
     test would have nowhere to say which one it means.
     """
+    if sys.platform == "darwin":
+        return MACOS
     if os.environ.get("XDG_SESSION_TYPE") == "x11":
         return X11
     if os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
@@ -125,7 +182,7 @@ def copy(text):
     here = desktop()
     if not shutil.which(here.clipboard):
         raise PasteError(t("{tool} not found. Install {packages}.",
-                           tool=here.clipboard, packages=here.packages))
+                           tool=here.clipboard, packages=t(here.packages)))
     try:
         res = _run_copy(text.encode("utf-8"))
     except (subprocess.SubprocessError, OSError) as exc:

--- a/paste.py
+++ b/paste.py
@@ -258,6 +258,10 @@ def type_out(text, delay=0.12):
 
     time.sleep(delay)
     if here is MACOS:
+        # The indicator took the keyboard off whatever window had it, without
+        # moving anything on screen. Handed back here, or the characters go
+        # out to nobody.
+        macos.give_the_keyboard_back()
         if not macos.type_text(text):
             raise PasteError(t("Could not type the transcript."))
         return
@@ -285,6 +289,7 @@ def press(shortcut="ctrl+v", delay=0.12):
 
     time.sleep(delay)  # let the selection settle and focus come back
     if here is MACOS:
+        macos.give_the_keyboard_back()
         _press_here(shortcut)
     else:
         _press_through_tool(here, shortcut)

--- a/paste.py
+++ b/paste.py
@@ -88,7 +88,8 @@ Desktop = collections.namedtuple(
     "Desktop",
     # The two programs, the packages to install them from, how to build the key
     # press, and what else to say when the key press fails.
-    "clipboard keyboard packages read_command copy_command key_command key_hint",
+    "clipboard keyboard packages read_command copy_command key_command "
+    "type_command key_hint",
 )
 
 WAYLAND = Desktop(
@@ -98,6 +99,9 @@ WAYLAND = Desktop(
     read_command=["wl-paste", "--no-newline"],
     copy_command=["wl-copy"],
     key_command=_ydotool_command,
+    # `--` so that a transcript beginning with a dash is text and not a flag,
+    # and no delay between keys: this is a paragraph, not a demonstration.
+    type_command=["ydotool", "type", "--key-delay", "0", "--"],
     key_hint="Is ydotoold running? (systemctl --user status ydotool)",
 )
 
@@ -108,6 +112,7 @@ X11 = Desktop(
     read_command=["xclip", "-selection", "clipboard", "-out"],
     copy_command=["xclip", "-selection", "clipboard", "-in"],
     key_command=_xdotool_command,
+    type_command=["xdotool", "type", "--clearmodifiers", "--"],
     key_hint="",
 )
 
@@ -123,6 +128,8 @@ MACOS = Desktop(
     read_command=["pbpaste"],
     copy_command=["pbcopy"],
     key_command=_quartz_keys,
+    # Not a program: macos.type_text carries the characters in the event.
+    type_command=[],
     key_hint="Allow the application running Dikte to control your computer, "
              "under System Settings → Privacy & Security → Accessibility.",
 )
@@ -220,6 +227,43 @@ def _press_through_tool(here, shortcut):
     command = here.key_command(shortcut)
     try:
         res = subprocess.run(command, capture_output=True, text=True, timeout=10)
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise PasteError(t("Could not run {tool}: {error}",
+                           tool=here.keyboard, error=exc)) from exc
+    if res.returncode != 0:
+        message = t("{tool} failed: {error}", tool=here.keyboard,
+                    error=res.stderr.strip() or "unknown error")
+        raise PasteError(f"{message}\n{t(here.key_hint)}" if here.key_hint
+                         else message)
+
+
+def type_out(text, delay=0.12):
+    """Put `text` where the keyboard is, without going through the clipboard.
+
+    The other way round from press(): instead of copying and asking the window
+    to paste, the characters are sent as if they had been typed. Nothing
+    anybody had copied is lost, no key combination has to mean paste in the
+    window receiving it, and there is no clipboard left holding a dictation
+    afterwards.
+
+    Slower for a long transcript, which is why it is a setting rather than the
+    way it works.
+    """
+    here = desktop()
+    if not paste_ready():
+        raise PasteError(
+            f"{t('Dikte is not allowed to press keys.')}\n{t(here.key_hint)}"
+            if here is MACOS else
+            t("{tool} not found, cannot paste automatically.", tool=here.keyboard))
+
+    time.sleep(delay)
+    if here is MACOS:
+        if not macos.type_text(text):
+            raise PasteError(t("Could not type the transcript."))
+        return
+    try:
+        res = subprocess.run([*here.type_command, text],
+                             capture_output=True, text=True, timeout=30)
     except (subprocess.SubprocessError, OSError) as exc:
         raise PasteError(t("Could not run {tool}: {error}",
                            tool=here.keyboard, error=exc)) from exc

--- a/paste.py
+++ b/paste.py
@@ -1,11 +1,11 @@
 """Clipboard and key injection, through whichever pair of programs is here.
 
 A Wayland session has wl-clipboard and ydotool, an X11 one has xclip and
-xdotool, and a session is one or the other. macOS has pbcopy and osascript and
-is neither. Which it is gets decided in one place, and each desktop is a small
-group of functions below it: another desktop, or another operating system, adds
-a group and a line to the chooser rather than a branch inside every function
-here.
+xdotool, and a session is one or the other. macOS has pbcopy, and presses the
+key itself rather than asking a program to. Which it is gets decided in one
+place, and each desktop is a small group of functions below it: another
+desktop, or another operating system, adds a group and a line to the chooser
+rather than a branch inside every function here.
 """
 
 import collections
@@ -15,12 +15,14 @@ import subprocess
 import sys
 import time
 
+import hotkey
+import macos
 from i18n import t
 
 # Linux input event codes (linux/input-event-codes.h), which is what ydotool
 # takes. They are also the list of keys a paste shortcut may be built from, so
-# xdotool and osascript are held to the same table rather than being handed the
-# text as typed. "cmd" is in here because it is the name macOS gives the key
+# the other two are held to the same table rather than being handed the text as
+# typed. "cmd" is in here because it is the name macOS gives the key
 # Linux calls super, not because ydotool has ever been asked for one.
 KEYCODES = {
     "ctrl": 29, "control": 29, "shift": 42, "alt": 56, "option": 56,
@@ -32,20 +34,6 @@ KEYCODES = {
 KEYSYMS = {"control": "ctrl", "meta": "super", "cmd": "super", "command": "super",
            "option": "alt", "insert": "Insert",
            "enter": "Return", "return": "Return"}
-
-# AppleScript names the modifiers in a `using {…}` clause, and the same physical
-# key answers to both names: what Linux calls super is what macOS calls command.
-MODIFIER_PHRASES = {
-    "cmd": "command down", "command": "command down",
-    "super": "command down", "meta": "command down",
-    "ctrl": "control down", "control": "control down",
-    "shift": "shift down", "alt": "option down", "option": "option down",
-}
-
-# The keys AppleScript cannot type as a character, by their virtual key code.
-# There is no insert key on a Mac keyboard; the code is the one macOS maps it to
-# when an external keyboard has one.
-MAC_KEY_CODES = {"enter": 36, "return": 36, "insert": 114}
 
 
 class PasteError(Exception):
@@ -74,25 +62,26 @@ def _xdotool_command(shortcut):
     return ["xdotool", "key", "--clearmodifiers", "+".join(keys)]
 
 
-def _osascript_command(shortcut):
-    """AppleScript presses the combination as one keystroke with its modifiers.
+def _quartz_keys(shortcut):
+    """'cmd+v' -> (CGEventFlags, virtual key code).
 
-    There is no press-and-release pair to build here: `keystroke "v" using
-    {command down}` is the whole event, and the modifiers are what it is held
-    down with rather than keys of their own.
+    macOS is the one of the three where the key press is not a program to run:
+    Dikte posts the event itself. Which is not a detail — permission to press a
+    key belongs to whoever posts it, and a helper Dikte shells out to is judged
+    by an application that may not be the one anybody allowed.
     """
     keys = _keys(shortcut)
-    modifiers = [MODIFIER_PHRASES[key] for key in keys if key in MODIFIER_PHRASES]
-    rest = [key for key in keys if key not in MODIFIER_PHRASES]
-    if len(rest) != 1:
+    modifiers = 0
+    rest = []
+    for key in keys:
+        if key in macos.CG_FLAGS:
+            modifiers |= macos.CG_FLAGS[key]
+        else:
+            rest.append(key)
+    if len(rest) != 1 or rest[0] not in hotkey.MAC_KEYS:
         raise PasteError(t("{shortcut} is not one key and its modifiers.",
                            shortcut=shortcut))
-    key = rest[0]
-    press = (f"key code {MAC_KEY_CODES[key]}" if key in MAC_KEY_CODES
-             else f'keystroke "{key}"')
-    using = f" using {{{', '.join(modifiers)}}}" if modifiers else ""
-    return ["osascript", "-e",
-            f'tell application "System Events" to {press}{using}']
+    return modifiers, hotkey.MAC_KEYS[rest[0]]
 
 
 Desktop = collections.namedtuple(
@@ -127,11 +116,13 @@ X11 = Desktop(
 # system rather than with the setup.
 MACOS = Desktop(
     clipboard="pbcopy",
-    keyboard="osascript",
+    # The key press is not a program here: `keyboard` names what does it, which
+    # is Dikte itself, and doctor reports the permission rather than a path.
+    keyboard="Quartz",
     packages="the macOS command line tools",
     read_command=["pbpaste"],
     copy_command=["pbcopy"],
-    key_command=_osascript_command,
+    key_command=_quartz_keys,
     key_hint="Allow the application running Dikte to control your computer, "
              "under System Settings → Privacy & Security → Accessibility.",
 )
@@ -204,18 +195,29 @@ def copy_bytes(data):
 # --- the key press ---------------------------------------------------------
 
 def paste_ready():
+    """Whether a key press would land anywhere.
+
+    Two different questions behind one name. On Linux it is whether the program
+    that presses keys is installed; on macOS the program is the operating
+    system, and what can be missing is permission to use it. Asked here rather
+    than discovered afterwards, because macOS answers a key press it did not
+    allow by saying it went through.
+    """
+    if desktop() is MACOS:
+        return macos.trusted_to_type()
     return shutil.which(desktop().keyboard) is not None
 
 
-def press(shortcut="ctrl+v", delay=0.12):
-    """Press a key combination, e.g. 'ctrl+v'."""
-    here = desktop()
-    if not paste_ready():
-        raise PasteError(t("{tool} not found, cannot paste automatically.",
-                           tool=here.keyboard))
+def _press_here(shortcut):
+    """macOS: post the event as this process, no program in between."""
+    modifiers, key_code = _quartz_keys(shortcut)
+    if not macos.press_keys(modifiers, key_code):
+        raise PasteError(t("Could not press {shortcut}.", shortcut=shortcut))
 
+
+def _press_through_tool(here, shortcut):
+    """Linux: run ydotool or xdotool and hold it to its exit code."""
     command = here.key_command(shortcut)
-    time.sleep(delay)  # let the selection settle and focus come back
     try:
         res = subprocess.run(command, capture_output=True, text=True, timeout=10)
     except (subprocess.SubprocessError, OSError) as exc:
@@ -226,3 +228,19 @@ def press(shortcut="ctrl+v", delay=0.12):
                     error=res.stderr.strip() or "unknown error")
         raise PasteError(f"{message}\n{t(here.key_hint)}" if here.key_hint
                          else message)
+
+
+def press(shortcut="ctrl+v", delay=0.12):
+    """Press a key combination, e.g. 'ctrl+v'."""
+    here = desktop()
+    if not paste_ready():
+        raise PasteError(
+            f"{t('Dikte is not allowed to press keys.')}\n{t(here.key_hint)}"
+            if here is MACOS else
+            t("{tool} not found, cannot paste automatically.", tool=here.keyboard))
+
+    time.sleep(delay)  # let the selection settle and focus come back
+    if here is MACOS:
+        _press_here(shortcut)
+    else:
+        _press_through_tool(here, shortcut)

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -106,11 +106,21 @@ REASONING_LEVELS = [
     ("Low", "low"), ("Medium", "medium"), ("High", "high"),
     ("Very high", "xhigh"), ("Maximum", "max"),
 ]
-PASTE_SHORTCUTS = ["ctrl+v", "ctrl+shift+v", "shift+insert"]
+PASTE_SHORTCUTS = (["cmd+v", "cmd+shift+v"] if cfg.MACOS
+                   else ["ctrl+v", "ctrl+shift+v", "shift+insert"])
 # Offered for every global shortcut, which keeps them one kind of field rather
 # than four. The boxes stay editable: this is a shortlist of combinations that
 # are usually free, not the set of ones that work.
+#
+# The macOS list is a different shortlist rather than the same one relabelled:
+# Ctrl+Space switches the input source there, Cmd+Space is Spotlight, and
+# Cmd+Alt+Space is the Finder search window, so none of the three is free.
 SHORTCUTS = [
+    "Ctrl+Alt+Space", "Ctrl+Shift+Space", "Cmd+Shift+Space",
+    "Ctrl+Alt+A", "Ctrl+Alt+D", "Ctrl+Alt+M", "Ctrl+Alt+Q",
+    "Cmd+Alt+A", "Cmd+Alt+D", "Cmd+Alt+M",
+    "F13", "F14", "F15",
+] if cfg.MACOS else [
     "Ctrl+Space", "Ctrl+Alt+Space", "Ctrl+Shift+Space", "Meta+Space",
     "Ctrl+Alt+A", "Ctrl+Alt+D", "Ctrl+Alt+M", "Ctrl+Alt+Q",
     "Meta+A", "Meta+D", "Meta+M",
@@ -985,6 +995,10 @@ class SettingsWindow(QDialog):
         sources_form.addRow(t("The other participants"), self.meeting_system)
 
         note = QLabel(t(
+            "Recording a meeting needs what comes out of the speakers, and macOS "
+            "hands that to nobody. Everything else on this tab still applies to "
+            "a recording made elsewhere and written up here."
+        ) if cfg.MACOS else t(
             "Wear headphones if you can. Through speakers your microphone hears "
             "the other side as well, and although a line that lands on both "
             "channels at once is dropped again, the repair is never as clean as "
@@ -1232,8 +1246,17 @@ class SettingsWindow(QDialog):
             "combination also reaches the focused application."
         ))
         layout.addWidget(self.evdev_enabled)
+        # There is no waiting for a desktop to pick the shortcut up on macOS,
+        # and so nothing for a listener to cover: the box below would be a
+        # switch for a thing that is already how the shortcuts work.
+        self.evdev_enabled.setVisible(not cfg.MACOS)
 
         note = QLabel(t(
+            "Dikte registers these itself and they work at once, for as long as "
+            "it is running. macOS keeps its own shortcuts to itself: a "
+            "combination one of them already uses is accepted here and then "
+            "never arrives, so pick another one if a key does nothing."
+        ) if cfg.MACOS else t(
             "KWin only reads shortcut settings at startup. After 'Install' the "
             "shortcut shows up under System Settings → Shortcuts, but it will not "
             "fire until you log out and back in. Until then, use the built-in listener."
@@ -1832,15 +1855,34 @@ class SettingsWindow(QDialog):
         if ok:
             self.conf[spec.setting] = combo
             self.conf.save()
+            if cfg.MACOS:
+                # On Linux the desktop now holds the binding and Dikte has
+                # nothing left to do. Here the binding is Dikte's own, so it
+                # has to go and make it: the setting alone changes nothing.
+                self.applied.emit()
         self._refresh_shortcut_status(which)
 
     def _remove_shortcut(self, which):
-        hotkey.remove_shortcut(hotkey.SHORTCUTS[which].desktop_id)
+        spec = hotkey.SHORTCUTS[which]
+        hotkey.remove_shortcut(spec.desktop_id)
+        if cfg.MACOS:
+            # The setting is the registration on macOS, so one goes with the
+            # other; on Linux the desktop entry is what was removed and the
+            # setting stays as the combination to install next time.
+            self.conf[spec.setting] = ""
+            self.conf.save()
+            self.applied.emit()
         self._refresh_shortcut_status(which)
 
     def _refresh_shortcut_status(self, which):
         _box, status, missing = self._shortcut_rows[which]
-        current = hotkey.shortcut_status(hotkey.SHORTCUTS[which].desktop_id)
+        spec = hotkey.SHORTCUTS[which]
+        if cfg.MACOS:
+            combo = self.conf[spec.setting]
+            status.setText(t("Active while Dikte runs: {shortcut}", shortcut=combo)
+                           if combo else missing)
+            return
+        current = hotkey.shortcut_status(spec.desktop_id)
         status.setText(
             t("Registered in {desktop}: {shortcut}",
               desktop=hotkey.desktop_name(), shortcut=current) if current

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -559,15 +559,27 @@ class SettingsWindow(QDialog):
         self.auto_paste = QCheckBox(t("Paste the text into the focused window"))
         form.addRow("", self.auto_paste)
 
+        self.type_out = QCheckBox(t("Type it out instead, leaving the clipboard alone"))
+        self.type_out.setToolTip(t(
+            "The characters are sent as if typed, so whatever you had copied "
+            "stays copied and no paste key has to work in that window. Slower "
+            "on a long transcript."
+        ))
+        form.addRow("", self.type_out)
+        self.type_out.toggled.connect(self._typing_changed)
+        self.auto_paste.toggled.connect(self._typing_changed)
+
         self.paste_shortcut = QComboBox()
         self.paste_shortcut.addItems(PASTE_SHORTCUTS)
         self.paste_shortcut.setToolTip(
             t("Terminals usually want ctrl+shift+v. Change this if pasting does nothing.")
         )
+        self.paste_key_row = self.paste_shortcut
         form.addRow(t("Paste key"), self.paste_shortcut)
 
         self.restore_clipboard = QCheckBox(t("Restore the previous clipboard after pasting"))
         form.addRow("", self.restore_clipboard)
+        self.general_form = form
 
         self.corner = QComboBox()
         for value in CORNERS:
@@ -1397,6 +1409,8 @@ class SettingsWindow(QDialog):
         self._select_data(self.mic, conf["mic_target"])
         self._select_data(self.language, conf["language"])
         self.auto_paste.setChecked(conf["auto_paste"])
+        self.type_out.setChecked(conf["type_instead_of_pasting"])
+        self._typing_changed()
         self.paste_shortcut.setCurrentText(conf["paste_shortcut"])
         self.restore_clipboard.setChecked(conf["restore_clipboard"])
         self._select_data(self.corner, conf["overlay_corner"])
@@ -1490,6 +1504,7 @@ class SettingsWindow(QDialog):
         conf["mic_target"] = self.mic.currentData() or ""
         conf["language"] = self.language.currentData() or "auto"
         conf["auto_paste"] = self.auto_paste.isChecked()
+        conf["type_instead_of_pasting"] = self.type_out.isChecked()
         conf["paste_shortcut"] = self.paste_shortcut.currentText().strip()
         conf["restore_clipboard"] = self.restore_clipboard.isChecked()
         conf["overlay_corner"] = self.corner.currentData() or "bottom-left"
@@ -1888,6 +1903,14 @@ class SettingsWindow(QDialog):
               desktop=hotkey.desktop_name(), shortcut=current) if current
             else missing
         )
+
+    def _typing_changed(self, *_):
+        """Neither the paste key nor putting the clipboard back means anything
+        when the text is typed: it never goes to the clipboard at all."""
+        pasting = self.auto_paste.isChecked() and not self.type_out.isChecked()
+        self.type_out.setEnabled(self.auto_paste.isChecked())
+        self.general_form.setRowVisible(self.paste_key_row, pasting)
+        self.restore_clipboard.setEnabled(pasting)
 
     def _cleanup_provider_changed(self):
         provider = self.cleanup_provider.currentData() or "openrouter"

--- a/tests/support.py
+++ b/tests/support.py
@@ -40,6 +40,14 @@ linux_only = unittest.skipUnless(
     "covers the Linux desktop stack (PipeWire, wl-clipboard, ydotool, KDE)",
 )
 
+# Its twin, and the reason the sentence above says "another desktop" rather
+# than naming one: avfoundation, pbcopy, osascript and Carbon are as
+# unreachable from a Linux machine as ydotool is from here.
+macos_only = unittest.skipUnless(
+    sys.platform == "darwin",
+    "covers the macOS stack (avfoundation, pbcopy, osascript, Carbon)",
+)
+
 
 def _no_network(*args, **kwargs):
     raise AssertionError(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -15,11 +15,14 @@ import unittest
 import wave
 from unittest import mock
 
+import sys
+
 import audio
 from tests.support import (
     DikteTest,
     FakeCompleted,
     linux_only,
+    macos_only,
     only_these_tools,
     pcm,
     silence,
@@ -191,11 +194,129 @@ class Devices(DikteTest):
                              "alsa_output.usb-something.monitor")
 
 
-class FakeProcess:
-    """A pw-record that hands over a fixed buffer and then ends."""
+# What ffmpeg prints when it is asked to list avfoundation's devices: the video
+# ones first, then the audio ones, all of it on stderr behind a prefix, and the
+# whole thing ending in the error that made it print at all.
+AVFOUNDATION_LISTING = """\
+[AVFoundation indev @ 0x14f605010] AVFoundation video devices:
+[AVFoundation indev @ 0x14f605010] [0] FaceTime HD Camera
+[AVFoundation indev @ 0x14f605010] [1] Capture screen 0
+[AVFoundation indev @ 0x14f605010] AVFoundation audio devices:
+[AVFoundation indev @ 0x14f605010] [0] MacBook Pro Microphone
+[AVFoundation indev @ 0x14f605010] [1] Someone's iPhone Microphone
+[in#0 @ 0x14f604e00] Error opening input: Input/output error
+Error opening input file .
+"""
 
-    def __init__(self, data):
-        self.stdout = io.BytesIO(data)
+
+@macos_only
+class MacDevices(DikteTest):
+    """The same list, read out of ffmpeg's complaints instead of pactl's JSON."""
+
+    @contextlib.contextmanager
+    def ffmpeg(self, stderr=AVFOUNDATION_LISTING, tools=("ffmpeg",)):
+        with only_these_tools(*tools), \
+                mock.patch.object(subprocess, "run",
+                                  return_value=FakeCompleted(returncode=1,
+                                                             stderr=stderr)):
+            yield
+
+    def test_no_ffmpeg_installed(self):
+        with only_these_tools():
+            self.assertEqual(audio.list_sources(), [])
+
+    def test_the_audio_devices_are_the_ones_listed(self):
+        """The video half is on the same stderr, under its own heading."""
+        with self.ffmpeg():
+            names = [name for name, _ in audio.list_sources()]
+        self.assertEqual(names, ["MacBook Pro Microphone",
+                                 "Someone's iPhone Microphone"])
+
+    def test_the_name_is_shown_as_well_as_stored(self):
+        """macOS has no second, friendlier name to put beside it."""
+        with self.ffmpeg():
+            self.assertTrue(all(name == shown
+                                for name, shown in audio.list_sources()))
+
+    def test_ffmpeg_saying_something_else_entirely(self):
+        with self.ffmpeg(stderr="ffmpeg: command not understood\n"):
+            self.assertEqual(audio.list_sources(), [])
+
+    def test_ffmpeg_that_will_not_run(self):
+        with only_these_tools("ffmpeg"), \
+                mock.patch.object(subprocess, "run", side_effect=OSError("nope")):
+            self.assertEqual(audio.list_sources(), [])
+
+    def test_there_is_no_speaker_output_to_offer(self):
+        """macOS hands out no loopback device, so a meeting cannot be recorded
+        and the tab says so rather than listing something that will not work."""
+        with self.ffmpeg():
+            self.assertEqual(audio.list_monitors(), [])
+            self.assertEqual(audio.default_monitor(), "")
+
+    def test_a_meeting_says_what_is_missing_rather_than_failing_oddly(self):
+        recorder = audio.MeetingRecorder()
+        failures = []
+        recorder.failed.connect(failures.append)
+        recorder.start(self.path("meeting.wav"))
+        self.assertIn("macOS", failures[0])
+        self.assertFalse(recorder.active)
+
+
+@macos_only
+class MacRecordingCommand(DikteTest):
+    """ffmpeg is the recorder here; there is no sound server to ask."""
+
+    def test_nothing_to_record_with(self):
+        with only_these_tools():
+            self.assertEqual(audio.recording_command(), [])
+
+    def test_what_to_install_names_homebrew(self):
+        self.assertIn("brew install ffmpeg", audio.missing_recorder_message())
+
+    def test_the_format_is_the_one_the_rest_of_the_code_expects(self):
+        with only_these_tools("ffmpeg"):
+            cmd = audio.recording_command()
+        self.assertEqual(cmd[cmd.index("-f") + 1], "avfoundation")
+        self.assertEqual(cmd[cmd.index("-ar") + 1], str(audio.RATE))
+        self.assertEqual(cmd[cmd.index("-ac") + 1], str(audio.CHANNELS))
+        self.assertEqual(cmd[-2:], ["s16le", "-"])
+
+    def test_the_video_half_of_the_input_is_left_empty(self):
+        """avfoundation takes `video:audio`, and asking for a camera as well
+        would open one and record nothing extra worth having."""
+        with only_these_tools("ffmpeg"):
+            cmd = audio.recording_command("Some Microphone")
+        self.assertEqual(cmd[cmd.index("-i") + 1], ":Some Microphone")
+
+
+# The program the recorder shells out to on this platform, which is the one
+# only_these_tools() has to leave standing for recording_command() to find.
+RECORDER = "ffmpeg" if sys.platform == "darwin" else "pw-record"
+
+
+class Trickle(io.BytesIO):
+    """A pipe that hands over less than it was asked for, as ffmpeg's does.
+
+    `read(n)` on an unbuffered pipe returns what has arrived rather than what
+    was wanted, and the amount is nobody's to promise. A recorder that took
+    each piece for a chunk would count a two-second recording as fifteen
+    seconds of level readings.
+    """
+
+    def __init__(self, data, piece=100):
+        super().__init__(data)
+        self.piece = piece
+
+    def read(self, size=-1):
+        return super().read(size if size < 0 else min(size, self.piece))
+
+
+class FakeProcess:
+    """A recorder that hands over a fixed buffer and then ends."""
+
+    def __init__(self, data, stream=None):
+        self.stdout = (stream or io.BytesIO)(data)
         self.stderr = io.BytesIO(b"")
         self.signals = []
         self.returncode = 0
@@ -270,24 +391,24 @@ class RecordingCommand(DikteTest):
                                   if arg.startswith(flag)])
 
 
-@linux_only
 class RecorderChain(DikteTest):
-    """Start to WAV, with pw-record faked out."""
+    """Start to WAV, with the platform's recorder faked out."""
 
-    def record(self, data, target="", max_seconds=300):
+    def record(self, data, target="", max_seconds=300, stream=None):
         recorder = audio.Recorder()
         results = []
         failures = []
         recorder.stopped.connect(lambda *args: results.append(args))
         recorder.failed.connect(failures.append)
-        proc = FakeProcess(data)
-        with only_these_tools("pw-record"), \
+        proc = FakeProcess(data, stream=stream)
+        with only_these_tools(RECORDER), \
                 mock.patch.object(subprocess, "Popen", return_value=proc) as popen:
             recorder.start(target=target, max_seconds=max_seconds)
             recorder._thread.join(timeout=5)
             recorder.stop()
         return recorder, results, failures, popen
 
+    @linux_only
     def test_the_capture_format_is_what_the_rest_of_the_code_expects(self):
         _, _, _, popen = self.record(silence(1.0))
         cmd = popen.call_args.args[0]
@@ -297,14 +418,54 @@ class RecorderChain(DikteTest):
         self.assertIn("--format=s16", cmd)
         self.assertEqual(cmd[-1], "-")
 
+    @linux_only
     def test_no_target_means_no_target_flag(self):
         _, _, _, popen = self.record(silence(0.5))
         self.assertFalse([arg for arg in popen.call_args.args[0]
                           if arg.startswith("--target=")])
 
+    @linux_only
     def test_a_chosen_microphone_is_passed_on(self):
         _, _, _, popen = self.record(silence(0.5), target="alsa_input.usb")
         self.assertIn("--target=alsa_input.usb", popen.call_args.args[0])
+
+    @macos_only
+    def test_the_capture_format_ffmpeg_is_asked_for(self):
+        _, _, _, popen = self.record(silence(1.0))
+        cmd = popen.call_args.args[0]
+        self.assertEqual(cmd[0], "ffmpeg")
+        self.assertIn("avfoundation", cmd)
+        self.assertEqual(cmd[cmd.index("-ar") + 1], str(audio.RATE))
+        self.assertEqual(cmd[cmd.index("-ac") + 1], str(audio.CHANNELS))
+        self.assertIn("s16le", cmd)
+        self.assertEqual(cmd[-1], "-")
+
+    @macos_only
+    def test_no_microphone_named_means_the_system_default(self):
+        _, _, _, popen = self.record(silence(0.5))
+        cmd = popen.call_args.args[0]
+        self.assertEqual(cmd[cmd.index("-i") + 1], ":default")
+
+    @macos_only
+    def test_a_chosen_microphone_goes_in_by_name(self):
+        """Its name and not its index: indexes move when a device is plugged
+        in, and a setting that means a different microphone tomorrow is worse
+        than one that stops matching anything."""
+        _, _, _, popen = self.record(silence(0.5), target="MacBook Pro Microphone")
+        cmd = popen.call_args.args[0]
+        self.assertEqual(cmd[cmd.index("-i") + 1], ":MacBook Pro Microphone")
+
+    def test_a_pipe_that_hands_over_pieces_still_reads_in_chunks(self):
+        """One RMS reading per chunk of a known length, however the bytes
+        arrive: vad.analyse() multiplies the count by that length, so a piece
+        counted as a chunk is a silent recording reported as speech."""
+        _, results, failures, _ = self.record(tone(1.0), stream=Trickle)
+        self.assertEqual(failures, [])
+        _path, duration, rms = results[0]
+        self.addCleanup(os.unlink, results[0][0])
+        self.assertAlmostEqual(duration, 1.0, places=2)
+        # A second is fifteen whole chunks and the beginning of a sixteenth.
+        self.assertEqual(len(rms), -(-audio.RATE // audio.CHUNK_FRAMES))
 
     def test_a_recording_ends_as_a_wav_with_its_duration_and_levels(self):
         _, results, failures, _ = self.record(tone(1.0))
@@ -327,7 +488,7 @@ class RecorderChain(DikteTest):
         results = []
         recorder.stopped.connect(lambda *args: results.append(args))
         proc = FakeProcess(tone(1.0))
-        with only_these_tools("pw-record"), \
+        with only_these_tools(RECORDER), \
                 mock.patch.object(subprocess, "Popen", return_value=proc):
             recorder.start()
             recorder._thread.join(timeout=5)
@@ -342,13 +503,16 @@ class RecorderChain(DikteTest):
         self.assertLessEqual(duration, 1.1)
 
     def test_a_recorder_that_is_not_installed_at_all(self):
+        """Said once, and it names what to install on the platform it is said
+        on: a Mac told to install pulseaudio-utils is being sent nowhere."""
         recorder = audio.Recorder()
         failures = []
         recorder.failed.connect(failures.append)
         with only_these_tools():
             recorder.start()
         self.assertEqual(len(failures), 1)
-        self.assertIn("pulseaudio-utils", failures[0])
+        self.assertIn("ffmpeg" if sys.platform == "darwin" else "pulseaudio-utils",
+                      failures[0])
 
     def pump(self, data=b"", stderr=b"", stopping=False, cancelled=False):
         """Run the pump in this thread, where a queued signal would need an
@@ -397,7 +561,7 @@ class RecorderChain(DikteTest):
         recorder = audio.Recorder()
         failures = []
         recorder.failed.connect(failures.append)
-        with only_these_tools("pw-record"), \
+        with only_these_tools(RECORDER), \
                 mock.patch.object(subprocess, "Popen", side_effect=OSError("nope")):
             recorder.start()
         self.assertEqual(len(failures), 1)

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -20,7 +20,7 @@ from unittest import mock
 import ggml
 import hub
 from tests.support import (DikteTest, fake_urlopen, http_error, json_body,
-                           linux_only, url_error)
+                           linux_only, macos_only, url_error)
 
 
 def body(data, length=None):
@@ -176,6 +176,12 @@ class Download(Local):
 class InstallProgram(Local):
     def setUp(self):
         super().setUp()
+        # Which asset gets picked is settled in WhichBuild below; everything
+        # here is about what happens to one once it has been picked, so the
+        # choice is pinned rather than left to follow whichever platform the
+        # tests are running on.
+        self.patch_attr(ggml, "_wanted_assets",
+                        lambda program: ("bin-ubuntu-x64.tar.gz",))
         # Built once, because the release listing has to publish its checksum
         # and a tarball is not the same bytes twice.
         self.archive = tarball({
@@ -210,10 +216,13 @@ class InstallProgram(Local):
         self.assertTrue(urls[1].endswith("whisper-bin-ubuntu-x64.tar.gz"))
 
     def test_a_release_with_nothing_for_this_machine_says_so(self):
+        # llama.cpp rather than whisper.cpp: a whisper release with nothing in
+        # it for this machine is the everyday state of affairs on macOS, and it
+        # is answered there by pointing at Homebrew instead.
         self.patch_attr(ggml, "_arch", lambda: "x64")
-        with fake_urlopen(self.release("whisper-bin-Win32.zip")):
+        with fake_urlopen(self.release("llama-bin-win-cuda-x64.zip")):
             with self.assertRaises(ggml.LocalError) as caught:
-                ggml.install_program(ggml.WHISPER)
+                ggml.install_program(ggml.LLAMA)
         self.assertIn("this machine", str(caught.exception))
 
     def test_what_was_installed_is_remembered(self):
@@ -294,16 +303,52 @@ class InstallProgram(Local):
             with self.subTest(url=url):
                 self.assertTrue(url.startswith("https://"))
 
-    def test_llama_takes_the_vulkan_build_when_there_is_a_loader(self):
+
+class WhichBuild(Local):
+    """Which of a release's assets this machine is owed.
+
+    Split out from the class above because it is the one thing there that has
+    to see the real platform: ggml-org publishes a different set of builds for
+    each, and picking the wrong one is a download that unpacks into a binary
+    the machine cannot run.
+    """
+
+    def setUp(self):
+        super().setUp()
         self.patch_attr(ggml, "_arch", lambda: "x64")
+
+    @linux_only
+    def test_llama_takes_the_vulkan_build_when_there_is_a_loader(self):
         self.patch_attr(ggml, "_has_vulkan", lambda: True)
         self.assertEqual(ggml._wanted_assets(ggml.LLAMA)[0],
                          "bin-ubuntu-vulkan-x64.tar.gz")
 
+    @linux_only
     def test_llama_falls_back_to_the_plain_build_without_one(self):
-        self.patch_attr(ggml, "_arch", lambda: "x64")
         self.patch_attr(ggml, "_has_vulkan", lambda: False)
         self.assertEqual(ggml._wanted_assets(ggml.LLAMA), ("bin-ubuntu-x64.tar.gz",))
+
+    @macos_only
+    def test_the_macos_build_is_the_only_one_offered_there(self):
+        """One build, and it already reaches the graphics card through Metal,
+        so there is no second choice to fall back to."""
+        self.assertEqual(ggml._wanted_assets(ggml.LLAMA), ("bin-macos-x64.tar.gz",))
+
+    @macos_only
+    def test_whisper_has_nothing_to_fetch_on_a_mac(self):
+        """whisper.cpp publishes no macOS build at all; Homebrew's is what runs
+        here, and program_path() prefers a system copy anyway."""
+        self.assertEqual(ggml._wanted_assets(ggml.WHISPER), ())
+
+    @macos_only
+    def test_asking_for_it_anyway_says_where_to_get_it(self):
+        listing = {"tag_name": "v1.9.1", "assets": [
+            {"name": "whisper-bin-ubuntu-x64.tar.gz", "size": 10,
+             "browser_download_url": "https://example.invalid/w.tar.gz"}]}
+        with serving(listing, b""):
+            with self.assertRaises(ggml.LocalError) as caught:
+                ggml.install_program(ggml.WHISPER)
+        self.assertIn("brew install whisper-cpp", str(caught.exception))
 
 
 class WhichCopyRuns(Local):

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import config as cfg
 import hotkey
-from tests.support import DikteTest, FakeCompleted, linux_only
+from tests.support import DikteTest, FakeCompleted, linux_only, macos_only
 
 SHORTCUTS_RC = """[services][dikte-toggle.desktop]
 _launch=Ctrl+Space
@@ -74,9 +74,18 @@ class Table(unittest.TestCase):
     def test_only_the_toggle_falls_back_to_a_key_of_its_own(self):
         """The rest are off until you pick one, and emptying the box is how you
         turn them off again."""
-        self.assertEqual(hotkey.SHORTCUTS["toggle"].fallback, "Ctrl+Space")
+        self.assertEqual(hotkey.SHORTCUTS["toggle"].fallback,
+                         cfg.DEFAULTS["shortcut"])
         self.assertEqual([name for name, spec in hotkey.SHORTCUTS.items()
                           if spec.fallback], ["toggle"])
+
+    def test_the_fallback_is_a_key_this_platform_can_actually_bind(self):
+        """Two lists of key names, and a fallback missing from the one in use
+        is a first run with no working shortcut at all."""
+        for name, spec in hotkey.SHORTCUTS.items():
+            if spec.fallback:
+                with self.subTest(name=name):
+                    self.assertTrue(hotkey.understands(spec.fallback))
 
 
 class ModsMatch(unittest.TestCase):
@@ -445,6 +454,222 @@ class KdeShortcut(DikteTest):
 
     def test_no_shortcuts_file_means_no_conflicts(self):
         self.assertEqual(hotkey.conflicting_shortcuts("Ctrl+Space"), [])
+
+
+@macos_only
+class ParseMacShortcut(unittest.TestCase):
+    """Combination to (Carbon modifier mask, virtual key code).
+
+    A second table because the numbers are macOS's own and the key names are
+    not quite the same list: there is no Insert on a Mac keyboard, and F13 to
+    F19 exist there and not in the evdev table.
+    """
+
+    def test_the_default(self):
+        # controlKey | optionKey, and kVK_Space.
+        self.assertEqual(hotkey.parse_mac_shortcut("Ctrl+Alt+Space"),
+                         (0x1000 | 0x0800, 0x31))
+
+    def test_case_and_spacing_do_not_matter(self):
+        self.assertEqual(hotkey.parse_mac_shortcut(" ctrl + ALT + space "),
+                         hotkey.parse_mac_shortcut("Ctrl+Alt+Space"))
+
+    def test_command_answers_to_the_names_the_other_platform_uses(self):
+        """A settings file carried over from Linux says Meta or Super."""
+        for name in ("Command", "Meta", "Super"):
+            with self.subTest(name=name):
+                self.assertEqual(hotkey.parse_mac_shortcut(f"{name}+A"),
+                                 hotkey.parse_mac_shortcut("Cmd+A"))
+
+    def test_option_is_the_key_linux_calls_alt(self):
+        self.assertEqual(hotkey.parse_mac_shortcut("Option+A"),
+                         hotkey.parse_mac_shortcut("Alt+A"))
+
+    def test_a_key_on_its_own(self):
+        self.assertEqual(hotkey.parse_mac_shortcut("F13"), (0, 0x69))
+
+    def test_modifiers_with_no_key(self):
+        self.assertEqual(hotkey.parse_mac_shortcut("Ctrl+Alt"), (None, None))
+
+    def test_two_keys_and_no_room_for_the_second(self):
+        self.assertEqual(hotkey.parse_mac_shortcut("Ctrl+A+B"), (None, None))
+
+    def test_a_key_nobody_mapped(self):
+        self.assertEqual(hotkey.parse_mac_shortcut("Ctrl+PrintScreen"),
+                         (None, None))
+
+    def test_nothing(self):
+        self.assertEqual(hotkey.parse_mac_shortcut(""), (None, None))
+        self.assertEqual(hotkey.parse_mac_shortcut("+++"), (None, None))
+        self.assertEqual(hotkey.parse_mac_shortcut(None), (None, None))
+
+    def test_understands_reads_the_table_this_platform_uses(self):
+        """F13 to F19 are on the macOS table and not on the evdev one, and they
+        are worth having: nothing on a Mac claims them."""
+        self.assertTrue(hotkey.understands("F13"))
+        self.assertEqual(hotkey.parse_shortcut("F13"), (None, None))
+        self.assertFalse(hotkey.understands("Ctrl+PrintScreen"))
+
+
+@macos_only
+class MacChooser(DikteTest):
+    """What the four platform-facing functions answer on macOS.
+
+    Nothing is written to disk here, which is the whole difference: a shortcut
+    lives for as long as the process that registered it, so `install` is a
+    check that it could be, `status` has nothing to report, and `remove` has
+    nothing to take away.
+    """
+
+    def test_it_knows_where_it_is(self):
+        self.assertEqual(hotkey.desktop_name(), "macOS")
+
+    def test_installing_accepts_a_combination_it_can_bind(self):
+        ok, message = hotkey.install_shortcut("Ctrl+Alt+Space", "dikte toggle")
+        self.assertTrue(ok)
+        self.assertIn("Ctrl+Alt+Space", message)
+
+    def test_installing_refuses_one_it_cannot(self):
+        ok, _ = hotkey.install_shortcut("Ctrl+PrintScreen", "dikte toggle")
+        self.assertFalse(ok)
+
+    def test_nothing_was_written_anywhere(self):
+        hotkey.install_shortcut("Ctrl+Alt+Space", "dikte toggle")
+        self.assertFalse((hotkey.APPLICATIONS_DIR / hotkey.DESKTOP_ID).exists())
+
+    def test_there_is_no_registration_to_report(self):
+        self.assertIsNone(hotkey.shortcut_status())
+
+    def test_removing_one_is_not_an_error(self):
+        hotkey.remove_shortcut()
+
+    def test_macos_will_not_say_what_else_holds_a_key(self):
+        """Its own shortcuts are a binary plist of numbers with no names in it;
+        a clash shows up as a press that never arrives."""
+        self.assertEqual(hotkey.conflicting_shortcuts("Ctrl+Alt+Space"), [])
+
+
+@macos_only
+class CarbonBindings(DikteTest):
+    """Registering and unregistering, with Carbon itself faked out.
+
+    The real thing is exercised by pressing the key, which no test can do; what
+    is held here is that each combination reaches RegisterEventHotKey once, as
+    the numbers macOS expects, and that every one of them is handed back.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.registered = []      # (key code, modifiers, id)
+        self.unregistered = []
+        self.carbon = mock.Mock()
+        self.carbon.GetApplicationEventTarget.return_value = 1
+        self.carbon.InstallEventHandler.return_value = 0
+        self.carbon.RemoveEventHandler.return_value = 0
+
+        def register(key, modifiers, hotkey_id, _target, _options, out_ref):
+            self.registered.append((key, modifiers, hotkey_id.id))
+            out_ref._obj.value = 1000 + len(self.registered)
+            return 0
+
+        self.carbon.RegisterEventHotKey.side_effect = register
+        self.carbon.UnregisterEventHotKey.side_effect = \
+            lambda ref: self.unregistered.append(ref) or 0
+        self.patch_attr(hotkey, "_carbon", self.carbon)
+        self.patch_attr(hotkey, "_load_carbon", lambda: self.carbon)
+
+    def start(self, **bindings):
+        listener = hotkey.CarbonHotkey()
+        self.failures = []
+        listener.failed.connect(self.failures.append)
+        self.addCleanup(listener.stop)
+        return listener, listener.start(bindings)
+
+    def test_each_combination_is_registered_once(self):
+        listener, ok = self.start(toggle="Ctrl+Alt+Space", cancel="Ctrl+Alt+D")
+        self.assertTrue(ok)
+        self.assertTrue(listener.running)
+        self.assertEqual([(key, mods) for key, mods, _ in self.registered],
+                         [(0x31, 0x1800), (0x02, 0x1800)])
+
+    def test_an_empty_combination_is_a_shortcut_turned_off(self):
+        _listener, ok = self.start(toggle="Ctrl+Alt+Space", meeting="")
+        self.assertTrue(ok)
+        self.assertEqual(len(self.registered), 1)
+
+    def test_nothing_bound_at_all_installs_no_handler(self):
+        listener, ok = self.start(toggle="", cancel="")
+        self.assertFalse(ok)
+        self.assertFalse(listener.running)
+        self.carbon.InstallEventHandler.assert_not_called()
+
+    def test_a_combination_that_cannot_be_parsed_is_said_and_skipped(self):
+        _listener, ok = self.start(toggle="Ctrl+Alt+Space", cancel="Ctrl+Nonsense")
+        self.assertTrue(ok)
+        self.assertEqual(len(self.registered), 1)
+        self.assertIn("Ctrl+Nonsense", self.failures[0])
+
+    def test_one_macos_refuses_is_reported_and_the_rest_go_on(self):
+        def refuse_the_second(key, modifiers, hotkey_id, target, options, out_ref):
+            if hotkey_id.id == 2:
+                return -9878        # eventHotKeyExistsErr
+            self.registered.append((key, modifiers, hotkey_id.id))
+            out_ref._obj.value = 1000
+            return 0
+
+        self.carbon.RegisterEventHotKey.side_effect = refuse_the_second
+        listener, ok = self.start(toggle="Ctrl+Alt+Space", cancel="Ctrl+Alt+D",
+                                  ask="Ctrl+Alt+A")
+        self.assertTrue(ok)
+        self.assertTrue(listener.running)
+        self.assertEqual(len(self.registered), 2)
+        self.assertEqual(len(self.failures), 1)
+
+    def test_stopping_hands_every_key_back(self):
+        listener, _ = self.start(toggle="Ctrl+Alt+Space", cancel="Ctrl+Alt+D")
+        listener.stop()
+        self.assertEqual(len(self.unregistered), 2)
+        self.assertFalse(listener.running)
+        self.carbon.RemoveEventHandler.assert_called_once()
+
+    def test_starting_again_does_not_stack_a_second_set(self):
+        """The settings window saves, and the shortcuts are registered afresh."""
+        listener, _ = self.start(toggle="Ctrl+Alt+Space")
+        listener.start({"toggle": "Ctrl+Alt+D"})
+        self.assertEqual(len(self.unregistered), 1)
+        self.assertEqual(len(self.registered), 2)
+
+    def test_a_press_arrives_under_the_name_it_was_bound_to(self):
+        listener, _ = self.start(toggle="Ctrl+Alt+Space", cancel="Ctrl+Alt+D")
+        fired = []
+        listener.triggered.connect(fired.append)
+
+        def read_id(_event, _name, _type, _actual, _size, _actual_size, out):
+            out._obj.id = 2         # the second one registered: cancel
+            return 0
+
+        self.carbon.GetEventParameter.side_effect = read_id
+        listener._on_event(None, None, None)
+        self.assertEqual(fired, ["cancel"])
+
+    def test_a_press_for_a_key_that_is_no_longer_ours_is_ignored(self):
+        listener, _ = self.start(toggle="Ctrl+Alt+Space")
+        fired = []
+        listener.triggered.connect(fired.append)
+        self.carbon.GetEventParameter.side_effect = None
+        self.carbon.GetEventParameter.return_value = 0
+        listener._on_event(None, None, None)
+        self.assertEqual(fired, [])
+
+    def test_carbon_missing_is_said_rather_than_raised(self):
+        """An exception here would come up through the tray icon's constructor."""
+        def missing():
+            raise OSError("Carbon framework not found")
+
+        self.patch_attr(hotkey, "_load_carbon", missing)
+        _listener, ok = self.start(toggle="Ctrl+Alt+Space")
+        self.assertFalse(ok)
+        self.assertIn("Carbon", self.failures[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -15,6 +15,7 @@ import unittest
 from typing import ClassVar
 from unittest import mock
 
+import hotkey
 import paste
 from tests.support import (DikteTest, FakeCompleted, linux_only, macos_only,
                            only_these_tools)
@@ -48,8 +49,8 @@ class Chooser(DikteTest):
         self.assertIs(self.under(), paste.WAYLAND)
 
 
-class DesktopContract:
-    """What both desktops owe. Each of them subclasses this once, below."""
+class ClipboardContract:
+    """What all three owe for the clipboard. Each subclasses it once, below."""
 
     env: ClassVar[dict] = {}
     here = None
@@ -139,7 +140,13 @@ class DesktopContract:
             paste.copy_bytes(b"\x89PNG\r\n")
         self.assertEqual(run.call_args.kwargs["input"], b"\x89PNG\r\n")
 
-    # ---- pressing the key -------------------------------------------------
+
+class KeyToolContract(ClipboardContract):
+    """What a desktop that presses keys by running a program owes on top.
+
+    macOS is not one of them: it posts the event itself, because permission to
+    press a key belongs to whoever posts it. Its half of this is below.
+    """
 
     def press(self, shortcut, result=None):
         with only_these_tools(self.here.keyboard), \
@@ -183,7 +190,7 @@ class DesktopContract:
 
 
 @linux_only
-class Wayland(DesktopContract, DikteTest):
+class Wayland(KeyToolContract, DikteTest):
     env: ClassVar[dict] = {"XDG_SESSION_TYPE": "wayland",
                            "WAYLAND_DISPLAY": "wayland-0"}
     here = paste.WAYLAND
@@ -210,7 +217,7 @@ class Wayland(DesktopContract, DikteTest):
 
 
 @linux_only
-class X11(DesktopContract, DikteTest):
+class X11(KeyToolContract, DikteTest):
     env: ClassVar[dict] = {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"}
     here = paste.X11
 
@@ -234,15 +241,26 @@ class X11(DesktopContract, DikteTest):
 
 
 @macos_only
-class MacOS(DesktopContract, DikteTest):
-    """The third group, and it owes the same list as the other two.
+class MacOS(ClipboardContract, DikteTest):
+    """The third group. The clipboard half is the same promise as the other two;
+    the key press is not a program at all.
 
-    What it does differently is press the key: AppleScript has no press and
-    release to spell out, only a keystroke and the modifiers it is held down
-    with, so the command is one string rather than a sequence of codes.
+    Dikte posts the event itself, because macOS gives permission to press a key
+    to whoever posts it — a helper it shelled out to would be judged by an
+    application nobody has allowed, and, worse, told to press a key it may not,
+    macOS answers that it did. So the check happens before the press.
     """
 
     here = paste.MACOS
+
+    def setUp(self):
+        super().setUp()
+        self.pressed = []
+        self.trusted = True
+        self.patch_attr(paste.macos, "trusted_to_type", lambda: self.trusted)
+        self.patch_attr(paste.macos, "press_keys",
+                        lambda mods, key: self.pressed.append((mods, key)) or True)
+        self.patch_attr(paste.time, "sleep", lambda seconds: None)
 
     def test_the_session_variables_change_nothing_here(self):
         """A Mac has no XDG_SESSION_TYPE, and something that set one anyway
@@ -251,35 +269,61 @@ class MacOS(DesktopContract, DikteTest):
                                           "DISPLAY": ":0"}, clear=True):
             self.assertIs(paste.desktop(), paste.MACOS)
 
-    def test_the_modifiers_are_held_down_around_one_keystroke(self):
-        self.assertEqual(
-            self.press("cmd+v"),
-            ["osascript", "-e", 'tell application "System Events" to '
-                                'keystroke "v" using {command down}'])
+    # ---- the combination, as Quartz counts it ----------------------------
 
-    def test_three_keys(self):
-        self.assertIn("using {command down, shift down}", self.press("cmd+shift+v")[-1])
+    def test_a_modifier_and_a_key(self):
+        self.assertEqual(paste.MACOS.key_command("cmd+v"),
+                         (paste.macos.CG_FLAGS["cmd"], hotkey.MAC_KEYS["v"]))
+
+    def test_two_modifiers_are_one_mask(self):
+        mods, key = paste.MACOS.key_command("cmd+shift+v")
+        self.assertEqual(mods, paste.macos.CG_FLAGS["cmd"]
+                         | paste.macos.CG_FLAGS["shift"])
+        self.assertEqual(key, hotkey.MAC_KEYS["v"])
 
     def test_command_is_the_key_linux_calls_super(self):
-        self.assertEqual(self.press("cmd+v"), self.press("super+v"))
-        self.assertEqual(self.press("command+v"), self.press("meta+v"))
+        for name in ("command", "meta", "super"):
+            with self.subTest(name=name):
+                self.assertEqual(paste.MACOS.key_command(f"{name}+v"),
+                                 paste.MACOS.key_command("cmd+v"))
 
-    def test_a_key_that_cannot_be_typed_goes_in_by_its_code(self):
-        """AppleScript types characters; Return is not one, so it is pressed."""
-        self.assertIn("key code 36 using {command down}", self.press("cmd+return")[-1])
+    def test_case_and_spacing_do_not_matter_for_the_combination(self):
+        self.assertEqual(paste.MACOS.key_command(" CMD + V "),
+                         paste.MACOS.key_command("cmd+v"))
 
     def test_a_combination_with_no_key_in_it_is_refused(self):
         with self.assertRaises(paste.PasteError) as caught:
             paste.MACOS.key_command("cmd+shift")
         self.assertIn("cmd+shift", str(caught.exception))
 
-    def test_a_failure_points_at_the_permission_it_needs(self):
-        """osascript is always installed, so a failure is never a missing
-        program: it is macOS refusing to let it type."""
+    # ---- pressing it -----------------------------------------------------
+
+    def test_the_event_is_posted_once_with_the_right_numbers(self):
+        paste.press("cmd+v")
+        self.assertEqual(self.pressed, [(paste.macos.CG_FLAGS["cmd"],
+                                         hotkey.MAC_KEYS["v"])])
+
+    def test_without_permission_nothing_is_pressed_and_it_says_why(self):
+        """The failure macOS will not report: told to press a key it has not
+        allowed, it says the key went through. Asked first instead."""
+        self.trusted = False
+        self.assertFalse(paste.paste_ready())
         with self.assertRaises(paste.PasteError) as caught:
-            self.press("cmd+v", FakeCompleted(
-                returncode=1, stderr="osascript is not allowed to send keystrokes"))
+            paste.press("cmd+v")
+        self.assertEqual(self.pressed, [])
         self.assertIn("Accessibility", str(caught.exception))
+
+    def test_a_post_that_fails_is_an_error_rather_than_a_shrug(self):
+        self.patch_attr(paste.macos, "press_keys", lambda mods, key: False)
+        with self.assertRaises(paste.PasteError):
+            paste.press("cmd+v")
+
+    def test_no_program_is_run_to_press_a_key(self):
+        """The point of the whole group: no second process, and so no second
+        application for macOS to judge the permission by."""
+        with mock.patch.object(subprocess, "run") as run:
+            paste.press("cmd+v")
+        run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_paste.py
+++ b/tests/test_paste.py
@@ -16,7 +16,8 @@ from typing import ClassVar
 from unittest import mock
 
 import paste
-from tests.support import DikteTest, FakeCompleted, linux_only, only_these_tools
+from tests.support import (DikteTest, FakeCompleted, linux_only, macos_only,
+                           only_these_tools)
 
 
 @linux_only
@@ -230,6 +231,55 @@ class X11(DesktopContract, DikteTest):
         with self.assertRaises(paste.PasteError) as caught:
             self.press("ctrl+v", FakeCompleted(returncode=1, stderr="bad keysym"))
         self.assertNotIn("ydotoold", str(caught.exception))
+
+
+@macos_only
+class MacOS(DesktopContract, DikteTest):
+    """The third group, and it owes the same list as the other two.
+
+    What it does differently is press the key: AppleScript has no press and
+    release to spell out, only a keystroke and the modifiers it is held down
+    with, so the command is one string rather than a sequence of codes.
+    """
+
+    here = paste.MACOS
+
+    def test_the_session_variables_change_nothing_here(self):
+        """A Mac has no XDG_SESSION_TYPE, and something that set one anyway
+        would otherwise send the clipboard to a wl-copy that is not there."""
+        with mock.patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11",
+                                          "DISPLAY": ":0"}, clear=True):
+            self.assertIs(paste.desktop(), paste.MACOS)
+
+    def test_the_modifiers_are_held_down_around_one_keystroke(self):
+        self.assertEqual(
+            self.press("cmd+v"),
+            ["osascript", "-e", 'tell application "System Events" to '
+                                'keystroke "v" using {command down}'])
+
+    def test_three_keys(self):
+        self.assertIn("using {command down, shift down}", self.press("cmd+shift+v")[-1])
+
+    def test_command_is_the_key_linux_calls_super(self):
+        self.assertEqual(self.press("cmd+v"), self.press("super+v"))
+        self.assertEqual(self.press("command+v"), self.press("meta+v"))
+
+    def test_a_key_that_cannot_be_typed_goes_in_by_its_code(self):
+        """AppleScript types characters; Return is not one, so it is pressed."""
+        self.assertIn("key code 36 using {command down}", self.press("cmd+return")[-1])
+
+    def test_a_combination_with_no_key_in_it_is_refused(self):
+        with self.assertRaises(paste.PasteError) as caught:
+            paste.MACOS.key_command("cmd+shift")
+        self.assertIn("cmd+shift", str(caught.exception))
+
+    def test_a_failure_points_at_the_permission_it_needs(self):
+        """osascript is always installed, so a failure is never a missing
+        program: it is macOS refusing to let it type."""
+        with self.assertRaises(paste.PasteError) as caught:
+            self.press("cmd+v", FakeCompleted(
+                returncode=1, stderr="osascript is not allowed to send keystrokes"))
+        self.assertIn("Accessibility", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -29,7 +29,9 @@ CHANGED = {
     "ui_language": "tr",
     "language": "tr",
     "auto_paste": False,
-    "paste_shortcut": "ctrl+shift+v",
+    # The paste box is the one shortcut field that is not editable, so the
+    # value has to be on the platform's own list to survive being loaded.
+    "paste_shortcut": "cmd+shift+v" if cfg.MACOS else "ctrl+shift+v",
     "restore_clipboard": True,
     "overlay_corner": "top-right",
     "max_seconds": 120,
@@ -177,7 +179,7 @@ class Settings(DikteTest):
         for box, _status, _missing in window._shortcut_rows.values():
             box.setCurrentText("")
         window._save()
-        self.assertEqual(conf["shortcut"], "Ctrl+Space")
+        self.assertEqual(conf["shortcut"], hotkey.SHORTCUTS["toggle"].fallback)
         self.assertEqual(conf["cancel_shortcut"], "")
         self.assertEqual(conf["assistant_shortcut"], "")
         self.assertEqual(conf["meeting_shortcut"], "")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -320,6 +320,14 @@ class Overlay(DikteTest):
         self.assertTrue(flags & Qt.WindowType.WindowDoesNotAcceptFocus)
         self.assertTrue(flags & Qt.WindowType.WindowStaysOnTopHint)
 
+    def test_the_cocoa_call_is_skipped_on_a_platform_that_is_not_cocoa(self):
+        """winId() is an NSView under the cocoa plugin and a handle that is not
+        an object anywhere else; sending that a message takes the process with
+        it, which a test discovers as a run that stops mid-line."""
+        widget = self.overlay()
+        widget.show_recording()
+        overlay_module.keep_visible_off_screen_focus(widget)   # must be a no-op
+
     def test_recording_then_working_then_done(self):
         widget = self.overlay()
         widget.show_recording()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import QApplication, QMessageBox
 import cleanup
 import config as cfg
 import hotkey
+import macos
 import overlay as overlay_module
 import settings_ui
 from tests.support import DikteTest, only_these_tools
@@ -320,13 +321,18 @@ class Overlay(DikteTest):
         self.assertTrue(flags & Qt.WindowType.WindowDoesNotAcceptFocus)
         self.assertTrue(flags & Qt.WindowType.WindowStaysOnTopHint)
 
-    def test_the_cocoa_call_is_skipped_on_a_platform_that_is_not_cocoa(self):
+    def test_the_cocoa_calls_are_skipped_on_a_platform_that_is_not_cocoa(self):
         """winId() is an NSView under the cocoa plugin and a handle that is not
         an object anywhere else; sending that a message takes the process with
-        it, which a test discovers as a run that stops mid-line."""
+        it, which a test discovers as a run that stops mid-line rather than as
+        a failure. Every call in macos.py is guarded by the same check, so they
+        are all run here."""
         widget = self.overlay()
         widget.show_recording()
-        overlay_module.keep_visible_off_screen_focus(widget)   # must be a no-op
+        self.assertFalse(macos.available())
+        self.assertFalse(macos.keep_visible_without_focus(widget))
+        self.assertFalse(macos.live_in_the_menu_bar())
+        self.assertFalse(macos.come_to_the_front())
 
     def test_recording_then_working_then_done(self):
         widget = self.overlay()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,13 +5,34 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PY="$(command -v python3 || true)"
 USER_NAME="$(id -un)"
 BIN_DIR="$HOME/.local/bin"
 APP_DIR="$HOME/.local/share/applications"
 AUTOSTART_DIR="$HOME/.config/autostart"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/dikte"
 DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/dikte"
+
+MACOS=0
+[[ "$(uname -s)" == "Darwin" ]] && MACOS=1
+MAC_APP="$HOME/Applications/Dikte.app"
+LAUNCH_AGENT="$HOME/Library/LaunchAgents/com.github.yusufipk.dikte.plist"
+
+# The same search install.sh does, for the same reason: on a Mac `python3` is
+# Apple's, and it cannot import PyQt6 to be asked to unregister anything.
+find_python() {
+  local candidate found
+  for candidate in "${DIKTE_PYTHON:-}" "$DIR/.venv/bin/python3" \
+                   python3 python3.13 python3.12 python3.11; do
+    [[ -n "$candidate" ]] || continue
+    found="$(command -v "$candidate" 2>/dev/null)" || continue
+    if "$found" -c 'import PyQt6.QtWidgets' 2>/dev/null; then
+      printf '%s' "$found"
+      return 0
+    fi
+  done
+  command -v python3 || true
+}
+PY="$(find_python)"
 
 PURGE=0
 ASSUME_YES=0
@@ -64,12 +85,16 @@ echo "──────────────────"
 # 1. Global shortcuts ------------------------------------------------------
 # Handed to Dikte while it can still run, because it is the half that knows
 # whether they went into KDE's kglobalshortcutsrc or GNOME's gsettings.
-if [[ -n "$PY" ]] && python3 -c 'import PyQt6.QtWidgets' 2>/dev/null; then
+if [[ -n "$PY" ]] && "$PY" -c 'import PyQt6.QtWidgets' 2>/dev/null; then
   for which in toggle cancel ask meeting; do
     "$PY" "$DIR/dikte.py" shortcut remove "$which" >/dev/null 2>&1 || true
   done
   ok "Global shortcuts unregistered"
-  say "KWin reads that file at startup, so the keys are free after your next login."
+  if ((MACOS)); then
+    say "They were Dikte's own, so they are free as soon as it stops running."
+  else
+    say "KWin reads that file at startup, so the keys are free after your next login."
+  fi
 else
   warn "PyQt6 is missing, so the shortcuts were left registered."
   say  "Remove them in your desktop's shortcut settings."
@@ -89,25 +114,41 @@ if pgrep -u "$USER_NAME" -f 'dikte\.py' >/dev/null 2>&1; then
 fi
 
 # 3. Launchers -------------------------------------------------------------
-# Only our own symlink goes: a file of the same name that somebody else put
-# there is not ours to delete.
+# Only what we put there goes: a file of the same name that somebody else wrote
+# is not ours to delete. On Linux ours is a symlink, on macOS a wrapper script
+# with install.sh's line in it.
 if [[ -L "$BIN_DIR/dikte" ]]; then
   remove "$BIN_DIR/dikte"
+elif ((MACOS)) && [[ -f "$BIN_DIR/dikte" ]] \
+     && grep -q "Written by Dikte's install.sh" "$BIN_DIR/dikte" 2>/dev/null; then
+  remove "$BIN_DIR/dikte"
 elif [[ -e "$BIN_DIR/dikte" ]]; then
-  warn "$BIN_DIR/dikte is not our symlink, leaving it alone"
+  warn "$BIN_DIR/dikte is not ours, leaving it alone"
 else
   gone "Was not there: $BIN_DIR/dikte"
 fi
-remove "$APP_DIR/dikte.desktop"
-remove "$AUTOSTART_DIR/dikte.desktop"
-# Removing the shortcut takes its desktop file with it, but an install from
-# before this script existed may have left one behind on a desktop that never
-# used them.
-for id in dikte-toggle dikte-cancel dikte-ask dikte-meeting; do
-  if [[ -e "$APP_DIR/$id.desktop" ]]; then
-    remove "$APP_DIR/$id.desktop"
+
+if ((MACOS)); then
+  launchctl bootout "gui/$(id -u)/com.github.yusufipk.dikte" 2>/dev/null || true
+  remove "$LAUNCH_AGENT"
+  if [[ -d "$MAC_APP" ]]; then
+    rm -rf "$MAC_APP"
+    ok "Removed $MAC_APP"
+  else
+    gone "Was not there: $MAC_APP"
   fi
-done
+else
+  remove "$APP_DIR/dikte.desktop"
+  remove "$AUTOSTART_DIR/dikte.desktop"
+  # Removing the shortcut takes its desktop file with it, but an install from
+  # before this script existed may have left one behind on a desktop that never
+  # used them.
+  for id in dikte-toggle dikte-cancel dikte-ask dikte-meeting; do
+    if [[ -e "$APP_DIR/$id.desktop" ]]; then
+      remove "$APP_DIR/$id.desktop"
+    fi
+  done
+fi
 
 # 4. Settings and dictations -----------------------------------------------
 echo

--- a/update.sh
+++ b/update.sh
@@ -3,8 +3,26 @@
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PY="$(command -v python3 || true)"
 USER_NAME="$(id -un)"
+
+MACOS=0
+[[ "$(uname -s)" == "Darwin" ]] && MACOS=1
+
+# install.sh's search, repeated here because this script talks to dikte.py too.
+find_python() {
+  local candidate found
+  for candidate in "${DIKTE_PYTHON:-}" "$DIR/.venv/bin/python3" \
+                   python3 python3.13 python3.12 python3.11; do
+    [[ -n "$candidate" ]] || continue
+    found="$(command -v "$candidate" 2>/dev/null)" || continue
+    if "$found" -c 'import PyQt6.QtWidgets' 2>/dev/null; then
+      printf '%s' "$found"
+      return 0
+    fi
+  done
+  command -v python3 || true
+}
+PY="$(find_python)"
 
 say()  { printf '  %s\n' "$1"; }
 ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
@@ -82,8 +100,13 @@ echo
 # writing them.
 shortcut="$(setting shortcut)"
 cancel_shortcut="$(setting cancel_shortcut)"
+if ((MACOS)); then
+  default_shortcut="Ctrl+Alt+Space"    # Ctrl+Space switches the input source
+else
+  default_shortcut="Ctrl+Space"
+fi
 # Positional, so a chosen discard key cannot be passed without the other one.
-"$DIR/install.sh" "${shortcut:-Ctrl+Space}" "${cancel_shortcut:-}"
+"$DIR/install.sh" "${shortcut:-$default_shortcut}" "${cancel_shortcut:-}"
 
 # 5. The running instance ---------------------------------------------------
 # It is still running the code from before the pull.

--- a/worker.py
+++ b/worker.py
@@ -137,11 +137,21 @@ class Pipeline(QObject):
             if paste_override is not None:
                 wants_paste = paste_override
 
-            with _paste_lock:
-                previous = paste.read_clipboard() if conf["restore_clipboard"] else None
-                paste.copy(text)
+            # Typed out, the transcript never goes near the clipboard: nothing
+            # of yours is overwritten, and there is nothing to put back
+            # afterwards either.
+            typing = wants_paste and conf["type_instead_of_pasting"]
 
-                if wants_paste:
+            with _paste_lock:
+                previous = (paste.read_clipboard()
+                            if conf["restore_clipboard"] and not typing else None)
+                if not typing:
+                    paste.copy(text)
+
+                if typing:
+                    self.stage.emit(t("Typing…"))
+                    paste.type_out(text)
+                elif wants_paste:
                     self.stage.emit(t("Pasting…"))
                     paste.press(conf["paste_shortcut"])
                     if previous is not None:


### PR DESCRIPTION
Dikte runs on macOS with this: dictation, the agent, audio and video files, the
command line and the settings window. Meetings stay Linux-only — they need what
comes out of the speakers, and macOS hands that to nobody.

The platform half was already a group of functions per desktop with one line
choosing between them, which `paste.py` says out loud in its docstring, so this
adds a third group to each place that has one rather than branching inside them:

| file | what is new |
|---|---|
| `paste.py` | pbcopy/pbpaste, and the key press posted through Quartz |
| `audio.py` | ffmpeg's avfoundation input; the device list read out of ffmpeg's own output |
| `hotkey.py` | Carbon's `RegisterEventHotKey`, through ctypes |
| `ggml.py` | llama.cpp's macos-arm64 build; whisper.cpp publishes none, so Homebrew's |
| `macos.py` | new — the handful of Cocoa calls the rest of it needs |

Two defaults differ: pasting is Cmd+V, and the toggle is `Ctrl+Alt+Space`
rather than `Ctrl+Space`, which belongs to the input source switcher there.

What macOS does differently is written down in the code where it bites, mostly
in `macos.py`. The short version: showing any window takes the key window away
from whatever had it and no flag prevents that; a key press without permission
is reported as having happened rather than failing; a `Qt.Tool` window hides
itself whenever its application is not in front; and a click on a menu bar icon
opens the menu *and* arrives as a `Trigger`.

Two things in here are not macOS-specific:

- **`read_exactly()` in `audio.py`.** `read(n)` on an unbuffered pipe returns
  what has arrived, not what was asked for, and both the level meter and the
  silence check are measured in chunks of one known length. Where the recorder
  hands over fractions of a chunk, `vad.analyse()` counted each piece as a whole
  one — two seconds of recording came out as fifteen seconds of speech, which is
  the silence check answering yes to everything. First commit, stands alone;
  happy to split it into its own PR if you would rather.

- **A second way for the transcript to arrive**, under Settings → General: type
  it out instead of pasting. The clipboard is never borrowed and no combination
  has to mean paste in the receiving window, which a terminal or a remote
  desktop may not agree on. Off by default, since it is slower on a long
  transcript. `ydotool type` / `xdotool type` on Linux.

## Testing

907 tests pass. `tests/support.py` gains `macos_only` beside `linux_only`, the
macOS half of `paste.py`, `audio.py` and `hotkey.py` gets the same shape of
coverage the Linux half has, and CI gains one macOS run.

Exercised by hand on macOS 26.5 (arm64): dictation end to end on whisper.cpp
from Homebrew, the global shortcuts, the settings window, file transcription,
and llama.cpp downloaded, verified and run.

Nothing on the Linux side changed apart from the two above. The shortcut
fallback, the evdev listener and the KDE/GNOME installation are untouched.
