### PR TITLE
Handle pw-record versions without --raw support

### DIFF
--- a/audio.py
+++ b/audio.py
@@ -458,9 +458,12 @@ def _pulse_record(target):
 def _pw_record_raw_option():
     """Use --raw only on pw-record releases that provide it.
 
-    PipeWire 1.0, including Ubuntu 24.04's build, writes raw PCM to stdout but
-    rejects the newer --raw option. A rejected option ends the recorder before
-    it receives sound, so ask the installed binary which form it understands.
+    PipeWire gained --raw in 1.4, and in the same release stopped treating a
+    filename of "-" as raw on its own: before it, the option is refused and the
+    recorder dies before any sound arrives; after it, leaving the option out
+    wraps the stream in a container the rest of this file would read as noise.
+    Ubuntu 24.04 and anything else still on 1.0 or 1.2 sit on the near side of
+    that line, so ask the installed binary which form it understands.
     """
     try:
         result = subprocess.run(

--- a/audio.py
+++ b/audio.py
@@ -197,7 +197,7 @@ def recording_command(target=""):
         return cmd
     if shutil.which("pw-record"):
         cmd = [
-            "pw-record", "--raw", f"--rate={RATE}",
+            "pw-record", *_pw_record_raw_option(), f"--rate={RATE}",
             f"--channels={CHANNELS}", "--format=s16",
         ]
         if target:
@@ -205,6 +205,25 @@ def recording_command(target=""):
         cmd.append("-")
         return cmd
     return []
+
+
+def _pw_record_raw_option():
+    """Use --raw only on pw-record releases that provide it.
+
+    PipeWire 1.0, including Ubuntu 24.04's build, writes raw PCM to stdout but
+    rejects the newer --raw option. A rejected option ends the recorder before
+    it receives sound, so ask the installed binary which form it understands.
+    """
+    try:
+        result = subprocess.run(
+            ["pw-record", "--help"], capture_output=True, text=True, timeout=2
+        )
+        help_text = (result.stdout or "") + (result.stderr or "")
+    except (subprocess.SubprocessError, OSError):
+        return ["--raw"]  # preserve the existing command when probing itself fails
+    if not help_text.strip():
+        return ["--raw"]
+    return ["--raw"] if "--raw" in help_text else []
 
 
 class MeetingRecorder(QObject):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -238,6 +238,14 @@ class FakeProcess:
 class RecordingCommand(OnLinux, DikteTest):
     """Which program captures the microphone, and how it is asked to."""
 
+    def setUp(self):
+        super().setUp()
+        # Whether pw-record takes --raw is read off the installed binary, and
+        # what is being tested here is the command rather than the machine the
+        # test is running on. PwRecordRawOption covers the reading itself.
+        self.enterContext(mock.patch.object(
+            audio, "_pw_record_raw_option", return_value=["--raw"]))
+
     def test_parec_is_preferred(self):
         """It speaks to PulseAudio and to PipeWire's compatibility service, so
         it is the one that works on both desktops."""
@@ -247,23 +255,6 @@ class RecordingCommand(OnLinux, DikteTest):
     def test_pw_record_is_the_fallback(self):
         with only_these_tools("pw-record"):
             self.assertEqual(audio.recording_command()[0], "pw-record")
-
-    def test_pw_record_uses_raw_when_the_installed_version_supports_it(self):
-        help_result = FakeCompleted(stdout="  --raw  Write raw samples\n")
-        with only_these_tools("pw-record"), \
-                mock.patch.object(audio.subprocess, "run", return_value=help_result):
-            self.assertIn("--raw", audio.recording_command())
-
-    def test_pw_record_omits_raw_when_pipewire_1_0_rejects_it(self):
-        help_result = FakeCompleted(stdout="  --rate  Sample rate\n")
-        with only_these_tools("pw-record"), \
-                mock.patch.object(audio.subprocess, "run", return_value=help_result):
-            self.assertNotIn("--raw", audio.recording_command())
-
-    def test_pw_record_help_failure_keeps_the_existing_command(self):
-        with only_these_tools("pw-record"), \
-                mock.patch.object(audio.subprocess, "run", side_effect=OSError):
-            self.assertIn("--raw", audio.recording_command())
 
     def test_neither_is_installed(self):
         with only_these_tools():
@@ -305,8 +296,44 @@ class RecordingCommand(OnLinux, DikteTest):
                                   if arg.startswith(flag)])
 
 
+class PwRecordRawOption(DikteTest):
+    """Two pw-record generations want opposite commands for the same stream.
+
+    PipeWire 1.4 added --raw and stopped treating a filename of "-" as raw on
+    its own, so the option is refused by everything older and needed by
+    everything newer. The help text is the only thing that tells them apart.
+    """
+
+    def option(self, **run):
+        with mock.patch.object(audio.subprocess, "run", **run):
+            return audio._pw_record_raw_option()
+
+    def test_a_version_that_offers_raw_is_asked_for_it(self):
+        self.assertEqual(["--raw"], self.option(
+            return_value=FakeCompleted(stdout="  -a, --raw   RAW mode\n")))
+
+    def test_a_version_without_it_is_not(self):
+        self.assertEqual([], self.option(
+            return_value=FakeCompleted(stdout="  --rate  Sample rate\n")))
+
+    def test_help_that_could_not_be_read_keeps_the_option(self):
+        """Whatever is installed, the command that worked before this check
+        existed is the safer guess."""
+        self.assertEqual(["--raw"], self.option(side_effect=OSError))
+        self.assertEqual(["--raw"], self.option(
+            side_effect=subprocess.TimeoutExpired("pw-record", 2)))
+
+    def test_help_that_said_nothing_keeps_it_too(self):
+        self.assertEqual(["--raw"], self.option(return_value=FakeCompleted()))
+
+
 class RecorderChain(OnLinux, DikteTest):
     """Start to WAV, with pw-record faked out."""
+
+    def setUp(self):
+        super().setUp()
+        self.enterContext(mock.patch.object(
+            audio, "_pw_record_raw_option", return_value=["--raw"]))
 
     def record(self, data, target="", max_seconds=300):
         recorder = audio.Recorder()
@@ -316,7 +343,6 @@ class RecorderChain(OnLinux, DikteTest):
         recorder.failed.connect(failures.append)
         proc = FakeProcess(data)
         with only_these_tools("pw-record"), \
-                mock.patch.object(audio, "_pw_record_raw_option", return_value=[]), \
                 mock.patch.object(subprocess, "Popen", return_value=proc) as popen:
             recorder.start(target=target, max_seconds=max_seconds)
             recorder._thread.join(timeout=5)
@@ -363,7 +389,6 @@ class RecorderChain(OnLinux, DikteTest):
         recorder.stopped.connect(lambda *args: results.append(args))
         proc = FakeProcess(tone(1.0))
         with only_these_tools("pw-record"), \
-                mock.patch.object(audio, "_pw_record_raw_option", return_value=[]), \
                 mock.patch.object(subprocess, "Popen", return_value=proc):
             recorder.start()
             recorder._thread.join(timeout=5)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -230,6 +230,23 @@ class RecordingCommand(DikteTest):
         with only_these_tools("pw-record"):
             self.assertEqual(audio.recording_command()[0], "pw-record")
 
+    def test_pw_record_uses_raw_when_the_installed_version_supports_it(self):
+        help_result = FakeCompleted(stdout="  --raw  Write raw samples\n")
+        with only_these_tools("pw-record"), \
+                mock.patch.object(audio.subprocess, "run", return_value=help_result):
+            self.assertIn("--raw", audio.recording_command())
+
+    def test_pw_record_omits_raw_when_pipewire_1_0_rejects_it(self):
+        help_result = FakeCompleted(stdout="  --rate  Sample rate\n")
+        with only_these_tools("pw-record"), \
+                mock.patch.object(audio.subprocess, "run", return_value=help_result):
+            self.assertNotIn("--raw", audio.recording_command())
+
+    def test_pw_record_help_failure_keeps_the_existing_command(self):
+        with only_these_tools("pw-record"), \
+                mock.patch.object(audio.subprocess, "run", side_effect=OSError):
+            self.assertIn("--raw", audio.recording_command())
+
     def test_neither_is_installed(self):
         with only_these_tools():
             self.assertEqual(audio.recording_command(), [])
@@ -282,6 +299,7 @@ class RecorderChain(DikteTest):
         recorder.failed.connect(failures.append)
         proc = FakeProcess(data)
         with only_these_tools("pw-record"), \
+                mock.patch.object(audio, "_pw_record_raw_option", return_value=[]), \
                 mock.patch.object(subprocess, "Popen", return_value=proc) as popen:
             recorder.start(target=target, max_seconds=max_seconds)
             recorder._thread.join(timeout=5)
@@ -328,6 +346,7 @@ class RecorderChain(DikteTest):
         recorder.stopped.connect(lambda *args: results.append(args))
         proc = FakeProcess(tone(1.0))
         with only_these_tools("pw-record"), \
+                mock.patch.object(audio, "_pw_record_raw_option", return_value=[]), \
                 mock.patch.object(subprocess, "Popen", return_value=proc):
             recorder.start()
             recorder._thread.join(timeout=5)


### PR DESCRIPTION
## Özet

Bu PR, Dikte’nin ses kaydı için parec bulunmadığında kullandığı pw-record komutunu farklı PipeWire sürümleriyle uyumlu hale getiriyor.

- Kurulu pw-record sürümünün raw seçeneğini destekleyip desteklemediği yardım çıktısından algılanıyor.
- Seçenek destekleniyorsa mevcut davranış korunuyor.
- Ubuntu 24.04 ile gelen PipeWire 1.0.x gibi seçeneği tanımayan sürümlerde raw parametresi gönderilmiyor.
- Sürüm sorgusu çalıştırılamazsa mevcut komut korunarak geriye dönük davranış tercih ediliyor.

## Sorun

Ubuntu 24.04 üzerinde bulunan PipeWire 1.0.5 sürümündeki pw-record, raw seçeneğini tanımıyor. Dikte bu seçeneği koşulsuz gönderdiğinde kayıt süreci ses almadan önce kapanıyor ve USB mikrofon doğru seçilmiş olsa bile kayıt başlamıyor.

Güncel kod normalde PulseAudio uyumluluk katmanı üzerinden parec aracını tercih ediyor. Bu hata, parec bulunmayan ve doğrudan pw-record kullanılan minimal PipeWire kurulumlarında ortaya çıkıyor.

## Çözüm

Yeni yardımcı fonksiyon pw-record --help çıktısını en fazla iki saniye bekleyerek okuyor:

- Yardım çıktısında raw seçeneği varsa komuta ekliyor.
- Seçenek yoksa parametreyi çıkartıyor.
- Yardım sorgusu hata verirse mevcut komut biçimini koruyor.

Böylece yeni PipeWire sürümlerindeki açık raw seçimi bozulmadan, Ubuntu 24.04 gibi eski sürümlerde kaydın başlaması sağlanıyor. parec yolu ve toplantı kayıt akışı değiştirilmedi.

## Testler

Aşağıdaki senaryolar için test eklendi:

- raw seçeneğini destekleyen pw-record sürümü
- seçeneği reddeden PipeWire 1.0 sürümü
- yardım sorgusunun başarısız olması
- kayıt zinciri testlerinde sürüm algılamasının izole edilmesi

Tam test paketi çalıştırıldı:

- 841 test başarılı
- Diff biçim kontrolü başarılı

## Gerçek ortam doğrulaması

Ubuntu 24.04 ve PipeWire 1.0.5 üzerinde sorun yeniden üretildi: raw parametresi bilinmeyen seçenek hatasıyla kayıt sürecini sonlandırdı. Aynı USB mikrofon, desteklenmeyen parametre kaldırıldığında başarıyla ses üretti.