### PR TITLE
Select native macOS local-model builds

### DIFF
--- a/ggml.py
+++ b/ggml.py
@@ -37,6 +37,7 @@ import shutil
 import signal
 import socket
 import subprocess
+import sys
 import tarfile
 import threading
 import time
@@ -220,8 +221,15 @@ def _has_vulkan():
 
 
 def _wanted_assets(program):
-    """Asset name endings to accept, best first."""
+    """Asset name endings to accept, best first.
+
+    llama.cpp publishes native Metal-enabled macOS archives. whisper.cpp does
+    not publish a runnable macOS server archive, so an arm64 Mac must not
+    mistake Ubuntu's arm64 archive for a native build.
+    """
     arch = _arch()
+    if sys.platform == "darwin":
+        return () if program is WHISPER else (f"bin-macos-{arch}.tar.gz",)
     if program is LLAMA and _has_vulkan():
         return (f"bin-ubuntu-vulkan-{arch}.tar.gz", f"bin-ubuntu-{arch}.tar.gz")
     return (f"bin-ubuntu-{arch}.tar.gz",)
@@ -311,6 +319,11 @@ def install_program(program, tag="", on_progress=None, should_stop=None,
         if item:
             break
     if item is None:
+        if sys.platform == "darwin" and program is WHISPER:
+            raise LocalError(t(
+                "whisper.cpp publishes no macOS build. Install it with: "
+                "brew install whisper-cpp"
+            ))
         raise LocalError(t("{repo} {tag} has no build for this machine.",
                            repo=program.repo, tag=tag))
 

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -176,6 +176,9 @@ class Download(Local):
 class InstallProgram(Local):
     def setUp(self):
         super().setUp()
+        # These fixtures are Ubuntu release archives.  Keep checking that path
+        # on every host, including the Mac that checks the macOS backend.
+        self.patch_attr(sys, "platform", "linux")
         # Built once, because the release listing has to publish its checksum
         # and a tarball is not the same bytes twice.
         self.archive = tarball({
@@ -215,6 +218,23 @@ class InstallProgram(Local):
             with self.assertRaises(ggml.LocalError) as caught:
                 ggml.install_program(ggml.WHISPER)
         self.assertIn("this machine", str(caught.exception))
+
+    def test_a_mac_does_not_install_an_ubuntu_archive_for_the_same_architecture(self):
+        self.patch_attr(sys, "platform", "darwin")
+        self.patch_attr(ggml, "_arch", lambda: "arm64")
+        listing = self.release("whisper-bin-ubuntu-arm64.tar.gz")
+        with fake_urlopen(listing):
+            with self.assertRaises(ggml.LocalError) as caught:
+                ggml.install_program(ggml.WHISPER)
+        self.assertIn("brew install whisper-cpp", str(caught.exception))
+
+    def test_a_mac_uses_the_native_llama_archive_instead_of_ubuntu(self):
+        self.patch_attr(sys, "platform", "darwin")
+        self.patch_attr(ggml, "_arch", lambda: "arm64")
+        self.assertEqual(
+            ggml._wanted_assets(ggml.LLAMA),
+            ("bin-macos-arm64.tar.gz",),
+        )
 
     def test_what_was_installed_is_remembered(self):
         path, _ = self.install("whisper-bin-ubuntu-x64.tar.gz")
@@ -661,4 +681,3 @@ class Sizes(DikteTest):
         self.assertEqual(ggml.human_size(512), "512 B")
         self.assertEqual(ggml.human_size(574041195), "547.4 MB")
         self.assertEqual(ggml.human_size(3_095_033_483), "2.9 GB")
-


### PR DESCRIPTION
## What changed

- Refuse Ubuntu whisper.cpp archives on macOS and point users to `brew install whisper-cpp`.
- Select llama.cpp's published `bin-macos-{arch}.tar.gz` archive instead of rejecting every Mac build.
- Keep the Linux selection path pinned in tests so a Mac CI runner cannot accidentally change Linux behavior.

## Why

Architecture alone is not an operating-system match: Apple Silicon previously accepted an Ubuntu ARM64 archive. Conversely, current llama.cpp releases do publish runnable native macOS archives, so rejecting both projects was also incorrect.

## Verification

- `QT_QPA_PLATFORM=offscreen python -m unittest discover -q`
- 937 tests passed, 43 skipped.
- Release naming verified against whisper.cpp v1.9.1 and llama.cpp b10241.