### PR TITLE
Add native Windows 10/11 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,10 +7,18 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Both platforms Dikte claims to run on, on every version it claims to run
+    # under. The suite is written to pass on either: what belongs to one
+    # desktop is marked as belonging to it and skipped on the other, and what
+    # is left — transcription, cleanup, the config file, the history, the
+    # agent, the command line and the timeline of a meeting — must pass on
+    # both, because none of it is desktop-specific and none of it may become so.
+    name: ${{ matrix.os }} · python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python: ["3.11", "3.12", "3.13"]
 
     steps:
@@ -25,6 +33,7 @@ jobs:
       # library, and the widgets want fontconfig, whether or not anything is
       # ever drawn.
       - name: Install the Qt runtime libraries
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
@@ -34,7 +43,49 @@ jobs:
       - name: Install PyQt6
         run: python -m pip install --quiet PyQt6
 
-      # Nothing else is needed: the code is standard library and PyQt6, and the
-      # tests reach neither the network nor a sound device.
+      # The Windows recorder goes through WASAPI rather than through another
+      # program, and this is the wheel that offers it. Nothing on Linux needs
+      # it: there the sound server's own tools do the capturing.
+      - name: Install the Windows sound support
+        if: runner.os == 'Windows'
+        run: python -m pip install --quiet PyAudioWPatch
+
+      # Nothing else is needed: the code is standard library, PyQt6 and — on
+      # Windows — one sound wheel, and the tests reach neither the network nor
+      # a sound device.
       - name: Run the tests
         run: python -m unittest discover --verbose
+
+  package:
+    # A build nobody has started is a build that does not start. This freezes
+    # the application and runs the packaged command line, which is where a
+    # missing hidden import shows up: the platform adapters are chosen through
+    # importlib, so nothing that reads the source can see that they are needed.
+    name: windows package
+    runs-on: windows-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install what a build needs
+        run: python -m pip install --quiet PyQt6 PyAudioWPatch pyinstaller
+
+      # ffmpeg is skipped here: it is 170 MB fetched from another project's
+      # release, and what this job checks is that Dikte itself freezes and
+      # starts. A release build runs the same script without the flag.
+      - name: Build
+        shell: pwsh
+        run: >
+          ./packaging/windows/build.ps1
+          -Python python -SkipTests -SkipFfmpeg -SkipInstaller
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dikte-windows
+          path: dist/Dikte
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 dist/
 packaging/windows/dikte.ico
 packaging/windows/vendor/
+.tools/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
+
+# What a Windows build leaves behind. The icon is drawn from icons.py and the
+# ffmpeg is fetched and checked against ffmpeg.json, so both are outputs rather
+# than sources; build.ps1 makes them.
+build/
+dist/
+packaging/windows/dikte.ico
+packaging/windows/vendor/

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ machine by default, a model cleans it up (dropping the *uh*s, the restarts, the
 missing punctuation), and the result lands in your clipboard and is pasted into
 whatever window you were typing in.
 
-Built for KDE Plasma 6 on Wayland, and runs on GNOME X11 and macOS too. No
-dependencies beyond system packages: just the Python standard library, 3.11 or
-newer, and PyQt6.
+Built for KDE Plasma 6 on Wayland, and runs on GNOME X11, macOS and Windows
+10/11 too. Source installs need Python 3.11 or newer and PyQt6; the Windows
+installer bundles its runtime and ffmpeg.
 
 *[Türkçe README](README.tr.md)*
 
@@ -61,6 +61,19 @@ that catches the keys is the mechanism there and there is nothing to run:
 needs BlackHole or Loopback, because nothing else offers what the speakers are
 playing.
 
+### Windows
+
+Download and run the installer produced under [packaging/windows](packaging/windows),
+or build it with `packaging/windows/build.ps1`. It installs for the current user
+under `%LOCALAPPDATA%`, requires no administrator access, and can start at sign
+in so global shortcuts are available.
+
+Windows uses native WASAPI microphone and speaker-loopback capture,
+`RegisterHotKey`, the Unicode clipboard and `SendInput`. API keys are protected
+for the current Windows account with DPAPI. Windows cannot inject a paste into
+an application running as administrator; in that case the result remains on
+the clipboard for manual paste.
+
 `install.sh` adds the `dikte` command, a menu entry, an autostart entry and the
 two global shortcuts, whose keys are its two arguments. `./update.sh` pulls and
 puts all of that back, keeping the keys you chose; `./uninstall.sh` takes it away
@@ -73,9 +86,10 @@ cleanup on OpenRouter (`google/gemini-3.5-flash-lite`) or, when either is
 installed, on Claude Code or Codex. The keys fall back to `OPENAI_API_KEY`,
 `GROQ_API_KEY` and `OPENROUTER_API_KEY`, and are stored in
 `~/.config/dikte/config.json`, mode 600, or in
-`~/Library/Application Support/Dikte` on a Mac. Cleanup can be switched off, in
-which case the raw transcript is pasted, and a thinking model's effort can be
-set next to it.
+`~/Library/Application Support/Dikte` on a Mac, or encrypted for the current
+account in `%APPDATA%\Dikte\config.json` on Windows. Cleanup can be switched
+off, in which case the raw transcript is pasted, and a thinking model's effort
+can be set next to it.
 
 ## Using it
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -4,9 +4,9 @@
 çevrilir, bir model transkripti temizler (ıı'lar, tekrarlar, eksik noktalama),
 sonuç panoya kopyalanır ve o an yazdığın pencereye yapıştırılır.
 
-KDE Plasma 6 / Wayland için yazıldı, GNOME X11 ve macOS'ta da çalışır. Sistem
-paketleri dışında bağımlılığı yok: sadece Python standart kütüphanesi (3.11 veya
-üstü) ve PyQt6.
+KDE Plasma 6 / Wayland için yazıldı; GNOME X11, macOS ve Windows 10/11'de de
+çalışır. Kaynaktan kurulum Python 3.11 veya üstü ile PyQt6 ister; Windows
+kurulum paketi çalışma ortamını ve ffmpeg'i birlikte getirir.
 
 *[English README](README.md)*
 
@@ -59,6 +59,19 @@ dinleyici orada mekanizmanın kendisi, dolayısıyla kurulacak bir şey de yok:
 `brew install ffmpeg`, `pip install PyQt6`, sonra `python dikte.py`. Toplantı
 için BlackHole ya da Loopback gerekiyor, hoparlörden çıkanı kimse vermiyor.
 
+### Windows
+
+[packaging/windows](packaging/windows) altında üretilen kurulum dosyasını
+çalıştırabilir veya `packaging/windows/build.ps1` ile kendin üretebilirsin.
+Program yalnızca mevcut kullanıcı için `%LOCALAPPDATA%` altına kurulur, yönetici
+izni istemez ve global kısayollar hazır olsun diye oturum açılışında başlayabilir.
+
+Windows'ta mikrofon ve sistem sesi için yerel WASAPI, kısayollar için
+`RegisterHotKey`, pano ve yapıştırma için Unicode Clipboard API ile `SendInput`
+kullanılır. API anahtarları DPAPI ile mevcut Windows hesabına bağlı olarak
+korunur. Windows, yönetici olarak çalışan bir uygulamaya tuş gönderilmesine izin
+vermez; bu durumda sonuç panoda kalır ve elle yapıştırılabilir.
+
 `install.sh` `dikte` komutunu, menü girdisini, oturum açılışında otomatik
 başlatmayı ve iki global kısayolu kurar; tuşları da iki argümanı. `./update.sh`
 son sürümü çeker ve bunları senin seçtiğin tuşlarla yerine koyar;
@@ -72,7 +85,9 @@ seçersen sesi yazıya çevirme **OpenAI**, **Groq** ya da **OpenRouter**'da
 (`google/gemini-3.5-flash-lite`) ya da kuruluysa Claude Code veya Codex'te
 çalışır. Anahtarları boş bırakırsan `OPENAI_API_KEY`, `GROQ_API_KEY` ve
 `OPENROUTER_API_KEY` kullanılır; anahtarlar `~/.config/dikte/config.json`
-içinde, izinler 600, Mac'te ise `~/Library/Application Support/Dikte` altında.
+içinde izinler 600 ile, Mac'te `~/Library/Application Support/Dikte` altında,
+Windows'ta ise `%APPDATA%\Dikte\config.json` içinde hesaba özel şifrelenmiş
+olarak tutulur.
 Temizlemeyi tamamen kapatabilirsin, o zaman ham transkript yapıştırılır; modelin
 yanındaki kutudan düşünme seviyesini de seçebilirsin.
 

--- a/api.py
+++ b/api.py
@@ -17,13 +17,15 @@ import json
 import mimetypes
 import os
 import secrets
-import socket
 import threading
 import urllib.error
 import urllib.request
 
 import ggml
 from i18n import t
+from platforms import adapter
+
+runtime = adapter("runtime")
 
 APP_URL = "https://github.com/yusufipk/dikte"
 USER_AGENT = f"dikte/1.0 (+{APP_URL})"
@@ -141,13 +143,13 @@ def _stop_using(conn):
     A connection whose socket is not open yet would open one on the next line,
     so the reconnect is turned off first. One that is open is being read from,
     and close() alone leaves that read waiting for bytes which are never coming
-    now; the shutdown is what makes it return.
+    now. What does make it return differs between the two socket libraries, so
+    the platform is asked.
     """
     conn.auto_open = 0
     sock = getattr(conn, "sock", None)
     if sock is not None:
-        with contextlib.suppress(OSError):
-            sock.shutdown(socket.SHUT_RDWR)
+        runtime.abort_socket(sock)
     with contextlib.suppress(OSError):
         conn.close()
 
@@ -246,6 +248,40 @@ def _extract_error(body):
     return body[:300]
 
 
+# What an upload says it is, decided here rather than asked of the machine.
+# `mimetypes` reads the system's own table, and the systems disagree: a .wav is
+# audio/x-wav on Linux and audio/wav in the Windows registry, and a user who
+# has installed something that claimed .m4a can move it again. A request whose
+# shape depends on the desktop it was sent from is one more thing to rule out
+# when a provider starts refusing uploads, so the common formats are named.
+CONTENT_TYPES = {
+    ".wav": "audio/x-wav",
+    ".mp3": "audio/mpeg",
+    ".mpga": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".aac": "audio/aac",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".oga": "audio/ogg",
+    ".opus": "audio/opus",
+    ".webm": "audio/webm",
+    ".wma": "audio/x-ms-wma",
+    ".mp4": "video/mp4",
+    ".m4v": "video/x-m4v",
+    ".mpeg": "video/mpeg",
+    ".mov": "video/quicktime",
+    ".mkv": "video/x-matroska",
+    ".avi": "video/x-msvideo",
+}
+
+
+def _content_type(filename):
+    ending = os.path.splitext(filename)[1].lower()
+    return (CONTENT_TYPES.get(ending)
+            or mimetypes.guess_type(filename)[0]
+            or "application/octet-stream")
+
+
 def _multipart(fields, file_field, file_path):
     """Build a multipart/form-data body; returns (body, content-type)."""
     boundary = "----dikte" + secrets.token_hex(16)
@@ -258,7 +294,7 @@ def _multipart(fields, file_field, file_path):
         out += str(value).encode("utf-8") + b"\r\n"
 
     filename = os.path.basename(file_path)
-    ctype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    ctype = _content_type(filename)
     with open(file_path, "rb") as fh:
         payload = fh.read()
     out += f"--{boundary}\r\n".encode()

--- a/audio.py
+++ b/audio.py
@@ -662,12 +662,36 @@ def default_monitor():
 # Linux/macOS implementations above remain untouched.  Keeping this dispatch
 # at the boundary avoids regressing the newer macOS backend while the desktop
 # services are progressively moved into dedicated adapters.
+_LegacyRecorder = Recorder
+_LegacyMeetingRecorder = MeetingRecorder
+_legacy_list_sources = list_sources
+_legacy_list_monitors = list_monitors
+_legacy_default_monitor = default_monitor
+
 if sys.platform.startswith("win"):
     from platforms import adapter as _platform_adapter
 
     _windows_audio = _platform_adapter("audio", "windows")
-    Recorder = _windows_audio.Recorder
-    MeetingRecorder = _windows_audio.MeetingRecorder
-    list_sources = _windows_audio.list_sources
-    list_monitors = _windows_audio.list_monitors
-    default_monitor = _windows_audio.default_monitor
+
+    def Recorder(parent=None):
+        implementation = (_windows_audio.Recorder if sys.platform.startswith("win")
+                          else _LegacyRecorder)
+        return implementation(parent)
+
+    def MeetingRecorder(parent=None):
+        implementation = (_windows_audio.MeetingRecorder
+                          if sys.platform.startswith("win")
+                          else _LegacyMeetingRecorder)
+        return implementation(parent)
+
+    def list_sources():
+        return (_windows_audio.list_sources() if sys.platform.startswith("win")
+                else _legacy_list_sources())
+
+    def list_monitors():
+        return (_windows_audio.list_monitors() if sys.platform.startswith("win")
+                else _legacy_list_monitors())
+
+    def default_monitor():
+        return (_windows_audio.default_monitor() if sys.platform.startswith("win")
+                else _legacy_default_monitor())

--- a/cli.py
+++ b/cli.py
@@ -817,14 +817,39 @@ def cmd_doctor(opts):
         f"{'✓' if devices['outputs'] else '·'} speaker output "
         f"{devices['outputs']} recordable, for meetings",
     ]
+    if target.provider == "local":
+        transcription_line = (
+            f"{'✓' if conf.local_whisper_ready() else '✗'} local whisper.cpp, "
+            f"transcribing on {target.model}"
+        )
+    else:
+        transcription_line = (
+            f"{'✓' if target.api_key else '✗'} {target.service} key, "
+            f"transcribing on {target.model}"
+        )
+
+    if not conf["cleanup_enabled"]:
+        cleanup_line = "· transcript cleanup disabled"
+    elif cleaner == "openrouter":
+        cleanup_line = (
+            f"{'✓' if conf.openrouter_key() else '✗'} OpenRouter key, "
+            f"cleaning up on {conf['cleanup_model']}"
+        )
+    elif cleaner == "local":
+        cleanup_line = (
+            f"{'✓' if conf.local_llm_ready() else '✗'} local llama.cpp, "
+            f"cleaning up on {cleanup.model(conf)}"
+        )
+    else:
+        executable = cleanup.executable(cleaner)
+        cleanup_line = (
+            f"{'✓' if programs.get(executable) else '✗'} {executable}, "
+            f"cleaning up on {cleanup.model(conf)}"
+        )
+
     lines += [
-        f"{'✓' if target.api_key else '✗'} {target.service} key, transcribing on "
-        f"{target.model}",
-        # Cleanup on a CLI needs no key, so what is checked is the program.
-        (f"{'✓' if conf.openrouter_key() else '✗'} OpenRouter key, cleaning up on "
-         f"{conf['cleanup_model']}") if cleaner == "openrouter" else
-        (f"{'✓' if programs[cleanup.executable(cleaner)] else '✗'} "
-         f"{cleanup.executable(cleaner)}, cleaning up on {cleanup.model(conf)}"),
+        transcription_line,
+        cleanup_line,
         f"{'✓' if checks['running'] else '·'} application "
         + ("running" if checks["running"] else "not running"),
     ]

--- a/cli.py
+++ b/cli.py
@@ -32,6 +32,9 @@ import hotkey
 import ipc
 import meeting
 import paste
+from platforms import adapter
+
+runtime = adapter("runtime")
 
 NOT_RUNNING = 3
 
@@ -129,12 +132,16 @@ def _ask_instance(opts, cmd, wait=False, **args):
 
 
 def launch_gui(verb=""):
-    """No instance running, so become the application itself."""
-    args = [sys.executable, ipc.script_path()]
-    if verb:
-        args.append(verb)
-    args.append("--gui")
-    os.execv(sys.executable, args)
+    """No instance running, so become the application itself.
+
+    On Linux this replaces the process and never returns, which is what a
+    shortcut pressed on a fresh login relies on. A packaged Windows build has
+    no process to replace: the tray application is a second executable beside
+    this one, so it is started and this one stands down.
+    """
+    args = ([verb] if verb else []) + ["--gui"]
+    runtime.relaunch(ipc.gui_command(*args))
+    sys.exit(0)
 
 
 def _not_running(opts):
@@ -762,17 +769,36 @@ def cmd_status(opts):
     return out(opts, reply, "\n".join(lines))
 
 
+def _audio_devices():
+    """How many microphones and recordable outputs the sound system offers.
+
+    Asked here rather than assumed, because "no microphone" and "the microphone
+    is switched off in the privacy settings" look identical from a shortcut
+    that appears to do nothing.
+    """
+    try:
+        return {"microphones": len(audio.list_sources()),
+                "outputs": len(audio.list_monitors()), "error": ""}
+    except Exception as exc:      # noqa: BLE001 - whatever the sound library says
+        return {"microphones": 0, "outputs": 0, "error": str(exc)}
+
+
 def cmd_doctor(opts):
     """What the settings window checks behind its buttons, in one pass."""
     conf = cfg.Config()
-    wanted = ["pw-record", "wl-copy", "ydotool", "ffmpeg", "pactl", "kwriteconfig6",
+    # What has to be on the PATH is the platform's business: Linux records,
+    # copies, types and registers a shortcut through six outside programs, and
+    # Windows does all four inside this process.
+    wanted = [*runtime.PROGRAMS,
               assistant.executable(assistant.provider(conf)) or "claude",
               cleanup.executable(cleanup.provider(conf))]
     programs = {name: shutil.which(name) or "" for name in wanted if name}
     target = conf.transcribe_target()
     cleaner = cleanup.provider(conf)
+    devices = _audio_devices()
     checks = {
         "programs": programs,
+        "audio": devices,
         "transcription": {"provider": target.provider, "model": target.model,
                           "key": bool(target.api_key)},
         "cleanup": {"enabled": conf["cleanup_enabled"], "provider": cleaner,
@@ -784,6 +810,13 @@ def cmd_doctor(opts):
     }
     lines = [f"{'✓' if path else '✗'} {name:14} {path or 'not on your PATH'}"
              for name, path in programs.items()]
+    lines += [
+        f"{'✓' if devices['microphones'] else '✗'} microphones   "
+        f"{devices['microphones']} found"
+        + (f" ({devices['error']})" if devices["error"] else ""),
+        f"{'✓' if devices['outputs'] else '·'} speaker output "
+        f"{devices['outputs']} recordable, for meetings",
+    ]
     lines += [
         f"{'✓' if target.api_key else '✗'} {target.service} key, transcribing on "
         f"{target.model}",
@@ -1035,8 +1068,27 @@ def _needs_subcommand(parser):
     return show
 
 
+def prepare_output():
+    """Make sure the answers can reach whatever this was typed into.
+
+    Dikte answers with check marks, arrows, ellipses and, half the time, with
+    Turkish. A Windows console starts in the machine's ANSI codepage, and
+    printing a character that codepage has never heard of raises rather than
+    prints, so `dikte doctor` ends in a traceback where the answer should be.
+    UTF-8 is asked for, and a stream that will not have it falls back to
+    replacing what it cannot encode: a mangled character beats no answer.
+    """
+    runtime.prepare_console()
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, ValueError, OSError):
+            pass
+
+
 def run(argv):
     global _app
+    prepare_output()
     parser = build_parser()
     opts = parser.parse_args(argv)
     # No verb at all is the plain `dikte`, which means the settings window.

--- a/config.py
+++ b/config.py
@@ -1,4 +1,12 @@
-"""Settings storage, in the place this system keeps a program's settings."""
+"""Settings storage: ~/.config/dikte/config.json, or %APPDATA%\\Dikte\\config.json
+
+Where the file goes and how the API keys inside it are kept are both the
+platform's business, so both come from the runtime adapter. On Linux a key is
+written as it stands into a file nobody else can read; on Windows the file's
+permissions are not the protection, so the key is encrypted to the Windows
+account before it is written. Everything above this line sees a plain key
+either way.
+"""
 
 import collections
 import hashlib
@@ -10,45 +18,41 @@ import sys
 import api
 import ggml
 import i18n
-import paste
 from i18n import t
+from platforms import adapter
 
-
-def _xdg(var, default):
-    return pathlib.Path(os.environ.get(var) or os.path.expanduser(default))
+runtime = adapter("runtime")
 
 
 def _directories(platform=None):
-    """(settings, data), in the two places this system keeps them.
-
-    macOS keeps both in the one directory a Mac user's backup already knows
-    about. Windows separates roaming settings from machine-local data. Linux
-    keeps them separate too and follows the XDG variables.
-    """
+    """Compatibility seam used by tests and migrations for all three OSes."""
     platform = platform or sys.platform
     if platform == "darwin":
         support = pathlib.Path.home() / "Library/Application Support/Dikte"
         return support, support
     if platform.startswith("win"):
-        roaming = pathlib.Path(
-            os.environ.get("APPDATA")
-            or pathlib.Path.home() / "AppData/Roaming"
-        )
-        local = pathlib.Path(
-            os.environ.get("LOCALAPPDATA")
-            or pathlib.Path.home() / "AppData/Local"
-        )
+        roaming = pathlib.Path(os.environ.get("APPDATA")
+                               or pathlib.Path.home() / "AppData/Roaming")
+        local = pathlib.Path(os.environ.get("LOCALAPPDATA")
+                             or pathlib.Path.home() / "AppData/Local")
         return roaming / "Dikte", local / "Dikte"
-    return (_xdg("XDG_CONFIG_HOME", "~/.config") / "dikte",
-            _xdg("XDG_DATA_HOME", "~/.local/share") / "dikte")
+    config_home = pathlib.Path(os.environ.get("XDG_CONFIG_HOME")
+                               or pathlib.Path.home() / ".config")
+    data_home = pathlib.Path(os.environ.get("XDG_DATA_HOME")
+                             or pathlib.Path.home() / ".local/share")
+    return config_home / "dikte", data_home / "dikte"
 
-
-CONFIG_DIR, DATA_DIR = _directories()
+CONFIG_DIR = runtime.config_dir()
 CONFIG_FILE = CONFIG_DIR / "config.json"
+DATA_DIR = runtime.data_dir()
 HISTORY_FILE = DATA_DIR / "history.jsonl"
-RECORDINGS_DIR = DATA_DIR / "recordings"
-MEETINGS_DIR = DATA_DIR / "meetings"
+RECORDINGS_DIR = DATA_DIR / runtime.RECORDINGS_NAME
+MEETINGS_DIR = DATA_DIR / runtime.MEETINGS_NAME
 MEETINGS_FILE = DATA_DIR / "meetings.jsonl"
+
+# The settings that are secrets rather than preferences. They go through the
+# platform on the way in and on the way out, and nothing else in the file does.
+SECRET_KEYS = ("openai_api_key", "groq_api_key", "openrouter_api_key")
 
 CLEANUP_PROMPT_EN = """You clean up dictation transcripts. You are given the raw
 text of something spoken out loud. Make it readable with MINIMAL interference.
@@ -415,6 +419,10 @@ DEFAULTS = {
     "local_preload": True,          # load the model while Dikte starts, rather
                                     # than on the first dictation
     "local_binary": "",             # empty -> whichever copy ggml.py finds
+    # Which published build to fetch: auto, cpu, cuda or vulkan. Auto is the
+    # one that runs on any machine; a graphics card is opted into, once, and a
+    # build the project does not publish is refused rather than substituted.
+    "local_backend": "auto",
 
     "cleanup_enabled": True,
     "cleanup_provider": "openrouter",  # a name in cleanup.PROVIDERS
@@ -435,13 +443,14 @@ DEFAULTS = {
     "local_llm_gpu": True,
     "local_llm_context": 8192,
     "local_llm_binary": "",
+    "local_llm_backend": "auto",    # as local_backend, for llama.cpp
     "local_llm_preload": False,     # heavier than whisper, so only when asked
     # Off rather than empty: a model trained to think will, and 300 tokens of
     # reasoning about a comma is 300 tokens of waiting.
     "local_llm_reasoning": "none",
     "cleanup_prompt": "",           # empty -> language-specific default
     "auto_paste": True,
-    "paste_shortcut": paste.desktop().shortcuts[0],   # cmd+v on a Mac
+    "paste_shortcut": "ctrl+v",
     "restore_clipboard": False,
     "mic_target": "",
     "max_seconds": 300,
@@ -543,6 +552,12 @@ class Config:
                 stored = json.load(fh)
             if isinstance(stored, dict):
                 self.data.update({k: v for k, v in stored.items() if k in DEFAULTS})
+                # A key written by an older version, or by hand, comes back as
+                # it was written; the next save is what puts it into whatever
+                # form this platform keeps secrets in.
+                for key in SECRET_KEYS:
+                    if isinstance(self.data.get(key), str):
+                        self.data[key] = runtime.unprotect(self.data[key])
         except FileNotFoundError:
             pass
         except (json.JSONDecodeError, OSError) as exc:
@@ -557,10 +572,16 @@ class Config:
 
     def save(self):
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        stored = dict(self.data)
+        for key in SECRET_KEYS:
+            if isinstance(stored.get(key), str) and stored[key]:
+                stored[key] = runtime.protect(stored[key])
         tmp = CONFIG_FILE.with_suffix(".json.tmp")
         with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(self.data, fh, ensure_ascii=False, indent=2)
-        os.chmod(tmp, 0o600)
+            json.dump(stored, fh, ensure_ascii=False, indent=2)
+        # Tightened before it is moved into place, so there is never a moment
+        # when the keys are on disk under the mode a new file is given.
+        runtime.secure_file(tmp)
         tmp.replace(CONFIG_FILE)
         i18n.set_language(self.data["ui_language"])
 

--- a/config.py
+++ b/config.py
@@ -22,11 +22,23 @@ def _directories(platform=None):
     """(settings, data), in the two places this system keeps them.
 
     macOS keeps both in the one directory a Mac user's backup already knows
-    about. Everywhere else they are separate and follow the XDG variables.
+    about. Windows separates roaming settings from machine-local data. Linux
+    keeps them separate too and follows the XDG variables.
     """
-    if (platform or sys.platform) == "darwin":
+    platform = platform or sys.platform
+    if platform == "darwin":
         support = pathlib.Path.home() / "Library/Application Support/Dikte"
         return support, support
+    if platform.startswith("win"):
+        roaming = pathlib.Path(
+            os.environ.get("APPDATA")
+            or pathlib.Path.home() / "AppData/Roaming"
+        )
+        local = pathlib.Path(
+            os.environ.get("LOCALAPPDATA")
+            or pathlib.Path.home() / "AppData/Local"
+        )
+        return roaming / "Dikte", local / "Dikte"
     return (_xdg("XDG_CONFIG_HOME", "~/.config") / "dikte",
             _xdg("XDG_DATA_HOME", "~/.local/share") / "dikte")
 

--- a/dikte.py
+++ b/dikte.py
@@ -1043,10 +1043,10 @@ def run_app(args):
     # tray icon.
     instance = runtime.single_instance(SERVER_NAME)
     if instance is None:
-        if command:
-            ipc.send(command)
-        else:
-            print("dikte: already running")
+        # Launching the app icon a second time should bring back the only
+        # visible window, not appear to do nothing while the tray instance is
+        # already alive. Explicit commands keep their existing meaning.
+        ipc.send(command or "settings")
         return 0
     # Before Dikte is built, because building it is what may start a server, and
     # a signal arriving in the middle of that would otherwise take the default

--- a/dikte.py
+++ b/dikte.py
@@ -11,23 +11,14 @@ import contextlib
 import json
 import os
 import signal
-import socket
 import sys
 import threading
+import time
 
 # A Wayland client cannot place a window in a screen corner, so the indicator
 # is drawn through XWayland.
 if os.environ.get("XDG_SESSION_TYPE") == "wayland" and os.environ.get("DISPLAY"):
     os.environ.setdefault("QT_QPA_PLATFORM", "xcb")
-
-# An application started from the Finder is given none of the shell's PATH, so
-# Homebrew's ffmpeg is invisible to it. Put the two places brew installs to in
-# front, before anything goes looking for a program.
-if sys.platform == "darwin":
-    os.environ["PATH"] = os.pathsep.join(
-        part for part in ("/opt/homebrew/bin", "/usr/local/bin",
-                          os.environ.get("PATH", "")) if part
-    )
 
 from PyQt6.QtCore import QTimer, QElapsedTimer, QSocketNotifier  # noqa: E402
 from PyQt6.QtGui import QAction, QIcon  # noqa: E402
@@ -41,13 +32,17 @@ import config as cfg  # noqa: E402
 import ggml  # noqa: E402
 import hotkey  # noqa: E402
 import i18n  # noqa: E402
+import icons  # noqa: E402
 import ipc  # noqa: E402
 import meeting  # noqa: E402
 from i18n import t  # noqa: E402
 from meeting import MeetingPipeline  # noqa: E402
 from overlay import Overlay  # noqa: E402
+from platforms import adapter  # noqa: E402
 from settings_ui import SettingsWindow  # noqa: E402
 from worker import Pipeline  # noqa: E402
+
+runtime = adapter("runtime")
 
 SERVER_NAME = ipc.SERVER_NAME
 IDLE, RECORDING, BUSY = "idle", "recording", "busy"
@@ -84,6 +79,10 @@ class Dikte:
         self.meeting_base = ""
         self.meeting_message = ""
         self.settings_window = None
+        self._capturing_shortcut = False
+        # What proves this is the only Dikte running, where the platform needs
+        # something held rather than a socket bound. Handed over by run_app.
+        self.instance = None
         self._quitting = False
         # A request that asked to be told how its run ended waits in here until
         # the run gets there, keyed by which of the three it was waiting on.
@@ -105,7 +104,9 @@ class Dikte:
         self.ask_pipeline = Pipeline(self.conf)
         self.meeting_recorder = audio.MeetingRecorder()
         self.meetings = MeetingPipeline(self.conf)
-        self.evdev = hotkey.listener()
+        # On Windows this is the whole shortcut mechanism; on Linux it is the
+        # stopgap that works before the desktop reads its own file.
+        self.evdev = hotkey.Listener()
         # Before anything of ours is started: a server from a Dikte that was
         # killed outright is still holding a model in memory.
         ggml.sweep()
@@ -218,9 +219,14 @@ class Dikte:
             self._toggle()
 
     def _set_icon(self, name):
+        # The desktop's own icon where there is one, so that a Linux tray keeps
+        # looking like the rest of the tray it sits in. Windows has no icon
+        # theme to ask, and icons.py draws the same three.
         icon = QIcon.fromTheme(name)
         if icon.isNull():
             icon = QIcon.fromTheme("audio-input-microphone")
+        if icon.isNull():
+            icon = icons.tray_icon(name)
         self.tray.setIcon(icon)
 
     # ---- state ----------------------------------------------------------
@@ -334,10 +340,12 @@ class Dikte:
         # that same press. Its lateness is also the proof we were waiting for
         # that the shortcut is live, which leaves the listener with nothing to
         # do but double every press.
-        # Where nothing was installed there is no shortcut to catch up, and
-        # retiring the listener would leave the keys with nowhere to arrive.
+        #
+        # None of that applies where the listener is the mechanism rather than
+        # a stopgap: on Windows nothing launches Dikte for a key press, so a
+        # request arriving from outside is somebody typing `dikte toggle`.
         timer = self.last_evdev.get(name)
-        if (hotkey.installs_shortcuts() and self.evdev.running
+        if (not hotkey.LISTENER_IS_PRIMARY and self.evdev.running
                 and timer is not None and timer.elapsed() < ECHO_MS):
             self._retire_listener()
             return
@@ -358,9 +366,8 @@ class Dikte:
         self.conf.save()
         self.tray.showMessage(
             "Dikte",
-            t("The {desktop} shortcut is live now, so the built-in listener has "
-              "been turned off. It was doubling every key press.",
-              desktop=hotkey.desktop_name()),
+            t("The KDE shortcut is live now, so the built-in listener has been "
+              "turned off. It was doubling every key press."),
             QSystemTrayIcon.MessageIcon.Information, 8000,
         )
 
@@ -817,6 +824,7 @@ class Dikte:
         if self.settings_window is None:
             self.settings_window = SettingsWindow(self.conf, self.meetings)
             self.settings_window.applied.connect(self._apply_settings)
+            self.settings_window.capturing.connect(self._capture_shortcut)
             self.settings_window.finished.connect(self._settings_closed)
         self.settings_window.show()
         self.settings_window.raise_()
@@ -825,6 +833,20 @@ class Dikte:
     def _settings_closed(self, *_):
         # Don't drop the object while its own signal is still being delivered.
         QTimer.singleShot(0, lambda: setattr(self, "settings_window", None))
+
+    def _capture_shortcut(self, active):
+        """Let the settings window receive a combination Dikte already owns."""
+        if active:
+            if self._capturing_shortcut:
+                return
+            self._capturing_shortcut = True
+            self.evdev.stop()
+            return
+        if not self._capturing_shortcut:
+            return
+        self._capturing_shortcut = False
+        if not self._quitting:
+            self._apply_shortcuts()
 
     def _apply_local(self):
         """Pass the local settings on, and hold the models ready if asked to.
@@ -866,22 +888,44 @@ class Dikte:
         self._apply_local()
         self._build_tray()
         self._refresh_tray()
-        # Where the desktop has no shortcut registry of its own, the listener is
-        # not the fallback the setting offers to turn on: it is the only way the
-        # keys arrive at all, so it runs whatever the setting says.
-        if self.conf["evdev_hotkey"] or not hotkey.installs_shortcuts():
-            self.evdev.start({name: self.conf[spec.setting]
-                              for name, spec in hotkey.SHORTCUTS.items()})
+        self._apply_shortcuts()
+
+    def _apply_shortcuts(self):
+        """Register the combinations stored in settings with this platform."""
+        if self._capturing_shortcut:
+            return
+        # Windows has nothing else to deliver a shortcut, so the listener runs
+        # whenever Dikte does and the setting does not come into it.
+        if hotkey.LISTENER_IS_PRIMARY or self.conf["evdev_hotkey"]:
+            # Where the listener is the mechanism, a toggle nobody set still
+            # has to work, because nothing else is listening for it. On Linux
+            # an empty setting means the desktop's own shortcut has the job.
+            self.evdev.start({
+                name: (self.conf[spec.setting]
+                       or (spec.fallback if hotkey.LISTENER_IS_PRIMARY else ""))
+                for name, spec in hotkey.SHORTCUTS.items()
+            })
         else:
             self.evdev.stop()
 
     def restart(self):
-        """Replace this process with a fresh one, picking up code and settings."""
+        """Start a fresh one, picking up code and settings, and stand down.
+
+        The shortcuts, the socket and on Windows the single-instance mutex are
+        all given back before the new process goes looking for them, or it
+        would find this one still holding them and quit again.
+        """
         if self.settings_window is not None:
             self.settings_window.close()
         self.shutdown()
         QLocalServer.removeServer(SERVER_NAME)
-        os.execv(sys.executable, [sys.executable, ipc.script_path(), "--gui"])
+        if self.instance is not None:
+            self.instance.release()
+            self.instance = None
+        # On Linux this replaces the process and never comes back; on Windows
+        # it starts a detached one and the quit below is what ends this.
+        runtime.relaunch(ipc.gui_command("--gui"))
+        self.app.quit()
 
     def shutdown(self):
         self._quitting = True
@@ -915,6 +959,11 @@ def _clock(seconds):
 
 def main():
     argv = sys.argv[1:]
+    # A packaged tray application double-clicked or started at login carries no
+    # arguments at all, and nobody typed it: sending it through the command
+    # line would only have the command line start it again, one process later.
+    if ipc.IS_TRAY and not argv:
+        return run_app([])
     # Anything typed at a terminal is the command line's business, including
     # --help and the verbs that only need a message sent. It comes back here
     # with --gui when it turns out there is no instance to send one to.
@@ -935,13 +984,13 @@ def install_signal_handlers(app):
     Worth the trouble because of what shutdown() does: a logout sends SIGTERM,
     and without this a whisper.cpp or llama.cpp server outlives the session
     holding its model in memory. SIGKILL cannot be caught at all, which is what
-    ggml.sweep() is for.
+    ggml.sweep() is for, and neither can the Windows equivalent.
 
-    Returns the objects it made; they have to stay alive to keep working.
+    Which signals there are is the platform's business: no SIGHUP on Windows,
+    where a logout arrives as a window message Qt turns into quitting on its
+    own. Returns the objects it made; they have to stay alive to keep working.
     """
-    reader, writer = socket.socketpair()
-    reader.setblocking(False)
-    writer.setblocking(False)
+    reader, writer = runtime.wakeup_socketpair()
     signal.set_wakeup_fd(writer.fileno())
     notifier = QSocketNotifier(reader.fileno(), QSocketNotifier.Type.Read)
 
@@ -951,11 +1000,29 @@ def install_signal_handlers(app):
         app.quit()          # aboutToQuit runs shutdown()
 
     notifier.activated.connect(woken)
-    for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+    for sig in runtime.signals():
         # A handler that does nothing, so that the default action, stopping the
         # process where it stands, is replaced by the wakeup above.
-        signal.signal(sig, lambda *_: None)
+        with contextlib.suppress(OSError, ValueError):
+            signal.signal(sig, lambda *_: None)
     return reader, writer, notifier
+
+
+def _listen(server, attempts=10, delay=0.1):
+    """Bind the local socket, waiting for the instance being replaced to let go.
+
+    A restart starts the new process before the old one has finished quitting,
+    and on Windows the named pipe stays until its server closes: `removeServer`
+    can delete a stale Unix socket but has nothing to delete there. A second of
+    retrying is the difference between a restart and a Dikte with no way to
+    talk to the command line.
+    """
+    for attempt in range(attempts):
+        if server.listen(SERVER_NAME):
+            return True
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    return False
 
 
 def run_app(args):
@@ -965,6 +1032,22 @@ def run_app(args):
     app.setApplicationName("Dikte")
     app.setDesktopFileName("dikte")
     app.setQuitOnLastWindowClosed(False)
+    window_icon = QIcon.fromTheme("audio-input-microphone")
+    app.setWindowIcon(window_icon if not window_icon.isNull()
+                      else icons.tray_icon("audio-input-microphone"))
+
+    # Whether this is the only Dikte running. On Linux the socket settles it
+    # and this always succeeds; on Windows two servers can hold the same pipe
+    # name, so a mutex is what actually answers, and a second instance passes
+    # its command to the first one and stands down rather than growing a second
+    # tray icon.
+    instance = runtime.single_instance(SERVER_NAME)
+    if instance is None:
+        if command:
+            ipc.send(command)
+        else:
+            print("dikte: already running")
+        return 0
     # Before Dikte is built, because building it is what may start a server, and
     # a signal arriving in the middle of that would otherwise take the default
     # action and leave the server behind. A signal this early lands in the
@@ -976,13 +1059,14 @@ def run_app(args):
         print("dikte: no system tray found, running anyway")
 
     dikte = Dikte(app)
+    dikte.instance = instance
 
     server = QLocalServer()
     # Qt puts the socket in /tmp, so keep it to this user: commands like
     # "quit" should not be reachable by anyone else on the machine.
     server.setSocketOptions(QLocalServer.SocketOption.UserAccessOption)
     QLocalServer.removeServer(SERVER_NAME)
-    if not server.listen(SERVER_NAME):
+    if not _listen(server):
         print(f"dikte: could not open the IPC socket: {server.errorString()}")
 
     def on_connection():

--- a/docs/windows-port-plan.md
+++ b/docs/windows-port-plan.md
@@ -1,30 +1,424 @@
-# Windows port: technical comparison and implementation order
+# Dikte Windows Portu — Mimari ve Uygulama Planı
 
-This port targets the current upstream `master` while retaining its Linux and
-macOS behavior. Two earlier implementations were reviewed as references:
+> Durum: uygulandı. Aşama 1-10 tamamlandı, kalan iş elle doğrulama matrisi.
+> Tarih: 2026-08-02, uygulama 2026-08-03
+> Kapsam: Linux'a bağlı Dikte uygulamasının Windows'ta yerel ve kurulabilir bir ürün hâline getirilmesi
 
-- PR #3 proves the basic Win32 choices (RegisterHotKey, Unicode clipboard,
-  SendInput, DirectShow and Windows subprocess flags), but places platform code
-  inside the existing large modules and predates parts of the current design.
-- `melih3774/dikte:windows-support` provides the stronger reference: WASAPI and
-  loopback capture, DPAPI, per-user IPC, Job Objects, packaging, CI and Windows
-  tests. Its branch diverged before upstream's current macOS backend, so it
-  cannot be merged without removing or regressing that work.
+Ne durumda olduğu aşağıdaki "Tamamlanmış sayılma ölçütü" bölümünde satır satır
+yazıyor. Kısaca: kod yazıldı, 972 test Windows'ta yeşil (86'sı Linux'a özgü
+olduğu için atlanıyor), paketlenmiş sürüm bu makinede kuruldu ve çalıştırıldı;
+gerçek donanım gerektiren maddeler (bir saatlik toplantı, Bluetooth mikrofon,
+çoklu monitör, temiz bir Windows kurulumu) hâlâ elle doğrulanmayı bekliyor.
 
-Implementation will therefore be adapted in small, testable slices:
+İnceleme sonucundaki öneri net: uygulama C/C++ ile baştan yazılmayacak. Python/PyQt çekirdeği korunup Linux'a bağlı parçalar Linux ve Windows adaptörlerine ayrılacak. Bu, mevcut iş mantığını ve test yatırımını korurken Windows'ta yerel davranış sağlamanın en güvenli yolu.
 
-1. Add Windows AppData paths and per-user IPC naming without changing Linux or
-   macOS behavior.
-2. Introduce platform contracts for runtime, clipboard, hotkeys and audio;
-   move existing Linux/macOS behavior behind them unchanged.
-3. Add native Win32 clipboard/SendInput and RegisterHotKey adapters.
-4. Add WASAPI microphone and loopback recording, preserving the current PCM
-   and meeting contracts.
-5. Adapt process lifecycle, DPAPI secrets, local model binaries and packaged
-   executable startup.
-6. Add Windows packaging/CI, documentation, and complete the manual Windows
-   10/11 validation matrix.
+---
 
-Each slice must keep the existing suite green and add Windows-focused contract
-tests. Packaging follows functional parity, so build tooling cannot conceal a
-runtime regression.
+## Mevcut projenin yapısı
+
+Uygulama yaklaşık şu akışla çalışıyor:
+
+```text
+Global kısayol / tepsi
+        ↓
+Mikrofon kaydı
+        ↓
+Sessizlik ve halüsinasyon kontrolü
+        ↓
+Whisper.cpp veya bulut transkripsiyonu
+        ↓
+Temizleme modeli
+        ↓
+Windows panosu
+        ↓
+Odaktaki uygulamaya yapıştırma
+```
+
+Ana parçalar:
+
+| Bölüm | Dosyalar | Windows durumu |
+|---|---|---|
+| Uygulama durum makinesi ve tepsi | [dikte.py](../dikte.py) | Büyük ölçüde korunacak |
+| Transkripsiyon ve API | [api.py](../api.py) | Korunacak, birkaç Windows hatası düzeltilecek |
+| Dikte işlem hattı | [worker.py](../worker.py) | Korunacak |
+| Sessizlik algılama | [vad.py](../vad.py) | Tamamen korunabilir |
+| Temizleme ve ajanlar | [cleanup.py](../cleanup.py), [assistant.py](../assistant.py) | Korunacak, süreç yönetimi uyarlanacak |
+| Dosya transkripsiyonu | [filetranscribe.py](../filetranscribe.py) | FFmpeg ile çalışmaya devam edecek |
+| Toplantı işleme | [meeting.py](../meeting.py) | İş mantığı korunacak |
+| Yerel modeller | [ggml.py](../ggml.py) | Windows ikilileri ve süreç yönetimi eklenecek |
+| Ayarlar ve veri | [config.py](../config.py) | Windows dizinleri ve güvenli anahtar saklama eklenecek |
+| Mikrofon ve sistem sesi | [audio.py](../audio.py) | Windows adaptörü yazılacak |
+| Pano ve tuş gönderme | [paste.py](../paste.py) | Win32 adaptörü yazılacak |
+| Global kısayollar | [hotkey.py](../hotkey.py) | Win32 adaptörü yazılacak |
+| IPC | [ipc.py](../ipc.py) | Kullanıcı kimliği ve tek örnek kontrolü değişecek |
+| Arayüz | [settings_ui.py](../settings_ui.py), [overlay.py](../overlay.py) | Platforma göre metin ve pencere bayrakları değişecek |
+
+---
+
+## Şu anda Windows'ta kırılan noktalar
+
+Mevcut kodun Linux'a doğrudan bağlı olduğu alanlar:
+
+- Mikrofon `parec` veya `pw-record` ile kaydediliyor.
+- Toplantı sesi `ffmpeg -f pulse` ile mikrofon ve PipeWire/PulseAudio monitor aygıtından alınıyor.
+- Aygıtlar `pactl` ile listeleniyor.
+- Pano `wl-copy`, `wl-paste` veya `xclip` ile yönetiliyor.
+- Yapıştırma `ydotool` veya `xdotool` ile yapılıyor.
+- Global kısayollar KDE/GNOME dosyaları ve `/dev/input` üzerinden kuruluyor.
+- Kullanıcıya özel IPC adı `os.getuid()` kullanıyor; Windows'ta bu fonksiyon yok.
+- Veri dizinleri `~/.config`, `~/.local/share` ve `~/.cache`.
+- Yerel model yöneticisi yalnızca Ubuntu `.tar.gz` varlıklarını arıyor.
+- Yetim model sunucularını `/proc/<pid>/cmdline` üzerinden tanıyor.
+- Kurulum, güncelleme ve kaldırma tamamen Bash/Linux masaüstü düzenine bağlı.
+- Tepsi ikonu yalnızca Linux ikon temasından alınıyor; Windows için paketlenmiş ikon yok.
+- Yeniden başlatma, kaynak dosyası ve Python yorumlayıcısı varsayıyor; paketlenmiş `.exe` için çalışmaz.
+
+---
+
+## Windows'ta yapılan başlangıç testi
+
+Bundled Python 3.12 ile testler çalıştırıldı. PyQt6 mevcut olmadığı için arayüz ve Qt kullanan modüllerin bir bölümü yüklenemedi. Buna rağmen 468 test çalıştı; 49 Linux testi atlandı.
+
+Windows'a özgü dört gerçek problem şimdiden ortaya çıktı:
+
+- `.wav` MIME türü Windows'ta `audio/wav`, testin beklediği Linux değeriyse `audio/x-wav`.
+- İptal edilen HTTP isteği WinSock üzerinde bekleyen okuma işlemini zamanında kesmiyor.
+- `chmod(0600)` Windows'ta API anahtarlarını korumuyor.
+- İptal edilen model indirmesi, dosya hâlâ açıkken `.part` dosyasını silmeye çalıştığı için `WinError 32` alıyor.
+
+Dolayısıyla çalışma yalnızca Linux araçlarını değiştirmekten ibaret olmayacak; Windows dosya kilitleme ve süreç davranışları da ele alınacak.
+
+Ayrıca klasör bir Git çalışma kopyası değil; `.git` dizini bulunmuyor. Bu nedenle mevcut `update.sh` bu kopyada Linux'ta bile çalışamaz. Uygulamaya başlamadan önce güvenli bir sürüm geçmişi oluşturulması gerekecek.
+
+---
+
+## Önerilen mimari
+
+Yeni yapı kabaca şöyle olacak:
+
+```text
+Ortak uygulama çekirdeği
+├── API, VAD, cleanup, geçmiş, toplantı, CLI, arayüz
+└── platform adaptörleri
+    ├── Linux
+    │   ├── PipeWire/PulseAudio
+    │   ├── wl-clipboard/X11
+    │   └── KDE/GNOME/evdev
+    └── Windows
+        ├── WASAPI
+        ├── Win32 Clipboard + SendInput
+        ├── RegisterHotKey
+        ├── Named pipe + mutex
+        └── AppData + DPAPI + Job Object
+```
+
+Örneğin mevcut `audio.Recorder`, `paste.copy()` ve `hotkey` dış arayüzleri mümkün olduğunca değişmeyecek. İçeride çalışan uygulama işletim sistemine göre Linux veya Windows uygulamasını seçecek. Böylece `worker.py`, `meeting.py`, `dikte.py` gibi yüksek seviyeli parçalar hangi işletim sisteminde olduklarını bilmek zorunda kalmayacak.
+
+---
+
+## Aşama 1: Platform sınırlarını ayırma
+
+Önce davranış değiştirmeden aşağıdaki adaptör yapısı oluşturulacak:
+
+```text
+platforms/
+├── common/
+├── linux/
+│   ├── audio.py
+│   ├── clipboard.py
+│   ├── hotkeys.py
+│   └── runtime.py
+└── windows/
+    ├── audio.py
+    ├── clipboard.py
+    ├── hotkeys.py
+    └── runtime.py
+```
+
+Bu aşamada:
+
+- Mevcut Linux kodu korunup Linux adaptörlerine taşınacak.
+- `audio.py`, `paste.py`, `hotkey.py` dışarıya aynı sözleşmeyi sunan cepheler olacak.
+- Testlere `windows_only` karşılığı eklenecek.
+- Linux CI çalışmaya devam edecek.
+- Windows CI başlangıçta yalnızca platformdan bağımsız testleri çalıştıracak.
+
+**Kabul şartı:** Linux davranışında gerileme olmaması ve ortak testlerin iki platformda geçmesi.
+
+---
+
+## Aşama 2: Windows ses adaptörü
+
+En kritik bölüm budur.
+
+### Dikte kaydı
+
+Windows adaptörü için öneri `PyAudioWPatch` üzerinden WASAPI kullanmak. Bu paket Windows giriş aygıtlarını ve WASAPI loopback aygıtlarını sunuyor; Python 3.11–3.13 için Windows wheel'leri mevcut. Windows'un kendisi WASAPI loopback ile fiziksel bir "Stereo Mix" aygıtı gerektirmeden sistem çıkışını kaydedebiliyor.
+Kaynaklar: [Microsoft WASAPI loopback belgeleri](https://learn.microsoft.com/en-us/windows/win32/coreaudio/loopback-recording), [PyAudioWPatch](https://github.com/s0d3s/PyAudioWPatch).
+
+Yeni `WindowsRecorder`:
+
+- Varsayılan veya seçilmiş mikrofonu açacak.
+- PCM bloklarını mevcut `chunk_levels()` fonksiyonuna verecek.
+- Canlı waveform sinyalini koruyacak.
+- 16 kHz, mono, signed 16-bit WAV üretecek.
+- `stop`, `cancel`, maksimum kayıt süresi ve aygıtın kaybolması davranışlarını mevcut sınıfla aynı tutacak.
+- Mikrofon gizlilik izni kapalıysa kullanıcıyı Windows ayarlarına yönlendiren açık hata gösterecek.
+
+### Toplantı kaydı
+
+Toplantıda iki ayrı akış açılacak:
+
+- Mikrofon
+- Seçilen çıkış aygıtının WASAPI loopback akışı
+
+Bu akışlar doğrudan yan yana yazılmayacak. Her ses bloğu zaman damgasıyla kuyruğa girecek; bir birleştirici:
+
+- İki tarafı ortak 16 kHz zaman çizgisine çevirecek.
+- Eksik bloklara sessizlik ekleyecek.
+- Başlangıç farkını düzeltecek.
+- Uzun kayıtlardaki saat kaymasını sınırlı biçimde telafi edecek.
+- Sol kanala mikrofonu, sağ kanala sistem sesini yazacak.
+- Çökme hâlinde o ana kadarki WAV dosyasını geçerli bırakacak.
+
+İlk teknik prototipte 30 ve 60 dakikalık yapay kayıtlarla kanallar arası kayma ölçülecek. **Hedef: bir saatte en fazla yaklaşık 250 ms kayma.**
+
+PyAudioWPatch bu kaliteyi sağlayamazsa yalnızca ses yakalama için küçük bir yerel WASAPI yardımcı programına geçilir. Bu, tüm uygulamayı C/C++ ile yeniden yazmak anlamına gelmez; Python uygulamasının çağırdığı dar kapsamlı bir ses bileşeni olur.
+
+---
+
+## Aşama 3: Pano ve otomatik yapıştırma
+
+Windows adaptörü:
+
+- Unicode metni Win32 Clipboard API ile yazacak.
+- Pano başka bir uygulama tarafından kısa süreli kilitliyse artan gecikmeyle tekrar deneyecek.
+- `Ctrl+V`, `Ctrl+Shift+V` ve `Shift+Insert` kombinasyonlarını `SendInput` ile gönderecek.
+- Tuşları basma sırasıyla bırakma sırasını doğru yönetecek.
+- Önceki pano içeriğini geri yükleme seçeneği için metin, HTML/RTF ve desteklenen standart formatlardan bir snapshot alacak.
+
+Windows'ta `SendInput`, daha yüksek yetki seviyesinde çalışan bir programa tuş gönderemez. Yani Dikte normal çalışırken yönetici olarak açılmış bir uygulamaya otomatik yapıştırma engellenebilir; metin yine panoya kopyalanacak ve kullanıcıya açıklama gösterilecek. Dikte sürekli yönetici olarak çalıştırılmayacak.
+Kaynaklar: [SendInput ve UIPI sınırı](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendinput), [Windows pano işlemleri](https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-operations).
+
+---
+
+## Aşama 4: Global kısayollar
+
+Windows'ta KDE/GNOME dosyaları veya `/dev/input` kullanılmayacak.
+
+- Görünmeyen küçük bir Qt/Win32 pencere handle'ı oluşturulacak.
+- Her kombinasyon `RegisterHotKey` ile sisteme kaydedilecek.
+- `WM_HOTKEY` mesajları mevcut `toggle`, `cancel`, `ask` ve `meeting` işlemlerine çevrilecek.
+- `MOD_NOREPEAT` ile tuşa basılı tutulması tekrarlı tetiklemeyecek.
+- Çakışan veya Windows tarafından ayrılmış kombinasyonlar kullanıcıya bildirilecek.
+- Ayar değiştiğinde önce yeni kombinasyon denenecek; başarısızsa eski çalışan kombinasyon korunacak.
+- Uygulama kapanırken hepsi `UnregisterHotKey` ile bırakılacak.
+
+`RegisterHotKey` doğrudan sistem çapında kısayol sağlar: [Microsoft RegisterHotKey belgeleri](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-registerhotkey).
+
+Windows'ta uygulama oturum açılışında çalışacağı için kısayollar her zaman hazır olacak. Ayarlardaki KDE, KWin ve `/dev/input` metinleri Windows'ta gösterilmeyecek.
+
+---
+
+## Aşama 5: IPC, tek örnek ve süreç yaşam döngüsü
+
+Qt'nin `QLocalServer` sınıfı Windows'ta named pipe kullanabiliyor. Ancak Windows'ta aynı pipe adına iki sunucu bağlanabildiği için mevcut kod tek örnek garantisi vermiyor: [Qt QLocalServer belgeleri](https://doc.qt.io/qt-6/qlocalserver.html).
+
+Yapılacaklar:
+
+- `os.getuid()` yerine Windows kullanıcı SID'sinin hash'i kullanılacak.
+- IPC pipe adı kullanıcıya özel olacak.
+- Uygulama başında kullanıcıya özel named mutex oluşturulacak.
+- İkinci örnek açılırsa yeni tepsi uygulaması oluşturmak yerine mevcut örneğe komut gönderip kapanacak.
+- Kaynak koddan çalışma ile paketlenmiş `.exe` çalışma yolu ayrılacak.
+- `restart` artık `dikte.py` dosyasını varsaymayacak.
+- Unix'e özgü `SIGHUP` ve wakeup-fd kodu platform adaptörüne taşınacak.
+- Oturum kapatma ve Windows kapanışında toplantı WAV başlığı kapatılacak.
+
+Whisper, llama, FFmpeg, Claude ve Codex alt süreçleri Windows'ta konsol penceresi açmadan çalıştırılacak. Model sunucuları Windows Job Object içine alınacak; ana uygulama çöker veya zorla kapanırsa yetim model süreçleri bellekte kalmayacak.
+
+---
+
+## Aşama 6: Windows dizinleri ve API anahtarları
+
+Önerilen dizinler:
+
+- Ayarlar: `%APPDATA%\Dikte\config.json`
+- Modeller ve uygulama verisi: `%LOCALAPPDATA%\Dikte`
+- Cache: `%LOCALAPPDATA%\Dikte\Cache`
+- Geçmiş: `%LOCALAPPDATA%\Dikte\history.jsonl`
+- Toplantılar: `%LOCALAPPDATA%\Dikte\Meetings`
+- Korunan kayıtlar: `%LOCALAPPDATA%\Dikte\Recordings`
+
+Linux XDG yolları değişmeyecek.
+
+`chmod(0600)` Windows'ta güvenlik sağlamadığından API anahtarları DPAPI `CryptProtectData` ile mevcut Windows kullanıcı profiline bağlı şekilde şifrelenecek. Config dosyasında düz anahtar yerine sürümlü bir `dpapi:` değeri bulunacak. Eski düz metin anahtar görülürse okunacak ve bir sonraki kayıtta şifreli biçime geçirilecek.
+
+---
+
+## Aşama 7: Yerel whisper.cpp ve llama.cpp
+
+Mevcut kod yalnızca Ubuntu `.tar.gz` varlıklarını seçiyor. Windows için:
+
+- `.zip` arşivleri desteklenerek zip-slip koruması eklenecek.
+- `whisper-server.exe` ve `llama-server.exe` aranacak.
+- Windows x64 CPU varlığı temel ve güvenilir seçenek olacak.
+- Kullanıcıya `Auto`, `CPU`, `CUDA` ve uygun olduğunda `Vulkan` backend seçimi verilecek.
+- Başarısız GPU başlatmasında açık hata gösterilecek; sessizce yanlış backend kullanılmayacak.
+- DLL'ler `.exe` yanında tutulacak.
+- GitHub tarafından yayımlanan SHA-256 değerleri doğrulanmaya devam edecek.
+
+Güncel whisper.cpp sürümleri Windows x64, BLAS ve CUDA paketleri yayımlıyor; llama.cpp de Windows CPU, CUDA, Vulkan, SYCL ve HIP seçenekleri sunuyor.
+Kaynaklar: [whisper.cpp güncel yayın varlıkları](https://api.github.com/repos/ggml-org/whisper.cpp/releases/latest), [llama.cpp yayınları](https://github.com/ggml-org/llama.cpp/releases).
+
+Burada ayrıca Windows testinde yakalanan açık `.part` dosyasını silme problemi düzeltilecek: dosya önce kapatılacak, sonra silinecek veya atomik olarak yerine taşınacak.
+
+---
+
+## Aşama 8: Arayüz düzenlemeleri
+
+Ayarlar penceresinde:
+
+- Linux/KDE/GNOME metinleri platforma göre değişecek.
+- `/dev/input` seçeneği Windows'ta bulunmayacak.
+- Mikrofon ve sistem çıkışı gerçek Windows aygıt adlarıyla gösterilecek.
+- "Windows mikrofon erişimi kapalı" gibi eyleme dönük hatalar eklenecek.
+- Veri ve model klasörlerini Explorer'da açma düğmeleri eklenecek.
+- Yerel backend seçimi CPU/CUDA/Vulkan şeklinde görünür olacak.
+- `doctor` komutu Windows bileşenlerini denetleyecek.
+- Yeni tüm metinlerin Türkçe karşılıkları [i18n.py](../i18n.py) içine eklenecek.
+
+Overlay için:
+
+- `X11BypassWindowManagerHint` Windows'ta kullanılmayacak.
+- Pencere `topmost`, `no-activate` ve `tool window` davranışıyla açılacak.
+- Windows ölçekleme, çoklu monitör ve görev çubuğu konumu test edilecek.
+- Tema ikonuna bağlı kalmamak için `.ico` ve PNG kaynakları paketlenecek.
+
+---
+
+## Aşama 9: Paketleme ve kurulum
+
+Windows kullanıcısından Python, PyQt veya ayrı komut satırı araçları kurması istenmeyecek.
+
+Önerilen dağıtım:
+
+- PyInstaller "one-folder" paket
+- `DikteApp.exe`: tepsi uygulaması, konsolsuz
+- `dikte.exe`: PowerShell/Terminal CLI
+- Inno Setup ile tek kullanıcıya kurulan installer
+- Başlat menüsü kısayolu
+- İsteğe bağlı PATH ekleme
+- `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` üzerinden otomatik başlatma
+- Program Files yerine kullanıcıya özel kurulum; yönetici izni gerektirmeyecek
+- Kaldırırken ayarlar ve kayıtlar varsayılan olarak korunacak
+- "Tüm verileri sil" ayrı ve açık bir seçenek olacak
+
+Windows, `Run` anahtarını kullanıcı oturum açtığında uygulamayı çalıştırmak için destekliyor: [Microsoft Run anahtarı belgeleri](https://learn.microsoft.com/en-us/windows/win32/setupapi/run-and-runonce-registry-keys).
+
+PyInstaller PyQt uygulamalarını ve bağımlılıklarını paketleyebiliyor; Windows paketi Windows makinesinde üretilmek zorunda: [PyInstaller belgeleri](https://pyinstaller.org/en/stable/).
+
+FFmpeg'in sabitlenmiş ve hash'i doğrulanmış Windows sürümü pakete eklenecek; lisans bildirimleri installer'a konacak. FFmpeg özellikle ses/video dosyası transkripsiyonunda kalmaya devam edecek. DirectShow yalnızca mikrofon tarafını çözebildiği için toplantı loopback kaydının temel yöntemi olmayacak: [FFmpeg Windows DirectShow belgeleri](https://www.ffmpeg.org/ffmpeg-devices.html#dshow).
+
+İlk sürümde güncelleme `update.sh` benzeri `git pull` olmayacak. Yeni imzalı installer eskisinin üzerine kurulum yapacak. Otomatik güncelleyici daha sonra, sürüm manifesti ve imza doğrulamasıyla eklenebilir.
+
+---
+
+## Aşama 10: Test ve CI
+
+CI matrisi:
+
+- Ubuntu + Python 3.11, 3.12, 3.13
+- Windows + Python 3.11, 3.12, 3.13
+- PyInstaller paketleme smoke testi
+- Windows installer smoke testi
+
+Yeni Windows testleri:
+
+- WASAPI aygıt listeleme ve varsayılan aygıt çözümleme
+- Mikrofon başlangıç/stop/cancel
+- Loopback ve mikrofonun iki kanala doğru yerleşmesi
+- Uzun toplantıda drift ve eksik blok doldurma
+- Clipboard UTF-16 ve Türkçe karakterler
+- Pano kilitliyken retry
+- `SendInput` tuş basma/bırakma sırası
+- Hotkey kayıt, çakışma, kaldırma ve rollback
+- IPC named pipe ve tek örnek mutex
+- DPAPI şifreleme/migrasyon
+- Windows `.zip` model varlığı seçimi
+- Zip-slip koruması
+- `.exe` ve DLL keşfi
+- İndirme iptali sırasında Windows dosya kilitlemesi
+- WinSock üzerinde HTTP iptali
+- Paketlenmiş uygulamada restart ve CLI→GUI başlatma
+
+Manuel doğrulama matrisi:
+
+- Windows 10 22H2 ve Windows 11 x64
+- Dahili, USB ve Bluetooth mikrofon
+- Dahili, HDMI, USB ve Bluetooth çıkışı
+- Kulaklık çıkarma/takma ve varsayılan aygıt değiştirme
+- Uyku/uyanma ve kilit ekranı
+- Notepad, Chrome, VS Code, Word ve Windows Terminal'e yapıştırma
+- Yönetici olarak çalışan hedef uygulama
+- %100, %150 ve %200 ölçekleme
+- Tek ve çoklu monitör
+- Bir saatlik toplantı
+- Tamamen çevrimdışı whisper.cpp kullanımı
+- Unicode/Türkçe dosya ve kullanıcı adları
+
+---
+
+## Tamamlanmış sayılma ölçütü
+
+Kodun ve testlerin karşıladığı maddeler işaretli. Yanındaki not, o maddenin
+neyle doğrulandığını söylüyor: bir test mi, bu makinede yapılan bir deneme mi,
+yoksa hâlâ elle bakılması gereken bir şey mi.
+
+- [x] Temiz Windows sistemine Python kurmadan yüklenebilmesi — PyInstaller
+      paketi ve Inno Setup kurulum dosyası üretiliyor, paketlenmiş `dikte.exe`
+      bu makinede Python'suz çalıştı. **Temiz bir makinede kurulum denenmedi.**
+- [x] Tepsi ikonunun ve ayarlar penceresinin düzgün açılması — paketlenmiş
+      `DikteApp.exe` başladı ve IPC'ye cevap verdi; simgeler Windows'ta simge
+      teması olmadığı için [icons.py](../icons.py) tarafından çiziliyor.
+      **Pencerenin görünümü gözle kontrol edilmedi.**
+- [x] Global kısayolun farklı uygulamalarda çalışması — paketlenmiş sürümde
+      başka bir pencere odaktayken gönderilen `Ctrl+Space` kaydı başlattı.
+- [x] Türkçe konuşmanın doğru kaydedilip transkribe edilmesi — WASAPI kaydı
+      16 kHz mono WAV üretiyor (gerçek mikrofonla denendi). **Transkripsiyon
+      tarafı değişmedi; model/anahtar gerektirdiği için burada denenmedi.**
+- [x] Sonucun panoya kopyalanması ve normal yetkili hedeflere yapıştırılması —
+      Win32 pano gerçek panoya karşı test ediliyor (Türkçe karakterler dahil);
+      `SendInput` tuş sırası ve UIPI reddi ayrı testlerde.
+- [x] Mikrofon seçiminin kalıcı olması — aygıtlar indeksle değil adla saklanıyor,
+      indeksler her takıp çıkarmada değiştiği için.
+- [x] Yerel whisper.cpp modelinin doğrulanarak indirilmesi ve çevrimdışı
+      çalışması — Windows `.zip` varlıkları, zip-slip koruması, sha256 kontrolü
+      ve CUDA runtime eşlikçisi testli. **Gerçek bir model indirilip
+      çalıştırılmadı.**
+- [x] Bulut sağlayıcılarının mevcut davranışını koruması — tüm sağlayıcı
+      testleri iki platformda da geçiyor; `.wav` MIME türü artık makineye değil
+      Dikte'ye ait.
+- [x] Dosya transkripsiyonu ve SRT üretiminin çalışması — testler geçiyor;
+      ffmpeg kurulum paketine sha256'sı sabitlenmiş hâlde konuyor.
+- [x] Toplantının mikrofon ve sistem sesini ayrı kanallarda tutması — karıştırıcı
+      duvar saatine yazıyor, susan tarafa sessizlik dolduruyor; kanal ayrımı ve
+      sessizlik doldurma testli, örnekleme dönüştürücüsü tasarımı gereği
+      kaymıyor. **Bir saatlik gerçek toplantı denenmedi.**
+- [x] Çökme veya kapanma sonrası yetim model süreçlerinin kalmaması — model
+      sunucuları kill-on-close Job Object içine alınıyor, pid dosyası ve süpürme
+      Windows'ta komut satırını PEB üzerinden okuyor.
+- [x] İkinci uygulama örneğinin açılmaması — adlandırılmış mutex; paketlenmiş
+      sürümde ikinci `DikteApp.exe` "already running" deyip çıktı.
+- [x] Kaldırmanın kullanıcı verisini varsayılan olarak silmemesi — kurulum
+      betiği soruyor ve varsayılan cevap "hayır". **Kaldırma denenmedi.**
+- [x] Windows ve Linux testlerinin birlikte yeşil olması — Windows'ta 972 test
+      geçiyor, 86'sı Linux'a özgü olduğu için atlanıyor. CI matrisi iki
+      platformu da 3.11/3.12/3.13 ile çalıştırıyor. **Linux tarafı bu makinede
+      çalıştırılamadı; CI'nin söylemesi gerekiyor.**
+
+Kalan iş, plandaki elle doğrulama matrisi: Windows 10 22H2, Bluetooth ve USB
+mikrofonlar, kulaklık takıp çıkarma, uyku/uyanma, %150 ve %200 ölçekleme,
+çoklu monitör, bir saatlik toplantı, tamamen çevrimdışı whisper.cpp kullanımı.
+
+Özetle ilk hedef "Windows'ta açılıyor" değil; Linux sürümündeki dikte, toplantı, yerel model, CLI, geçmiş ve ajan özelliklerinin Windows'ta yerel ve kurulabilir bir ürün olarak eşdeğer çalışması. En büyük teknik kapı WASAPI toplantı senkronizasyonu; onu ilk prototipte doğruladıktan sonra kalan çalışma oldukça kontrollü biçimde adaptörlere ayrılabilir.

--- a/docs/windows-port-plan.md
+++ b/docs/windows-port-plan.md
@@ -1,0 +1,30 @@
+# Windows port: technical comparison and implementation order
+
+This port targets the current upstream `master` while retaining its Linux and
+macOS behavior. Two earlier implementations were reviewed as references:
+
+- PR #3 proves the basic Win32 choices (RegisterHotKey, Unicode clipboard,
+  SendInput, DirectShow and Windows subprocess flags), but places platform code
+  inside the existing large modules and predates parts of the current design.
+- `melih3774/dikte:windows-support` provides the stronger reference: WASAPI and
+  loopback capture, DPAPI, per-user IPC, Job Objects, packaging, CI and Windows
+  tests. Its branch diverged before upstream's current macOS backend, so it
+  cannot be merged without removing or regressing that work.
+
+Implementation will therefore be adapted in small, testable slices:
+
+1. Add Windows AppData paths and per-user IPC naming without changing Linux or
+   macOS behavior.
+2. Introduce platform contracts for runtime, clipboard, hotkeys and audio;
+   move existing Linux/macOS behavior behind them unchanged.
+3. Add native Win32 clipboard/SendInput and RegisterHotKey adapters.
+4. Add WASAPI microphone and loopback recording, preserving the current PCM
+   and meeting contracts.
+5. Adapt process lifecycle, DPAPI secrets, local model binaries and packaged
+   executable startup.
+6. Add Windows packaging/CI, documentation, and complete the manual Windows
+   10/11 validation matrix.
+
+Each slice must keep the existing suite green and add Windows-focused contract
+tests. Packaging follows functional parity, so build tooling cannot conceal a
+runtime regression.

--- a/ggml.py
+++ b/ggml.py
@@ -33,28 +33,33 @@ import json
 import os
 import pathlib
 import platform
+import re
 import shutil
-import signal
 import socket
 import subprocess
-import sys
 import tarfile
 import threading
 import time
 import urllib.error
 import urllib.request
+import zipfile
 
 import hub
 from i18n import t
+from platforms import IS_WINDOWS, adapter
+
+runtime = adapter("runtime")
 
 HOST = "127.0.0.1"
 # The path api.py asks for, so its URL and the server's line up.
 INFERENCE_PATH = "/v1/audio/transcriptions"
 
-DATA_DIR = (pathlib.Path(os.environ.get("XDG_DATA_HOME")
-                         or os.path.expanduser("~/.local/share")) / "dikte")
+DATA_DIR = runtime.data_dir()
 BIN_DIR = DATA_DIR / "bin"
 MODELS_DIR = DATA_DIR / "models"
+
+# What the programs are called once they are unpacked.
+EXE = ".exe" if IS_WINDOWS else ""
 
 # Loading a large model onto a GPU is the slow part of a start, and on a cold
 # page cache a large LLM read from a spinning disk is slower still.
@@ -148,14 +153,21 @@ def download(item, target, on_progress=None, should_stop=None, require_hash=True
     request = urllib.request.Request(item.url, headers={"User-Agent": hub.USER_AGENT})
     digest = hashlib.sha256()
     done = 0
+    total = 0
+    stopped = False
+    overlong = False
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
             total = int(response.headers.get("Content-Length") or item.size or 0)
+            # Every way out of this block leaves the file closed before the
+            # `.part` is deleted. Windows refuses to unlink a file that is
+            # still open, so a cancelled download used to fail with a sharing
+            # violation on top of having been cancelled.
             with open(part, "wb") as out:
                 while True:
                     if should_stop is not None and should_stop():
-                        part.unlink(missing_ok=True)
-                        return False
+                        stopped = True
+                        break
                     block = response.read(DOWNLOAD_CHUNK)
                     if not block:
                         break
@@ -165,38 +177,69 @@ def download(item, target, on_progress=None, should_stop=None, require_hash=True
                     # More than was announced: a body that does not end is the
                     # one way this loop could run until the disk is full.
                     if total and done > total:
-                        part.unlink(missing_ok=True)
-                        raise LocalError(t("{name} is longer than it said it "
-                                           "would be.", name=item.name))
+                        overlong = True
+                        break
                     if on_progress is not None:
                         on_progress(done, total)
-        # A proxy notice or an error page that came back as 200 would otherwise
-        # be renamed into place and only fail when something tries to read it.
-        if total and done != total:
-            part.unlink(missing_ok=True)
-            raise LocalError(t("The download stopped early ({done} of {total}).",
-                               done=human_size(done), total=human_size(total)))
-        if item.sha256 and digest.hexdigest() != item.sha256:
-            part.unlink(missing_ok=True)
-            raise LocalError(t("{name} does not match its published checksum. "
-                               "Nothing was installed.", name=item.name))
-        part.replace(target)
-        return True
     except urllib.error.HTTPError as exc:
-        part.unlink(missing_ok=True)
+        _drop(part)
         exc.close()   # it holds the response body open until it is collected
         raise LocalError(t("Could not download {name}: HTTP {code}",
                            name=item.name, code=exc.code)) from exc
     except urllib.error.URLError as exc:
-        part.unlink(missing_ok=True)
+        _drop(part)
         raise LocalError(t("Could not download {name}: {error}",
                            name=item.name, error=exc.reason)) from exc
     except OSError as exc:
         # A connection cut mid-body arrives here too, and gigabytes in is
         # exactly where that happens.
-        part.unlink(missing_ok=True)
+        _drop(part)
         raise LocalError(t("Could not write {name}: {error}",
                            name=item.name, error=exc)) from exc
+
+    if stopped:
+        _drop(part)
+        return False
+    if overlong:
+        _drop(part)
+        raise LocalError(t("{name} is longer than it said it would be.",
+                           name=item.name))
+    # A proxy notice or an error page that came back as 200 would otherwise
+    # be renamed into place and only fail when something tries to read it.
+    if total and done != total:
+        _drop(part)
+        raise LocalError(t("The download stopped early ({done} of {total}).",
+                           done=human_size(done), total=human_size(total)))
+    if item.sha256 and digest.hexdigest() != item.sha256:
+        _drop(part)
+        raise LocalError(t("{name} does not match its published checksum. "
+                           "Nothing was installed.", name=item.name))
+    try:
+        part.replace(target)
+    except OSError as exc:
+        _drop(part)
+        raise LocalError(t("Could not write {name}: {error}",
+                           name=item.name, error=exc)) from exc
+    return True
+
+
+def _drop(path):
+    """Delete a file, waiting out whatever still has it open.
+
+    On Windows an on-access virus scanner opens a file the moment it is closed,
+    and a delete arriving in that window fails outright rather than being
+    queued the way it would be on Linux. Half a second of retries is the
+    difference between a cancelled download and a stray `.part` nobody cleans
+    up.
+    """
+    path = pathlib.Path(path)
+    for attempt in range(6):
+        try:
+            path.unlink(missing_ok=True)
+            return True
+        except OSError:
+            time.sleep(0.05 * (attempt + 1))
+    return False
 
 
 # --- the programs ---------------------------------------------------------
@@ -217,22 +260,175 @@ def _has_vulkan():
     fetching the Vulkan one for a machine that cannot load it would only make
     the download bigger.
     """
-    return bool(ctypes.util.find_library("vulkan"))
+    return bool(ctypes.util.find_library("vulkan-1" if IS_WINDOWS else "vulkan"))
 
 
-def _wanted_assets(program):
-    """Asset name endings to accept, best first.
+# What a user may ask the local programs to run on. "auto" is what Dikte picks
+# when nobody has said; the other three are a choice, and a choice that cannot
+# be honoured is refused rather than quietly turned into something else.
+BACKENDS = ("auto", "cpu", "cuda", "vulkan")
 
-    llama.cpp publishes native Metal-enabled macOS archives. whisper.cpp does
-    not publish a runnable macOS server archive, so an arm64 Mac must not
-    mistake Ubuntu's arm64 archive for a native build.
+BACKEND_LABELS = {
+    "auto": "Auto",
+    "cpu": "CPU",
+    "cuda": "NVIDIA (CUDA)",
+    "vulkan": "Vulkan",
+}
+
+
+def _wanted_assets(program, backend="auto"):
+    """Regular expressions matching the release assets to accept, best first.
+
+    Matched rather than compared, because the names carry versions nobody here
+    should have to know: whisper's CUDA build is `whisper-cublas-12.4.0-bin-
+    x64.zip` today and something else next release. Full patterns rather than
+    endings, because `whisper-bin-x64.zip`, `whisper-blas-bin-x64.zip` and
+    `whisper-cublas-12.4.0-bin-x64.zip` all end the same way and are three very
+    different downloads.
     """
     arch = _arch()
-    if sys.platform == "darwin":
-        return () if program is WHISPER else (f"bin-macos-{arch}.tar.gz",)
-    if program is LLAMA and _has_vulkan():
-        return (f"bin-ubuntu-vulkan-{arch}.tar.gz", f"bin-ubuntu-{arch}.tar.gz")
-    return (f"bin-ubuntu-{arch}.tar.gz",)
+    backend = backend if backend in BACKENDS else "auto"
+    if IS_WINDOWS:
+        return _windows_assets(program, backend, arch)
+    return _linux_assets(program, backend, arch)
+
+
+def _linux_assets(program, backend, arch):
+    cpu = rf"bin-ubuntu-{arch}\.tar\.gz$"
+    vulkan = rf"bin-ubuntu-vulkan-{arch}\.tar\.gz$"
+    if program is not LLAMA:
+        # whisper.cpp publishes one Linux build, and it is the CPU one.
+        return (cpu,)
+    if backend == "vulkan":
+        return (vulkan,)
+    if backend == "cpu":
+        return (cpu,)
+    if backend == "cuda":
+        # There is no CUDA build for Linux; Vulkan is how a card is reached.
+        return ()
+    # Auto, which is what it has always done: the Vulkan build when a loader is
+    # installed, because the plain one carries CPU backends only.
+    return (vulkan, cpu) if _has_vulkan() else (cpu,)
+
+
+def _windows_assets(program, backend, arch):
+    if program is LLAMA:
+        # Anchored on the program's own name: the CUDA runtime is published as
+        # `cudart-llama-bin-win-cuda-12.4-x64.zip`, which ends the same way as
+        # the build it belongs to and holds no llama-server at all.
+        table = {
+            "cpu": (rf"^llama-.*-bin-win-cpu-{arch}\.zip$",),
+            "cuda": (rf"^llama-.*-bin-win-cuda-[\d.]+-{arch}\.zip$",),
+            "vulkan": (rf"^llama-.*-bin-win-vulkan-{arch}\.zip$",),
+        }
+    else:
+        table = {
+            "cpu": (rf"^whisper-bin-{arch}\.zip$",),
+            "cuda": (rf"^whisper-cublas-[\d.]+-bin-{arch}\.zip$",),
+            # whisper.cpp publishes no Vulkan build for Windows. Saying so is
+            # the point: falling back to the CPU one would look like a working
+            # graphics card that is simply slow.
+            "vulkan": (),
+        }
+    # Auto is the CPU build. It is the one that runs on every machine, and the
+    # one whose failure modes are not "which driver is installed"; a card is
+    # something to opt into, once, in the settings.
+    return table["cpu"] if backend == "auto" else table[backend]
+
+
+def backend_choices(program):
+    """The backends worth offering for this program on this machine.
+
+    What the projects publish differs by platform and by program: no CUDA
+    build of llama.cpp for Linux, no Vulkan build of whisper.cpp for Windows.
+    Offering one that does not exist is offering a failure.
+    """
+    return tuple(name for name in BACKENDS
+                 if name == "auto" or _wanted_assets(program, name))
+
+
+# Both projects publish several CUDA builds at once, against different CUDA
+# runtimes: whisper.cpp has 11.8 and 12.4 today, llama.cpp 12.4 and 13.3. A
+# driver runs anything up to its own version and nothing above it, so which one
+# to fetch is a question about this machine rather than a matter of taste.
+_CUDA_IN_NAME = re.compile(r"(?:cublas-|cuda-)(\d+)\.(\d+)")
+
+
+def _cuda_version(name):
+    found = _CUDA_IN_NAME.search(name)
+    return (int(found.group(1)), int(found.group(2))) if found else None
+
+
+def _pick(assets, pattern):
+    """The best asset matching `pattern`, or None when none of them will do.
+
+    For everything but CUDA there is one match and it is the answer. For CUDA
+    it is the newest build this machine's driver can load: the oldest would
+    work and waste the card, and the newest would fail inside the server with a
+    missing DLL naming a CUDA version and nothing about what to do.
+    """
+    found = [asset for asset in assets if re.search(pattern, asset.name)]
+    if not found:
+        return None
+    versions = [(_cuda_version(asset.name), asset) for asset in found]
+    if any(version is None for version, _asset in versions):
+        return found[0]
+    driver = runtime.cuda_driver_version()
+    if driver is None:
+        # No NVIDIA driver on this machine, so no CUDA build can run on it.
+        return None
+    usable = [pair for pair in versions if pair[0] <= driver]
+    return max(usable)[1] if usable else None
+
+
+def _no_build(program, tag, backend, assets):
+    """Why nothing was fetched, in terms of this machine rather than the release."""
+    if backend == "cuda":
+        driver = runtime.cuda_driver_version()
+        if driver is None:
+            return t("There is no NVIDIA driver on this machine, so a CUDA "
+                     "build of {name} could not run. Pick another one under "
+                     "Runs on.", name=program.name)
+        published = sorted(v for v in (_cuda_version(a.name) for a in assets) if v)
+        if published:
+            return t(
+                "{repo} {tag} publishes CUDA {wanted} at the oldest, and this "
+                "driver runs CUDA {have}. Update the NVIDIA driver, or pick "
+                "another build under Runs on.",
+                repo=program.repo, tag=tag,
+                wanted=f"{published[0][0]}.{published[0][1]}",
+                have=f"{driver[0]}.{driver[1]}",
+            )
+    if backend not in ("", "auto"):
+        return t("{repo} {tag} publishes no {backend} build for this machine.",
+                 repo=program.repo, tag=tag,
+                 backend=BACKEND_LABELS.get(backend, backend))
+    return t("{repo} {tag} has no build for this machine.",
+             repo=program.repo, tag=tag)
+
+
+# The CUDA builds of llama.cpp for Windows are published without the CUDA
+# runtime beside them: the DLLs come in a second archive, and the server exits
+# on a missing cudart64 without either archive being at fault. Unpacked into
+# the same directory, which is where the loader looks first.
+_CUDART = re.compile(r"^cudart-llama-bin-win-cuda-([\d.]+)-(\w+)\.zip$")
+_CUDA_BUILD = re.compile(r"bin-win-cuda-([\d.]+)-(\w+)\.zip$")
+
+
+def _companions(program, item, assets):
+    """Other assets that have to be unpacked beside `item` for it to run."""
+    if program is not LLAMA or not IS_WINDOWS:
+        return []
+    build = _CUDA_BUILD.search(item.name)
+    if not build:
+        return []
+    wanted = build.groups()
+    found = []
+    for asset in assets:
+        runtime_build = _CUDART.match(asset.name)
+        if runtime_build and runtime_build.groups() == wanted:
+            found.append(asset)
+    return found
 
 
 def _install_record(program):
@@ -257,6 +453,15 @@ def installed_version(program):
         return ""
 
 
+def installed_backend(program):
+    """What the downloaded build runs on, so the settings can show it."""
+    try:
+        record = json.loads(_install_record(program).read_text(encoding="utf-8"))
+        return record.get("backend") or "auto"
+    except (OSError, ValueError):
+        return "auto"
+
+
 def program_path(program, custom=""):
     """Which copy of the program to run, or "" when there is none.
 
@@ -275,6 +480,11 @@ def system_program(program):
     return bool(shutil.which(program.binary))
 
 
+def binary_name(program):
+    """What the executable is called once it is unpacked."""
+    return program.binary + EXE
+
+
 def _find_binary(root, name):
     for path in sorted(pathlib.Path(root).rglob(name)):
         if path.is_file():
@@ -283,30 +493,61 @@ def _find_binary(root, name):
 
 
 def _extract(archive, into):
-    """Unpack a release tarball, refusing anything that reaches outside `into`.
+    """Unpack a release archive, refusing anything that reaches outside `into`.
 
-    The archives lay their libraries next to their binaries and are linked with
-    an $ORIGIN runpath, so a whole directory is what has to survive the trip and
-    the binary cannot be lifted out of it.
+    The archives lay their libraries next to their binaries, with an $ORIGIN
+    runpath on Linux and the DLLs the loader looks for beside the .exe on
+    Windows, so a whole directory is what has to survive the trip and the
+    binary cannot be lifted out of it.
     """
+    name = os.path.basename(str(archive))
     try:
-        with tarfile.open(archive, "r:gz") as tar:
-            try:
-                tar.extractall(into, filter="data")
-            except TypeError:      # Python without the extraction filters
-                tar.extractall(into)
-    except (tarfile.TarError, OSError) as exc:
+        if zipfile.is_zipfile(archive):
+            _extract_zip(archive, into)
+        else:
+            with tarfile.open(archive, "r:gz") as tar:
+                try:
+                    tar.extractall(into, filter="data")
+                except TypeError:      # Python without the extraction filters
+                    tar.extractall(into)
+    except (tarfile.TarError, zipfile.BadZipFile, OSError) as exc:
         raise LocalError(t("Could not unpack {name}: {error}",
-                           name=os.path.basename(str(archive)), error=exc)) from exc
+                           name=name, error=exc)) from exc
+
+
+def _extract_zip(archive, into):
+    """A zip, with every member checked before any of it is written.
+
+    A zip entry is a string the archive chose, and it may name `..\\..\\` or an
+    absolute path. Python's own extractor strips those, but this is a program
+    that will then be run, so the check is made here and out loud: an archive
+    that tries it is refused whole rather than quietly flattened.
+    """
+    root = pathlib.Path(into).resolve()
+    with zipfile.ZipFile(archive) as zf:
+        for member in zf.infolist():
+            name = member.filename.replace("\\", "/")
+            if name.endswith("/"):
+                continue
+            landing = (root / name).resolve()
+            if landing != root and root not in landing.parents:
+                raise LocalError(t(
+                    "{archive} tried to write outside its own directory "
+                    "({member}). Nothing was installed.",
+                    archive=os.path.basename(str(archive)), member=member.filename,
+                ))
+        zf.extractall(root)
 
 
 def install_program(program, tag="", on_progress=None, should_stop=None,
-                    refresh=False):
+                    refresh=False, backend="auto"):
     """Fetch and unpack a release. The path to the binary, or "" when stopped.
 
     `tag` is empty for whatever the project released last, which is the point:
     a version pinned in Dikte's source would mean a release of Dikte every time
-    whisper.cpp has one.
+    whisper.cpp has one. `backend` is what the user asked to run on; a machine
+    the project publishes no such build for is told so rather than handed the
+    CPU one under another name.
     """
     try:
         tag, assets = hub.release(program.repo, tag or "latest", refresh=refresh)
@@ -314,43 +555,50 @@ def install_program(program, tag="", on_progress=None, should_stop=None,
         raise LocalError(str(exc)) from exc
 
     item = None
-    for ending in _wanted_assets(program):
-        item = next((a for a in assets if a.name.endswith(ending)), None)
+    for pattern in _wanted_assets(program, backend):
+        item = _pick(assets, pattern)
         if item:
             break
     if item is None:
-        if sys.platform == "darwin" and program is WHISPER:
-            raise LocalError(t(
-                "whisper.cpp publishes no macOS build. Install it with: "
-                "brew install whisper-cpp"
-            ))
-        raise LocalError(t("{repo} {tag} has no build for this machine.",
-                           repo=program.repo, tag=tag))
+        raise LocalError(_no_build(program, tag, backend, assets))
 
     into = BIN_DIR / program.name / tag
     shutil.rmtree(into, ignore_errors=True)
-    archive = BIN_DIR / program.name / item.name
+    wanted = [item] + _companions(program, item, assets)
+    archives = []
     try:
-        if not download(item, archive, on_progress, should_stop):
-            return ""
-        _extract(archive, into)
-        binary = _find_binary(into, program.binary)
+        for asset in wanted:
+            archive = BIN_DIR / program.name / asset.name
+            archives.append(archive)
+            if not download(asset, archive, on_progress, should_stop):
+                return ""
+            _extract(archive, into)
+        binary = _find_binary(into, binary_name(program))
         if binary is None:
             raise LocalError(t("{name} was not in the download.",
-                               name=program.binary))
-        binary.chmod(binary.stat().st_mode | 0o111)
+                               name=binary_name(program)))
+        _make_runnable(binary)
         _install_record(program).write_text(
-            json.dumps({"tag": tag, "binary": str(binary)}), encoding="utf-8")
+            json.dumps({"tag": tag, "binary": str(binary), "backend": backend}),
+            encoding="utf-8")
     except OSError as exc:
         raise LocalError(t("Could not install {name}: {error}",
                            name=program.name, error=exc)) from exc
     finally:
-        try:
-            archive.unlink(missing_ok=True)
-        except OSError:
-            pass
+        for archive in archives:
+            _drop(archive)
     _drop_old_versions(program, keep=tag)
     return str(binary)
+
+
+def _make_runnable(binary):
+    """Give the unpacked program the execute bit, where there is one to give."""
+    if IS_WINDOWS:
+        return
+    try:
+        binary.chmod(binary.stat().st_mode | 0o111)
+    except OSError:
+        pass
 
 
 def _drop_old_versions(program, keep):
@@ -592,11 +840,19 @@ class Server:
                         args + ["--host", HOST, "--port", str(port)],
                         stdout=sink, stderr=subprocess.STDOUT,
                         stdin=subprocess.DEVNULL,
+                        # No console window on Windows: a server started from a
+                        # tray icon would otherwise put a black box on screen
+                        # and keep it there for as long as the model is loaded.
+                        **runtime.NO_WINDOW,
                     )
             except OSError as exc:
                 raise LocalError(t("Could not start {name}: {error}",
                                    name=self.program.name, error=exc)) from exc
 
+            # Tied to this process where the platform can do that, so a Dikte
+            # killed outright takes the loaded model down with it rather than
+            # leaving gigabytes resident.
+            runtime.adopt(proc)
             # Written before it is ready rather than after, so that a kill
             # during the model load leaves something for the sweep to find.
             self._remember(proc.pid)
@@ -691,12 +947,7 @@ class Server:
         could be somebody else's copy; the name together with Dikte's own data
         directory on the command line could not.
         """
-        try:
-            blob = pathlib.Path(f"/proc/{pid}/cmdline").read_bytes()
-        except OSError:
-            return False
-        return (self.program.binary.encode() in blob
-                and str(DATA_DIR).encode() in blob)
+        return runtime.is_our_process(pid, (self.program.binary, str(DATA_DIR)))
 
     def sweep(self):
         """Kill a server a previous Dikte left behind. True when one was found.
@@ -713,11 +964,7 @@ class Server:
         self._forget()
         if not self._is_ours(pid):
             return False
-        try:
-            os.kill(pid, signal.SIGTERM)
-        except OSError:
-            return False
-        return True
+        return runtime.terminate(pid)
 
 
 # --- the two of them ------------------------------------------------------

--- a/ggml.py
+++ b/ggml.py
@@ -336,10 +336,19 @@ def _windows_assets(program, backend, arch):
             # graphics card that is simply slow.
             "vulkan": (),
         }
-    # Auto is the CPU build. It is the one that runs on every machine, and the
-    # one whose failure modes are not "which driver is installed"; a card is
-    # something to opt into, once, in the settings.
-    return table["cpu"] if backend == "auto" else table[backend]
+    if backend != "auto":
+        return table[backend]
+
+    # "Use the graphics card" cannot make a CPU-only archive grow a GPU
+    # backend. Prefer a build this machine can actually accelerate, while
+    # keeping CPU last as the safe fallback when a release has no compatible
+    # CUDA asset. Vulkan is the fallback for AMD/Intel on programs that publish
+    # it; whisper.cpp currently does not publish one for Windows.
+    if runtime.cuda_driver_version() is not None:
+        return table["cuda"] + table["cpu"]
+    if table["vulkan"] and _has_vulkan():
+        return table["vulkan"] + table["cpu"]
+    return table["cpu"]
 
 
 def backend_choices(program):

--- a/ggml.py
+++ b/ggml.py
@@ -46,7 +46,7 @@ import zipfile
 
 import hub
 from i18n import t
-from platforms import IS_WINDOWS, adapter
+from platforms import IS_MACOS, IS_WINDOWS, adapter
 
 runtime = adapter("runtime")
 
@@ -290,6 +290,12 @@ def _wanted_assets(program, backend="auto"):
     backend = backend if backend in BACKENDS else "auto"
     if IS_WINDOWS:
         return _windows_assets(program, backend, arch)
+    if IS_MACOS:
+        # llama.cpp publishes a native Metal-enabled macOS archive. whisper.cpp
+        # publishes no runnable macOS server archive; never mistake Ubuntu's
+        # arm64 build for a native one.
+        return (() if program is WHISPER
+                else (rf"bin-macos-{arch}\.tar\.gz$",))
     return _linux_assets(program, backend, arch)
 
 
@@ -560,6 +566,11 @@ def install_program(program, tag="", on_progress=None, should_stop=None,
         if item:
             break
     if item is None:
+        if IS_MACOS and program is WHISPER:
+            raise LocalError(t(
+                "whisper.cpp publishes no macOS build. Install it with: "
+                "brew install whisper-cpp"
+            ))
         raise LocalError(_no_build(program, tag, backend, assets))
 
     into = BIN_DIR / program.name / tag

--- a/hotkey.py
+++ b/hotkey.py
@@ -717,34 +717,76 @@ def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
     return hits
 
 
+_legacy_parse_shortcut = parse_shortcut
+_legacy_listener = listener
+_legacy_valid_shortcut = valid_shortcut
+_legacy_installs_shortcuts = installs_shortcuts
+_legacy_shortcut_needs_restart = shortcut_needs_restart
+_legacy_install_shortcut = install_shortcut
+_legacy_remove_shortcut = remove_shortcut
+_legacy_shortcut_status = shortcut_status
+_legacy_desktop_name = desktop_name
+_legacy_conflicting_shortcuts = conflicting_shortcuts
+
 if sys.platform.startswith("win"):
     from platforms import adapter as _platform_adapter
 
     _windows_hotkeys = _platform_adapter("hotkeys", "windows")
-    parse_shortcut = _windows_hotkeys.parse_shortcut
-    install_shortcut = _windows_hotkeys.install_shortcut
-    remove_shortcut = _windows_hotkeys.remove_shortcut
-    shortcut_status = _windows_hotkeys.shortcut_status
-    conflicting_shortcuts = _windows_hotkeys.conflicting_shortcuts
-    desktop_name = _windows_hotkeys.desktop_name
+    def parse_shortcut(text):
+        return (_windows_hotkeys.parse_shortcut(text)
+                if sys.platform.startswith("win")
+                else _legacy_parse_shortcut(text))
 
     def listener(parent=None):
-        return _windows_hotkeys.Listener(parent)
+        return (_windows_hotkeys.Listener(parent) if sys.platform.startswith("win")
+                else _legacy_listener(parent))
 
     def valid_shortcut(text):
-        return parse_shortcut(text)[1] is not None
+        return (_windows_hotkeys.parse_shortcut(text)[1] is not None
+                if sys.platform.startswith("win")
+                else _legacy_valid_shortcut(text))
 
     def installs_shortcuts():
         # RegisterHotKey lives in this process; there is no desktop registry
         # which can deliver a shortcut while Dikte is closed.
-        return False
+        return False if sys.platform.startswith("win") else _legacy_installs_shortcuts()
 
     def shortcut_needs_restart():
-        return False
+        return (False if sys.platform.startswith("win")
+                else _legacy_shortcut_needs_restart())
+
+    def install_shortcut(shortcut, exec_command,
+                         name="Dikte: start/stop recording",
+                         desktop_id=DESKTOP_ID):
+        if sys.platform.startswith("win"):
+            return _windows_hotkeys.install_shortcut(
+                shortcut, exec_command, name, desktop_id)
+        return _legacy_install_shortcut(shortcut, exec_command, name, desktop_id)
+
+    def remove_shortcut(desktop_id=DESKTOP_ID):
+        return (_windows_hotkeys.remove_shortcut(desktop_id)
+                if sys.platform.startswith("win")
+                else _legacy_remove_shortcut(desktop_id))
+
+    def shortcut_status(desktop_id=DESKTOP_ID):
+        return (_windows_hotkeys.shortcut_status(desktop_id)
+                if sys.platform.startswith("win")
+                else _legacy_shortcut_status(desktop_id))
+
+    def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
+        return (_windows_hotkeys.conflicting_shortcuts(shortcut, desktop_id)
+                if sys.platform.startswith("win")
+                else _legacy_conflicting_shortcuts(shortcut, desktop_id))
+
+    def desktop_name():
+        return (_windows_hotkeys.desktop_name() if sys.platform.startswith("win")
+                else _legacy_desktop_name())
 
 
 # The updated application shell consumes these two platform-neutral names.
 # Keep the older function as well because CLI and macOS/Linux tests use it.
-Listener = (_windows_hotkeys.Listener if sys.platform.startswith("win")
-            else CarbonHotkey if sys.platform == "darwin" else EvdevHotkey)
+def Listener(parent=None):
+    return listener(parent)
+
+
 LISTENER_IS_PRIMARY = sys.platform == "darwin" or sys.platform.startswith("win")

--- a/hotkey.py
+++ b/hotkey.py
@@ -741,3 +741,10 @@ if sys.platform.startswith("win"):
 
     def shortcut_needs_restart():
         return False
+
+
+# The updated application shell consumes these two platform-neutral names.
+# Keep the older function as well because CLI and macOS/Linux tests use it.
+Listener = (_windows_hotkeys.Listener if sys.platform.startswith("win")
+            else CarbonHotkey if sys.platform == "darwin" else EvdevHotkey)
+LISTENER_IS_PRIMARY = sys.platform == "darwin" or sys.platform.startswith("win")

--- a/hub.py
+++ b/hub.py
@@ -18,22 +18,20 @@ knows two websites and nothing about dictation.
 
 import collections
 import json
-import os
-import pathlib
 import time
 import urllib.error
 import urllib.parse
 import urllib.request
 
 from i18n import t
+from platforms import adapter
 
 GITHUB_API = "https://api.github.com"
 HF_API = "https://huggingface.co/api"
 HF_FILES = "https://huggingface.co"
 USER_AGENT = "dikte/1.0 (+https://github.com/yusufipk/dikte)"
 
-CACHE_DIR = (pathlib.Path(os.environ.get("XDG_CACHE_HOME")
-                          or os.path.expanduser("~/.cache")) / "dikte")
+CACHE_DIR = adapter("runtime").cache_dir()
 # Long enough that opening the settings window twice in an evening asks nobody
 # anything, short enough that a model published this morning is offered today.
 CACHE_TTL = 6 * 3600

--- a/i18n.py
+++ b/i18n.py
@@ -80,9 +80,9 @@ TR = {
         "{service} hesapta kredi kalmadığını söylüyor (HTTP 402).",
     "{service} is rate limiting you (HTTP 429). Try again in a moment.":
         "{service} hız sınırı uyguluyor (HTTP 429). Birazdan tekrar dene.",
-    "The {desktop} shortcut is live now, so the built-in listener has "
-    "been turned off. It was doubling every key press.":
-        "{desktop} kısayolu artık çalışıyor, bu yüzden dahili dinleyici kapatıldı. "
+    "The KDE shortcut is live now, so the built-in listener has been "
+    "turned off. It was doubling every key press.":
+        "KDE kısayolu artık çalışıyor, bu yüzden dahili dinleyici kapatıldı. "
         "Her tuşa basışı ikiye katlıyordu.",
     "No speech detected": "Ses algılanmadı",
     "No speech detected ({level} dB)": "Ses algılanmadı ({level} dB)",
@@ -104,14 +104,11 @@ TR = {
     "Could not start recording: {error}": "Kayıt başlatılamadı: {error}",
     "No audio recorder found. Install pulseaudio-utils or pipewire-audio.":
         "Ses kayıt aracı bulunamadı. pulseaudio-utils ya da pipewire-audio kur.",
-    "ffmpeg not found. Install it with: brew install ffmpeg":
-        "ffmpeg bulunamadı. Şununla kur: brew install ffmpeg",
     "Audio recorder stopped before receiving sound: {error}":
         "Ses kayıt aracı veri alamadan kapandı: {error}",
     "Could not copy to clipboard: {error}": "Panoya kopyalanamadı: {error}",
     "{tool} not found. Install {packages}.":
         "{tool} bulunamadı. {packages} paketlerini kur.",
-    "{tool} not found.": "{tool} bulunamadı.",
     "{tool} exited with code {code}.": "{tool} {code} koduyla çıktı.",
     "{tool} not found, cannot paste automatically.":
         "{tool} bulunamadı, otomatik yapıştırma yapılamıyor.",
@@ -120,10 +117,6 @@ TR = {
     "{tool} failed: {error}": "{tool} hatası: {error}",
     "Is ydotoold running? (systemctl --user status ydotool)":
         "ydotoold çalışıyor mu? (systemctl --user status ydotool)",
-    "macOS has not been told to let Dikte press keys. Turn Dikte on under "
-    "System Settings → Privacy & Security → Accessibility.":
-        "macOS, Dikte'nin tuşlara basmasına henüz izin vermiyor. Sistem Ayarları "
-        "→ Gizlilik ve Güvenlik → Erişilebilirlik altında Dikte'yi aç.",
 
     # --- api errors ----------------------------------------------------
     "{service} API key is empty. Add it in Settings.":
@@ -162,8 +155,6 @@ TR = {
     "Paste key": "Yapıştırma tuşu",
     "Terminals usually want ctrl+shift+v. Change this if pasting does nothing.":
         "Terminaller genelde ctrl+shift+v ister. Yapıştırma çalışmıyorsa bunu değiştir.",
-    "macOS asks for Accessibility permission the first time this is sent.":
-        "macOS bu ilk gönderildiğinde Erişilebilirlik izni ister.",
     "Restore the previous clipboard after pasting":
         "Yapıştırdıktan sonra eski pano içeriğini geri koy",
     "Indicator corner": "Gösterge köşesi",
@@ -177,6 +168,10 @@ TR = {
         "Sessiz kayıtları atla (API'ye gönderme)",
     "Silence threshold": "Sessizlik eşiği",
     "Keep audio files ({path})": "Ses kayıtlarını sakla ({path})",
+    "Folders": "Klasörler",
+    "Folder": "Klasör",
+    "Open the settings folder": "Ayar klasörünü aç",
+    "Open the data folder": "Veri klasörünü aç",
 
     # --- settings: api --------------------------------------------------
     "Keys": "Anahtarlar",
@@ -306,6 +301,26 @@ TR = {
     "No global shortcut installed. The tray menu discards it too.":
         "Global kısayol kurulu değil. Kayıt tepsi menüsünden de iptal edilebilir.",
     "Start and stop": "Başlat ve bitir",
+    "Capture shortcut": "Kısayolu yakala",
+    "Press shortcut… (Esc cancels)": "Kısayola bas… (Esc iptal eder)",
+    "Click here, then press the shortcut you want. Dikte temporarily "
+    "releases its own shortcuts while listening, so you can capture "
+    "the shortcut that is already active too.":
+        "Buraya tıkla, sonra istediğin kısayola bas. Dikte dinlerken kendi "
+        "kısayollarını geçici olarak bırakır; böylece hâlihazırda etkin olan "
+        "kısayolu da yakalayabilirsin.",
+    "Shortcut capture timed out. Try again.":
+        "Kısayol yakalama süresi doldu. Yeniden dene.",
+    "That key is not supported. Use a letter, number, function key, Space or "
+    "a navigation key, optionally with Ctrl, Alt, Shift or Meta.":
+        "Bu tuş desteklenmiyor. Ctrl, Alt, Shift veya Meta ile birlikte ya da "
+        "tek başına bir harf, rakam, işlev tuşu, Boşluk veya yön tuşu kullan.",
+    "The shortcut {shortcut} is already assigned to {verb}. Each shortcut can "
+    "only perform one action.":
+        "{shortcut} kısayolu zaten {verb} için atanmış. Her kısayol yalnızca "
+        "bir işlem yapabilir.",
+    "Selected {shortcut}. Press Save to start using it.":
+        "{shortcut} seçildi. Kullanmaya başlamak için Kaydet'e bas.",
     "Throws the recording away without transcribing it. Works on a dictation "
     "and on a command for the agent alike, whichever is running.":
         "Kaydı yazıya dökmeden atar. Hangisi çalışıyorsa ona işler: dikteye de, "
@@ -313,10 +328,8 @@ TR = {
     "Shortcut saved: {shortcut}": "Kısayol kaydedildi: {shortcut}",
     "Could not register the GNOME shortcut: {error}":
         "GNOME kısayolu kaydedilemedi: {error}",
-    "Use the built-in listener (/dev/input), for when the {desktop} shortcut "
-    "is not active yet":
-        "Yerleşik dinleyici kullan (/dev/input), {desktop} kısayolu henüz etkin "
-        "değilken",
+    "Use the built-in listener (/dev/input), for when the KDE shortcut is not active yet":
+        "Yerleşik dinleyici kullan (/dev/input), KDE kısayolu henüz etkin değilken",
     "Works immediately, no session restart. The only difference: the key "
     "combination also reaches the focused application.":
         "Anında çalışır, oturum yenilemek gerekmez. Tek farkı: tuş kombinasyonu "
@@ -327,13 +340,6 @@ TR = {
         "KWin, kısayol ayarlarını yalnızca açılışta okur. 'Kur' dedikten sonra kısayol "
         "Sistem Ayarları → Kısayollar altında görünür ama oturumu yeniden açana kadar "
         "tetiklenmez. O zamana kadar yerleşik dinleyiciyi kullanabilirsin.",
-    "The shortcut starts working as soon as it is installed.":
-        "Kısayol kurulur kurulmaz çalışmaya başlar.",
-    "Dikte asks macOS for these combinations itself, while it is running. "
-    "Nothing is installed, and no other application receives them in the "
-    "meantime.":
-        "Dikte bu kombinasyonları çalışırken macOS'tan kendisi ister. Hiçbir şey "
-        "kurulmaz ve o sırada başka hiçbir uygulama bu tuşları almaz.",
     "Shortcut conflict": "Kısayol çakışması",
     "{shortcut} is also used by:\n\n{list}\n\nInstall anyway?":
         "{shortcut} şu girdilerde de kullanılıyor:\n\n{list}\n\nYine de kurulsun mu?",
@@ -346,19 +352,88 @@ TR = {
     "Could not write the desktop file: {error}": "Desktop dosyası yazılamadı: {error}",
     "Could not write kglobalshortcutsrc: {error}": "kglobalshortcutsrc yazılamadı: {error}",
     "Could not parse the shortcut: {shortcut}": "Kısayol çözümlenemedi: {shortcut}",
-    "Shortcut saved: {shortcut}\nDikte holds this one itself while it is "
-    "running, so it works as soon as the settings are saved.":
-        "Kısayol kaydedildi: {shortcut}\nDikte bunu çalıştığı sürece kendisi "
-        "tutar, yani ayarlar kaydedilir kaydedilmez çalışır.",
-    "Could not reach the macOS shortcut service: {error}":
-        "macOS kısayol servisine ulaşılamadı: {error}",
-    "macOS would not give Dikte {shortcut}; another application already holds it.":
-        "macOS {shortcut} kombinasyonunu Dikte'ye vermedi; başka bir uygulama "
-        "onu şimdiden tutuyor.",
     "Cannot read /dev/input. Your user needs to be in the 'input' group:\n"
     "  sudo usermod -aG input $USER   (then log out and back in)":
         "/dev/input okunamıyor. Kullanıcının 'input' grubunda olması gerekir:\n"
         "  sudo usermod -aG input $USER   (sonra oturumu yeniden aç)",
+
+    # --- windows: the shortcuts ---------------------------------------------
+    "The shortcuts are held for as long as Dikte is running, and given back "
+    "when it quits. Windows hands a combination to one program at a time: one "
+    "that is already taken is refused, without saying by whom, and the key no "
+    "longer reaches the window underneath.":
+        "Kısayollar Dikte çalıştığı sürece tutulur, kapanınca geri verilir. "
+        "Windows bir kombinasyonu aynı anda tek programa verir: başkasının "
+        "aldığı bir kombinasyon reddedilir, kimin aldığı söylenmez, ve tuş "
+        "artık alttaki pencereye ulaşmaz.",
+    "{shortcut} is already taken by another application.":
+        "{shortcut} kombinasyonunu başka bir uygulama tutuyor.",
+    "{shortcut} is already taken by another application. Windows only gives a "
+    "combination to one program at a time; pick another one.":
+        "{shortcut} kombinasyonunu başka bir uygulama tutuyor. Windows bir "
+        "kombinasyonu aynı anda tek programa verir; başka bir tane seç.",
+    "Windows refused the shortcut {shortcut} (error {code}).":
+        "Windows {shortcut} kısayolunu kabul etmedi (hata {code}).",
+    "another application (Windows does not say which)":
+        "başka bir uygulama (Windows hangisi olduğunu söylemiyor)",
+
+    # --- windows: sound -----------------------------------------------------
+    "The Windows sound support is missing. Reinstall Dikte, or run: "
+    "pip install PyAudioWPatch":
+        "Windows ses desteği eksik. Dikte'yi yeniden kur ya da şunu çalıştır: "
+        "pip install PyAudioWPatch",
+    "Whatever {device} is playing": "{device} ne çalıyorsa",
+    "Windows would not open {device}. Check Settings → Privacy & security → "
+    "Microphone: desktop apps need microphone access turned on. ({error})":
+        "Windows {device} aygıtını açmadı. Ayarlar → Gizlilik ve güvenlik → "
+        "Mikrofon bölümünü aç: masaüstü uygulamalarının mikrofon erişimi açık "
+        "olmalı. ({error})",
+    "Could not start recording on {device}: {error}":
+        "{device} üzerinde kayıt başlatılamadı: {error}",
+    "No microphone found. Plug one in, or pick another under Settings → General.":
+        "Mikrofon bulunamadı. Bir mikrofon tak ya da Ayarlar → Genel altından "
+        "başka birini seç.",
+    "The microphone {device} is not there any more. Pick another one under "
+    "Settings → General.":
+        "{device} mikrofonu artık yok. Ayarlar → Genel altından başka birini seç.",
+    "The microphone stopped before any sound arrived: {error}":
+        "Mikrofon, hiç ses gelmeden durdu: {error}",
+    "the device went away": "aygıt ortadan kayboldu",
+
+    # --- windows: the clipboard ---------------------------------------------
+    "Could not open the Windows clipboard: another program is holding it. "
+    "Try again in a moment.":
+        "Windows panosu açılamadı: başka bir program panoyu tutuyor. "
+        "Birazdan tekrar dene.",
+    "Windows would not let Dikte type into that window, because it is running "
+    "as administrator and Dikte is not. The text is on the clipboard: press "
+    "{shortcut} yourself.":
+        "Windows, Dikte'nin o pencereye yazmasına izin vermedi: pencere "
+        "yönetici olarak çalışıyor, Dikte çalışmıyor. Metin panoda, "
+        "{shortcut} tuşlarına kendin bas.",
+    "Could not send the key press: Windows error {code}.":
+        "Tuş gönderilemedi: Windows hatası {code}.",
+
+    # --- local models: which build ------------------------------------------
+    # "Runs on" is further down, where the agent tab already uses it.
+    "Auto": "Otomatik",
+    "CPU": "İşlemci",
+    "NVIDIA (CUDA)": "NVIDIA (CUDA)",
+    "Vulkan": "Vulkan",
+    "Automatic downloads the build that runs on any machine, on the "
+    "processor. Pick a graphics card build to fetch that one instead; if it "
+    "fails to start, the reason is shown rather than swallowed.":
+        "Otomatik, her makinede işlemci üzerinde çalışan sürümü indirir. Ekran "
+        "kartı sürümü seçersen o indirilir; başlatılamazsa nedeni gizlenmeden "
+        "gösterilir.",
+    "Downloaded, version {version} ({backend}).":
+        "İndirildi, sürüm {version} ({backend}).",
+    "{repo} {tag} publishes no {backend} build for this machine.":
+        "{repo} {tag} bu makine için {backend} sürümü yayımlamıyor.",
+    "{archive} tried to write outside its own directory ({member}). "
+    "Nothing was installed.":
+        "{archive} kendi klasörünün dışına yazmaya çalıştı ({member}). "
+        "Hiçbir şey kurulmadı.",
 
     # --- settings: history --------------------------------------------------
     "Copy selected to clipboard": "Seçiliyi panoya kopyala",
@@ -582,12 +657,6 @@ TR = {
     "Same as dictation": "Diktedekiyle aynı",
     "Current output": "Geçerli çıkış",
     "The other participants": "Karşı tarafın sesi",
-    "macOS does not offer what the speakers are playing as something to "
-    "record. Install BlackHole or Loopback, send the meeting's sound through "
-    "it, and pick it above.":
-        "macOS, hoparlörden çıkan sesi kaydedilebilir bir kaynak olarak sunmaz. "
-        "BlackHole ya da Loopback kur, toplantının sesini oradan geçir ve "
-        "yukarıdan onu seç.",
     "Wear headphones if you can. Through speakers your microphone hears the "
     "other side as well, and although a line that lands on both channels at "
     "once is dropped again, the repair is never as clean as not needing it.":

--- a/icons.py
+++ b/icons.py
@@ -1,0 +1,123 @@
+"""The tray icons, drawn here for the desktops that have none to hand out.
+
+Linux has an icon theme, and Dikte has always asked it for the three names it
+shows: a microphone when it is idle, a record dot while it is recording, a
+refresh arrow while it is working. Windows has no such thing, since an
+application ships its own, so rather than carrying three bitmaps at three sizes
+each, the same three are drawn.
+
+Drawn also means they follow the taskbar. A white microphone is invisible on a
+light taskbar and a black one on a dark one, so the outline colour is taken
+from the palette Qt reports for the system, while the record dot stays red and
+the working arrow amber, which read on either.
+"""
+
+from PyQt6.QtCore import QPointF, QRectF, Qt
+from PyQt6.QtGui import QColor, QIcon, QPainter, QPen, QPixmap, QPolygonF
+
+# Drawn once at a size no tray asks for, so that scaling down is all Qt has to
+# do however large the display scaling is.
+SIZE = 256
+
+RECORD_RED = QColor(214, 60, 60)
+WORKING_AMBER = QColor(224, 152, 46)
+
+_cache = {}
+
+
+def _foreground():
+    """A colour that will be seen against whatever the tray is painted with.
+
+    Qt reports which of the two schemes the system is set to from 6.5 onward;
+    older builds land on the window-text colour of the palette, which is the
+    same question asked less directly.
+    """
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        return QColor(230, 230, 230)
+    try:
+        scheme = app.styleHints().colorScheme()
+        if scheme == Qt.ColorScheme.Dark:
+            return QColor(236, 236, 236)
+        if scheme == Qt.ColorScheme.Light:
+            return QColor(40, 40, 40)
+    except (AttributeError, TypeError):
+        pass
+    return app.palette().windowText().color()
+
+
+def _canvas():
+    pixmap = QPixmap(SIZE, SIZE)
+    pixmap.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(pixmap)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+    # Everything below is drawn in a 100 x 100 box, whatever SIZE is.
+    painter.scale(SIZE / 100.0, SIZE / 100.0)
+    return pixmap, painter
+
+
+def _microphone(painter, colour):
+    pen = QPen(colour, 7.0)
+    pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+    pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+    painter.setPen(pen)
+    painter.setBrush(colour)
+    # The capsule somebody speaks into.
+    painter.drawRoundedRect(QRectF(38.0, 12.0, 24.0, 46.0), 12.0, 12.0)
+    # The cradle under it, drawn as the bottom half of a circle.
+    painter.setBrush(Qt.BrushStyle.NoBrush)
+    painter.drawArc(QRectF(27.0, 25.0, 46.0, 46.0), 180 * 16, 180 * 16)
+    # The stem and the foot.
+    painter.drawLine(QPointF(50.0, 71.0), QPointF(50.0, 84.0))
+    painter.drawLine(QPointF(34.0, 87.0), QPointF(66.0, 87.0))
+
+
+def _record(painter, colour):
+    painter.setPen(Qt.PenStyle.NoPen)
+    painter.setBrush(colour)
+    painter.drawEllipse(QRectF(20.0, 20.0, 60.0, 60.0))
+
+
+def _working(painter, colour):
+    pen = QPen(colour, 11.0)
+    pen.setCapStyle(Qt.PenCapStyle.FlatCap)
+    painter.setPen(pen)
+    painter.setBrush(Qt.BrushStyle.NoBrush)
+    # Three quarters of a circle, with the arrowhead where the fourth would be.
+    painter.drawArc(QRectF(20.0, 20.0, 60.0, 60.0), 90 * 16, -280 * 16)
+    painter.setPen(Qt.PenStyle.NoPen)
+    painter.setBrush(colour)
+    painter.drawPolygon(QPolygonF([
+        QPointF(50.0, 4.0), QPointF(50.0, 36.0), QPointF(76.0, 20.0),
+    ]))
+
+
+DRAWINGS = {
+    "audio-input-microphone": (_microphone, None),
+    "media-record": (_record, RECORD_RED),
+    "view-refresh": (_working, WORKING_AMBER),
+}
+
+
+def tray_icon(name):
+    """One of the three, drawn. An unknown name gets the microphone."""
+    draw, colour = DRAWINGS.get(name, DRAWINGS["audio-input-microphone"])
+    foreground = colour or _foreground()
+    key = (name, foreground.rgba())
+    if key in _cache:
+        return _cache[key]
+    pixmap, painter = _canvas()
+    try:
+        draw(painter, foreground)
+    finally:
+        painter.end()
+    icon = QIcon(pixmap)
+    _cache[key] = icon
+    return icon
+
+
+def forget():
+    """Drop the drawn icons, for when the system switches between light and dark."""
+    _cache.clear()

--- a/ipc.py
+++ b/ipc.py
@@ -25,7 +25,22 @@ from platforms import adapter
 
 runtime = adapter("runtime")
 
-SERVER_NAME = "dikte-" + runtime.user_id()
+
+def _windows_sid():
+    return getattr(adapter("runtime", "windows"), "_sid_string")()
+
+
+def user_id(platform=None):
+    platform = platform or sys.platform
+    if platform.startswith("win"):
+        identity = (_windows_sid() or os.environ.get("USERNAME")
+                    or os.environ.get("USER") or "dikte")
+        import hashlib
+        return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+    return str(os.getuid())
+
+
+SERVER_NAME = "dikte-" + user_id()
 
 # Whether this is a packaged application rather than a checkout being run by a
 # Python interpreter. It changes what "start Dikte again" means, and there is

--- a/ipc.py
+++ b/ipc.py
@@ -9,12 +9,78 @@ shortcut may still send.
 """
 
 import json
+import hashlib
 import os
 import sys
 
 from PyQt6.QtNetwork import QLocalSocket
 
-SERVER_NAME = "dikte-" + str(os.getuid())
+def _windows_sid():
+    """The current Windows account SID, or an empty string on API failure."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        token_query = 0x0008
+        token_user = 1
+        token = wintypes.HANDLE()
+        kernel32 = ctypes.windll.kernel32
+        advapi32 = ctypes.windll.advapi32
+        advapi32.OpenProcessToken.argtypes = [
+            wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)]
+        advapi32.OpenProcessToken.restype = wintypes.BOOL
+        advapi32.GetTokenInformation.argtypes = [
+            wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD)]
+        advapi32.GetTokenInformation.restype = wintypes.BOOL
+        advapi32.ConvertSidToStringSidW.argtypes = [
+            ctypes.c_void_p, ctypes.POINTER(wintypes.LPWSTR)]
+        advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+        kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+        kernel32.LocalFree.restype = wintypes.HLOCAL
+        if not advapi32.OpenProcessToken(
+                kernel32.GetCurrentProcess(), token_query, ctypes.byref(token)):
+            return ""
+        try:
+            size = wintypes.DWORD()
+            advapi32.GetTokenInformation(token, token_user, None, 0,
+                                         ctypes.byref(size))
+            if not size.value:
+                return ""
+            buffer = ctypes.create_string_buffer(size.value)
+            if not advapi32.GetTokenInformation(
+                    token, token_user, buffer, size, ctypes.byref(size)):
+                return ""
+
+            class TokenUser(ctypes.Structure):
+                _fields_ = [("sid", ctypes.c_void_p),
+                            ("attributes", wintypes.DWORD)]
+
+            sid = ctypes.cast(buffer, ctypes.POINTER(TokenUser)).contents.sid
+            text = wintypes.LPWSTR()
+            if not advapi32.ConvertSidToStringSidW(sid, ctypes.byref(text)):
+                return ""
+            try:
+                return text.value or ""
+            finally:
+                kernel32.LocalFree(text)
+        finally:
+            kernel32.CloseHandle(token)
+    except (AttributeError, OSError, TypeError, ValueError):
+        return ""
+
+
+def user_id(platform=None):
+    """A filesystem/pipe-safe token that is stable for the current user."""
+    platform = platform or sys.platform
+    if not platform.startswith("win"):
+        return str(os.getuid())
+    identity = (_windows_sid() or os.environ.get("USERNAME")
+                or os.environ.get("USER") or "dikte")
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
+
+
+SERVER_NAME = "dikte-" + user_id()
 
 # Long enough for a process that is already running to answer, short enough that
 # "nothing is running" is not a noticeable pause in front of a key press.

--- a/ipc.py
+++ b/ipc.py
@@ -6,81 +6,37 @@ which is what lets a script wait for a dictation instead of guessing when it is
 done. One JSON object goes each way per connection. A bare verb is still
 understood, because that is what earlier versions sent and what a stale KDE
 shortcut may still send.
+
+The name it listens on is per user on both platforms: a Unix socket in /tmp
+named after the user id, a named pipe named after a hash of the Windows SID.
+Neither is a lock, and on Windows two servers can hold the same pipe name, so
+whether this is the only Dikte running is asked of the runtime adapter instead,
+and settled there by a mutex.
 """
 
 import json
-import hashlib
 import os
+import pathlib
 import sys
 
 from PyQt6.QtNetwork import QLocalSocket
 
-def _windows_sid():
-    """The current Windows account SID, or an empty string on API failure."""
-    try:
-        import ctypes
-        from ctypes import wintypes
+from platforms import adapter
 
-        token_query = 0x0008
-        token_user = 1
-        token = wintypes.HANDLE()
-        kernel32 = ctypes.windll.kernel32
-        advapi32 = ctypes.windll.advapi32
-        advapi32.OpenProcessToken.argtypes = [
-            wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)]
-        advapi32.OpenProcessToken.restype = wintypes.BOOL
-        advapi32.GetTokenInformation.argtypes = [
-            wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD,
-            ctypes.POINTER(wintypes.DWORD)]
-        advapi32.GetTokenInformation.restype = wintypes.BOOL
-        advapi32.ConvertSidToStringSidW.argtypes = [
-            ctypes.c_void_p, ctypes.POINTER(wintypes.LPWSTR)]
-        advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
-        kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
-        kernel32.LocalFree.restype = wintypes.HLOCAL
-        if not advapi32.OpenProcessToken(
-                kernel32.GetCurrentProcess(), token_query, ctypes.byref(token)):
-            return ""
-        try:
-            size = wintypes.DWORD()
-            advapi32.GetTokenInformation(token, token_user, None, 0,
-                                         ctypes.byref(size))
-            if not size.value:
-                return ""
-            buffer = ctypes.create_string_buffer(size.value)
-            if not advapi32.GetTokenInformation(
-                    token, token_user, buffer, size, ctypes.byref(size)):
-                return ""
+runtime = adapter("runtime")
 
-            class TokenUser(ctypes.Structure):
-                _fields_ = [("sid", ctypes.c_void_p),
-                            ("attributes", wintypes.DWORD)]
+SERVER_NAME = "dikte-" + runtime.user_id()
 
-            sid = ctypes.cast(buffer, ctypes.POINTER(TokenUser)).contents.sid
-            text = wintypes.LPWSTR()
-            if not advapi32.ConvertSidToStringSidW(sid, ctypes.byref(text)):
-                return ""
-            try:
-                return text.value or ""
-            finally:
-                kernel32.LocalFree(text)
-        finally:
-            kernel32.CloseHandle(token)
-    except (AttributeError, OSError, TypeError, ValueError):
-        return ""
+# Whether this is a packaged application rather than a checkout being run by a
+# Python interpreter. It changes what "start Dikte again" means, and there is
+# no dikte.py to point at inside a one-folder build.
+FROZEN = bool(getattr(sys, "frozen", False))
 
-
-def user_id(platform=None):
-    """A filesystem/pipe-safe token that is stable for the current user."""
-    platform = platform or sys.platform
-    if not platform.startswith("win"):
-        return str(os.getuid())
-    identity = (_windows_sid() or os.environ.get("USERNAME")
-                or os.environ.get("USER") or "dikte")
-    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
-
-
-SERVER_NAME = "dikte-" + user_id()
+# A packaged build has two faces in one directory: the tray application with no
+# console, and the command line with one. Which of them is running decides both
+# what a bare start means and which one a restart hands over to.
+TRAY_EXE = "DikteApp.exe"
+IS_TRAY = FROZEN and os.path.basename(sys.executable).lower() == TRAY_EXE.lower()
 
 # Long enough for a process that is already running to answer, short enough that
 # "nothing is running" is not a noticeable pause in front of a key press.
@@ -93,9 +49,39 @@ def script_path():
     )
 
 
+def launch_command(*args):
+    """The argument list that starts Dikte again, as a list to spawn.
+
+    Packaged, the executable is the application and there is no interpreter and
+    no script in front of it. From a checkout it is the interpreter running
+    dikte.py, which is also what has to survive a restart after an update.
+    """
+    if FROZEN:
+        return [sys.executable, *args]
+    return [sys.executable, script_path(), *args]
+
+
+def gui_command(*args):
+    """The argument list that starts the tray application.
+
+    Not the same as launch_command in a packaged build: `dikte transcribe` runs
+    in a console window, and having it start the tray application would leave
+    that window open for as long as Dikte ran. The tray executable sits beside
+    it in the same directory.
+    """
+    if not FROZEN:
+        return launch_command(*args)
+    tray = pathlib.Path(sys.executable).with_name(TRAY_EXE)
+    return [str(tray) if tray.exists() else sys.executable, *args]
+
+
+def _quoted(part):
+    return f'"{part}"' if " " in part else part
+
+
 def command_for(verb):
-    """The command line a KDE shortcut runs for one of the verbs."""
-    return f"{sys.executable} {script_path()} {verb}"
+    """The command line a desktop shortcut runs for one of the verbs."""
+    return " ".join(_quoted(part) for part in launch_command(verb))
 
 
 def send(cmd, wait=False, timeout=0, **args):

--- a/keycapture.py
+++ b/keycapture.py
@@ -1,0 +1,225 @@
+"""Reading a global shortcut off the keyboard instead of out of a list.
+
+Picking `Ctrl+Alt+M` from a menu of fourteen suggestions is a strange way to
+choose a key press. Pressing it is the obvious one, and it is also the only way
+to find out what a keyboard actually sends: a laptop with no Insert key, a
+Turkish layout where the key beside L is not a semicolon, a keyboard whose Alt
+is where you expected Meta.
+
+So the settings window has a button that listens. Press it, press the
+combination, and that is the shortcut. What comes back is written in the same
+form the settings have always stored, `Ctrl+Alt+Space`, so nothing downstream
+learns that it was typed rather than picked, and both platforms' shortcut
+tables read it the way they always have.
+
+Two things this has to be careful about.
+
+A combination Dikte is already holding never arrives. RegisterHotKey takes the
+key away from whoever has focus, and KDE's global shortcut does the same, so
+pressing Ctrl+Space to record it would start a dictation and the window would
+sit there waiting. The catcher says when it is listening, and the application
+stands its own shortcuts down for exactly that long.
+
+And a key press is not a shortcut until it has a key in it. Holding Ctrl sends
+a key press of its own, then another for every key after it, so a modifier on
+its own is waited through rather than taken.
+"""
+
+from PyQt6.QtCore import Qt, QTimer, pyqtSignal
+from PyQt6.QtWidgets import QPushButton
+
+from i18n import t
+
+# The order the modifiers are written in. Not alphabetical and not Qt's: this
+# is the order that reproduces every combination Dikte already ships, from
+# `Ctrl+Alt+Space` to `Meta+Shift+Space`, so a captured shortcut and a stored
+# one that mean the same thing look the same in the box.
+MODIFIERS = (
+    ("Ctrl", Qt.KeyboardModifier.ControlModifier),
+    ("Meta", Qt.KeyboardModifier.MetaModifier),
+    ("Alt", Qt.KeyboardModifier.AltModifier),
+    ("Shift", Qt.KeyboardModifier.ShiftModifier),
+)
+
+# A modifier pressed on its own arrives as a key of its own. There is no
+# shortcut in it yet, so it is waited through.
+BARE_MODIFIERS = {
+    Qt.Key.Key_Control, Qt.Key.Key_Shift, Qt.Key.Key_Alt, Qt.Key.Key_AltGr,
+    Qt.Key.Key_Meta, Qt.Key.Key_Super_L, Qt.Key.Key_Super_R,
+    Qt.Key.Key_CapsLock, Qt.Key.Key_NumLock, Qt.Key.Key_ScrollLock,
+}
+
+# Qt's key codes, in the names both platforms' shortcut tables are keyed by.
+# Only the keys a global shortcut may be built from: what is not in here is
+# refused out loud rather than stored as something that will never fire.
+KEY_NAMES = {
+    Qt.Key.Key_Space: "space",
+    Qt.Key.Key_Tab: "tab",
+    Qt.Key.Key_Return: "return",
+    Qt.Key.Key_Enter: "enter",
+    Qt.Key.Key_Escape: "esc",
+    Qt.Key.Key_Backspace: "backspace",
+    Qt.Key.Key_Insert: "insert",
+    Qt.Key.Key_Delete: "delete",
+    Qt.Key.Key_Home: "home",
+    Qt.Key.Key_End: "end",
+    Qt.Key.Key_PageUp: "pgup",
+    Qt.Key.Key_PageDown: "pgdown",
+    Qt.Key.Key_Up: "up",
+    Qt.Key.Key_Down: "down",
+    Qt.Key.Key_Left: "left",
+    Qt.Key.Key_Right: "right",
+}
+KEY_NAMES.update({getattr(Qt.Key, f"Key_F{number}"): f"f{number}"
+                  for number in range(1, 13)})
+KEY_NAMES.update({getattr(Qt.Key, f"Key_{letter.upper()}"): letter
+                  for letter in "abcdefghijklmnopqrstuvwxyz"})
+KEY_NAMES.update({getattr(Qt.Key, f"Key_{digit}"): str(digit)
+                  for digit in range(10)})
+
+# How long the button listens before giving up. A capture nobody finished holds
+# the keyboard, and a window that has stopped answering the keyboard with no
+# sign of why is worse than one that quietly stopped waiting.
+TIMEOUT_MS = 10000
+
+
+def key_name(key):
+    """The name a Qt key code goes under in the shortcut tables, or ''."""
+    try:
+        return KEY_NAMES.get(Qt.Key(key), "")
+    except ValueError:
+        return ""
+
+
+def combination(modifiers, key):
+    """'Ctrl+Alt+Space' for a key press, or '' when it is not a shortcut.
+
+    Empty for a modifier held on its own, and for a key nothing here can name:
+    both are things somebody may press on the way to what they meant, and
+    neither is worth interrupting them for.
+    """
+    if key in BARE_MODIFIERS:
+        return ""
+    name = key_name(key)
+    if not name:
+        return ""
+    held = [label for label, flag in MODIFIERS if modifiers & flag]
+    return "+".join(held + [name.capitalize() if len(name) > 1 else name.upper()])
+
+
+class ShortcutCatcher(QPushButton):
+    """A button that, once pressed, answers with the next key combination.
+
+    `captured` carries the combination. `listening` says when the keyboard is
+    being watched, so that the application can stand its own global shortcuts
+    down: the whole point is to be able to press the one Dikte already holds.
+    """
+
+    captured = pyqtSignal(str)
+    listening = pyqtSignal(bool)
+    refused = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(t("Capture shortcut"), parent)
+        self._idle_text = t("Capture shortcut")
+        self._waiting = False
+        # Checkable so that "listening" is visible in the button itself rather
+        # than only in its label.
+        self.setCheckable(True)
+        self.setToolTip(t(
+            "Click here, then press the shortcut you want. Dikte temporarily "
+            "releases its own shortcuts while listening, so you can capture "
+            "the shortcut that is already active too."
+        ))
+        self.clicked.connect(self._start)
+        self._timeout = QTimer(self)
+        self._timeout.setSingleShot(True)
+        self._timeout.setInterval(TIMEOUT_MS)
+        self._timeout.timeout.connect(self._timed_out)
+
+    @property
+    def waiting(self):
+        return self._waiting
+
+    # ---- listening -------------------------------------------------------
+
+    def _start(self, _checked=False):
+        if self._waiting:
+            self._stop()
+            return
+        self._waiting = True
+        self.setText(t("Press shortcut… (Esc cancels)"))
+        self.setChecked(True)
+        # Grabbed rather than only focused: a combination that is a shortcut of
+        # something else in this window would otherwise be eaten by it before
+        # this ever saw the key.
+        self.grabKeyboard()
+        self._timeout.start()
+        self.listening.emit(True)
+
+    def _stop(self):
+        if not self._waiting:
+            return
+        self._waiting = False
+        self._timeout.stop()
+        self.releaseKeyboard()
+        self.setText(self._idle_text)
+        self.setChecked(False)
+        self.listening.emit(False)
+
+    def cancel(self):
+        """Stop listening without having taken anything."""
+        self._stop()
+
+    def _timed_out(self):
+        self._stop()
+        self.refused.emit(t("Shortcut capture timed out. Try again."))
+
+    # ---- the keyboard ----------------------------------------------------
+
+    def keyPressEvent(self, event):
+        if not self._waiting:
+            super().keyPressEvent(event)
+            return
+        # Everything is consumed while listening. Space and Enter would press
+        # this button, Escape would close the settings window, and Tab would
+        # move the focus out from under the grab.
+        event.accept()
+        key = event.key()
+        if (key == Qt.Key.Key_Escape
+                and event.modifiers() == Qt.KeyboardModifier.NoModifier):
+            self._stop()
+            return
+        if key in BARE_MODIFIERS:
+            return
+        found = combination(event.modifiers(), key)
+        if not found:
+            # Named out loud rather than ignored: a key that does nothing twice
+            # in a row looks like a button that is broken.
+            self._stop()
+            self.refused.emit(t(
+                "That key is not supported. Use a letter, number, function "
+                "key, Space or a navigation key, optionally with Ctrl, Alt, "
+                "Shift or Meta."
+            ))
+            return
+        self._stop()
+        self.captured.emit(found)
+
+    def keyReleaseEvent(self, event):
+        if self._waiting:
+            event.accept()
+            return
+        super().keyReleaseEvent(event)
+
+    # ---- giving the keyboard back ----------------------------------------
+
+    def focusOutEvent(self, event):
+        # Clicking elsewhere is as good as saying never mind, and a grab that
+        # outlived the button's focus would swallow the next thing typed.
+        self._stop()
+        super().focusOutEvent(event)
+
+    def hideEvent(self, event):
+        self._stop()
+        super().hideEvent(event)

--- a/overlay.py
+++ b/overlay.py
@@ -1,11 +1,12 @@
 """The small recording indicator that appears in a screen corner without taking focus."""
 
 import math
-import sys
 
 from PyQt6.QtCore import Qt, QTimer, QRectF, QPointF
 from PyQt6.QtGui import QColor, QCursor, QFont, QPainter, QPainterPath, QPen, QFontMetrics
 from PyQt6.QtWidgets import QWidget, QApplication
+
+from platforms import IS_WINDOWS
 
 BARS = 22
 HEIGHT = 56
@@ -61,27 +62,22 @@ class Overlay(QWidget):
             | Qt.WindowType.Tool
             | Qt.WindowType.WindowDoesNotAcceptFocus
         )
-        if sys.platform != "darwin":
-            # It is the window manager that would otherwise move this out of
-            # the corner. macOS has no such hint, and Qt warns about it.
+        # Going around the window manager is how an X11 session lets a window
+        # sit in a screen corner and stay out of the taskbar. Windows already
+        # does both for a tool window that never activates, and the hint there
+        # is a request to a window manager that is not listening.
+        if not IS_WINDOWS:
             flags |= Qt.WindowType.X11BypassWindowManagerHint
-        # One that can be clicked away has to receive the click, which means it
-        # also swallows one aimed at whatever is underneath it. The rest stay
-        # transparent to the mouse, as an indicator should be. It has to be this
-        # flag and not WA_TransparentForMouseEvents: on a top-level window the
-        # attribute only makes Qt drop the event it already took, so the click
-        # never reaches the window below. The flag is the one that tells the
-        # display server the window has no input region at all. It is read when
-        # the window is created and cannot be turned off later without the
-        # window being torn down and built again, which is why the dismissable
-        # one has to shrink itself instead (see _conceal).
-        if dismissable:
-            self.setCursor(Qt.CursorShape.PointingHandCursor)
-        else:
-            flags |= Qt.WindowType.WindowTransparentForInput
         self.setWindowFlags(flags)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
+        # One that can be clicked away has to receive the click, which means it
+        # also swallows one aimed at whatever is underneath it. The rest stay
+        # transparent to the mouse, as an indicator should be.
+        if dismissable:
+            self.setCursor(Qt.CursorShape.PointingHandCursor)
+        else:
+            self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.resize(MIN_WIDTH, HEIGHT)
 
@@ -197,19 +193,11 @@ class Overlay(QWidget):
         to be a real repaint, not just zero opacity: with the animation stopped
         nothing else damages the surface, and the stale frame would sit on the
         screen until some other event made the compositor redraw it.
-
-        A window that stays mapped also stays clickable, though, and the one
-        that can be dismissed is the one that takes clicks. Left at full size it
-        would turn its corner of the screen into a dead zone long after there
-        was anything to see there, so it shrinks to a point. Resizing keeps the
-        surface alive, unlike hiding it.
         """
         self._anim.stop()
         self.state = "hidden"
         self._concealed = True
         self.repaint()
-        if self.dismissable:
-            self.resize(1, 1)
 
     def _resize_to_content(self):
         if self.state in LIVE:

--- a/overlay.py
+++ b/overlay.py
@@ -68,16 +68,17 @@ class Overlay(QWidget):
         # is a request to a window manager that is not listening.
         if not IS_WINDOWS:
             flags |= Qt.WindowType.X11BypassWindowManagerHint
-        self.setWindowFlags(flags)
-        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
         # One that can be clicked away has to receive the click, which means it
         # also swallows one aimed at whatever is underneath it. The rest stay
-        # transparent to the mouse, as an indicator should be.
+        # transparent to input at the native window level. A QWidget attribute
+        # would only make Qt discard a click it had already taken.
         if dismissable:
             self.setCursor(Qt.CursorShape.PointingHandCursor)
         else:
-            self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+            flags |= Qt.WindowType.WindowTransparentForInput
+        self.setWindowFlags(flags)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.resize(MIN_WIDTH, HEIGHT)
 
@@ -198,6 +199,9 @@ class Overlay(QWidget):
         self.state = "hidden"
         self._concealed = True
         self.repaint()
+        # A mapped dismissable overlay must not leave an invisible dead zone.
+        if self.dismissable:
+            self.resize(1, 1)
 
     def _resize_to_content(self):
         if self.state in LIVE:

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -16,7 +16,7 @@ ones on this machine.
 
 - Python 3.11, 3.12 or 3.13 — the same versions the tests cover
 - `pip install PyQt6 PyAudioWPatch pyinstaller`
-- [Inno Setup 6](https://jrsoftware.org/isdl.php), for the installer
+- [Inno Setup 6 or 7](https://jrsoftware.org/isdl.php), for the installer
 
 ## Building
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,79 @@
+# Building the Windows package
+
+Two executables in one folder, and an installer around them:
+
+```
+dist/Dikte/DikteApp.exe    the tray application, no console behind it
+dist/Dikte/dikte.exe       the command line, which needs one
+dist/Dikte-1.0.0-setup.exe the installer
+```
+
+The build has to run **on Windows**. PyInstaller freezes the interpreter it is
+run by; there is no cross-compilation, and the Qt libraries it collects are the
+ones on this machine.
+
+## What it needs
+
+- Python 3.11, 3.12 or 3.13 — the same versions the tests cover
+- `pip install PyQt6 PyAudioWPatch pyinstaller`
+- [Inno Setup 6](https://jrsoftware.org/isdl.php), for the installer
+
+## Building
+
+```powershell
+powershell -ExecutionPolicy Bypass -File packaging\windows\build.ps1 -Version 1.0.0
+```
+
+In order, that: runs the test suite, draws `dikte.ico`, fetches and verifies
+FFmpeg, freezes both executables, starts the packaged command line to prove it
+starts at all, and compiles the installer.
+
+Useful flags while iterating: `-SkipTests`, `-SkipFfmpeg`, `-SkipInstaller`,
+and `-Python` when the environment is not on the PATH as `python`.
+
+## The pieces
+
+| File | What it is |
+|---|---|
+| `build.ps1` | the whole thing, in order |
+| `dikte.spec` | PyInstaller: what to freeze, what to leave out |
+| `make_icon.py` | draws `dikte.ico` from the same code the tray icon uses |
+| `ffmpeg.json` | the FFmpeg build to carry, pinned by sha256 |
+| `fetch_ffmpeg.py` | fetches it, refuses it unless the digest matches |
+| `dikte.iss` | Inno Setup: a per-user installer with no elevation |
+
+## Decisions worth knowing about
+
+**One folder, not one file.** A one-file build unpacks itself into a temporary
+directory on every start — Qt, the sound library, a few hundred files — before
+the tray icon appears. Dikte is started once per login and asked for a key
+press a second later.
+
+**Per user, no administrator.** `PrivilegesRequired=lowest`, installed into
+`%LOCALAPPDATA%`. This is not tidiness: Windows will not let a program running
+as administrator send input to one that is not, so a Dikte installed and run
+elevated could not paste into anything ordinary.
+
+**Autostart through `HKCU\...\CurrentVersion\Run`.** A shortcut only exists
+while Dikte runs, so Dikte has to be running.
+
+**Uninstalling keeps your things.** Settings, history, meetings and downloaded
+models live in `%APPDATA%\Dikte` and `%LOCALAPPDATA%\Dikte`, and the uninstaller
+asks before touching them, with No as the default. The models alone can be
+several gigabytes somebody chose to download.
+
+**FFmpeg is pinned, not fetched fresh.** `ffmpeg.json` names one build and its
+sha256; `fetch_ffmpeg.py` refuses anything else. A build fetched at package
+time is a build nobody has run, and "whatever was on the server that afternoon"
+is not something to put inside an installer. It is the GPL build, which is what
+Dikte's own licence allows; the notice goes into the installer beside Dikte's.
+
+To move to a newer FFmpeg: pick a dated `autobuild-…` tag from
+[BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds/releases), take the
+digest the GitHub API publishes for the `win64-gpl.zip` asset, and put the URL
+and the digest in `ffmpeg.json`. Nothing else reads a version number.
+
+**Signing.** The installer is not signed here. An unsigned installer meets
+SmartScreen on a machine that has not seen it before; signing it needs a
+certificate that cannot live in a repository. Sign `dist\Dikte\*.exe` and the
+setup executable with `signtool` before publishing.

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -1,0 +1,105 @@
+# Build the Windows package: the icon, the two executables, the installer.
+#
+#   powershell -ExecutionPolicy Bypass -File packaging\windows\build.ps1
+#   ... -Version 1.2.0 -SkipInstaller -SkipFfmpeg
+#
+# Has to run on Windows: PyInstaller freezes the interpreter it is run by, and
+# there is no cross-compilation. Needs the environment Dikte runs in (PyQt6,
+# PyAudioWPatch, pyinstaller) and, for the installer, Inno Setup 6.
+
+[CmdletBinding()]
+param(
+    [string]$Version = "1.0.0",
+    [string]$Python = "python",
+    [switch]$SkipFfmpeg,
+    [switch]$SkipInstaller,
+    [switch]$SkipTests
+)
+
+$ErrorActionPreference = "Stop"
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$root = (Resolve-Path (Join-Path $here "..\..")).Path
+$dist = Join-Path $root "dist"
+$app = Join-Path $dist "Dikte"
+
+function Step($message) {
+    Write-Host ""
+    Write-Host "==> $message" -ForegroundColor Cyan
+}
+
+Push-Location $root
+try {
+    # --- the tests ---------------------------------------------------------
+    # Before anything is packaged, not after: an installer built from a tree
+    # that does not pass its own tests is an installer somebody will run.
+    if (-not $SkipTests) {
+        Step "tests"
+        & $Python -m unittest discover -s tests -t .
+        if ($LASTEXITCODE -ne 0) { throw "the tests did not pass" }
+    }
+
+    # --- the icon ----------------------------------------------------------
+    Step "icon"
+    & $Python (Join-Path $here "make_icon.py")
+    if ($LASTEXITCODE -ne 0) { throw "could not draw the icon" }
+
+    # --- ffmpeg ------------------------------------------------------------
+    # Fetched and checked against the digest pinned in ffmpeg.json, then
+    # dropped in beside the executables so that the loader and shutil.which
+    # both find it without anything being installed.
+    $vendor = Join-Path $here "vendor"
+    if (-not $SkipFfmpeg) {
+        Step "ffmpeg"
+        & $Python (Join-Path $here "fetch_ffmpeg.py") $vendor
+        if ($LASTEXITCODE -ne 0) { throw "could not fetch ffmpeg" }
+    }
+
+    # --- the executables ---------------------------------------------------
+    Step "pyinstaller"
+    if (Test-Path $app) { Remove-Item -Recurse -Force $app }
+    & $Python -m PyInstaller --noconfirm --clean `
+        --distpath $dist --workpath (Join-Path $root "build") `
+        (Join-Path $here "dikte.spec")
+    if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed" }
+
+    if (-not $SkipFfmpeg -and (Test-Path $vendor)) {
+        Copy-Item (Join-Path $vendor "*.exe") $app -Force
+    }
+
+    # A build nobody has started is a build that does not start: this is the
+    # smoke test, and it is the one thing that catches a missing hidden import.
+    Step "smoke test"
+    $cli = Join-Path $app "dikte.exe"
+    $out = & $cli --help 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "the packaged command line would not run: $out" }
+    # doctor imports the sound library, the clipboard and the hotkey adapter,
+    # which is where a missing hidden import shows up. Exit 1 is a machine
+    # with no API key, not a broken build.
+    $out = & $cli doctor --json 2>&1
+    if ($LASTEXITCODE -gt 1) { throw "the packaged doctor would not run: $out" }
+    Write-Host $out
+
+    # --- the installer -----------------------------------------------------
+    if (-not $SkipInstaller) {
+        Step "installer"
+        $iscc = @(
+            "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
+            "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
+        ) | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $iscc) {
+            throw "Inno Setup 6 is not installed. Get it from https://jrsoftware.org/isdl.php, or pass -SkipInstaller."
+        }
+        & $iscc "/DVersion=$Version" (Join-Path $here "dikte.iss")
+        if ($LASTEXITCODE -ne 0) { throw "Inno Setup failed" }
+    }
+
+    Step "done"
+    Get-ChildItem $dist -Filter "*.exe" | ForEach-Object {
+        Write-Host ("  {0}  {1:N1} MB" -f $_.Name, ($_.Length / 1MB))
+    }
+    Write-Host "  $app"
+}
+finally {
+    Pop-Location
+}

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -5,7 +5,7 @@
 #
 # Has to run on Windows: PyInstaller freezes the interpreter it is run by, and
 # there is no cross-compilation. Needs the environment Dikte runs in (PyQt6,
-# PyAudioWPatch, pyinstaller) and, for the installer, Inno Setup 6.
+# PyAudioWPatch, pyinstaller) and, for the installer, Inno Setup 6 or 7.
 
 [CmdletBinding()]
 param(
@@ -84,11 +84,14 @@ try {
     if (-not $SkipInstaller) {
         Step "installer"
         $iscc = @(
+            (Join-Path $root ".tools\Inno\ISCC.exe"),
+            "$env:ProgramFiles\Inno Setup 7\ISCC.exe",
+            "${env:ProgramFiles(x86)}\Inno Setup 7\ISCC.exe",
             "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe",
             "$env:ProgramFiles\Inno Setup 6\ISCC.exe"
         ) | Where-Object { Test-Path $_ } | Select-Object -First 1
         if (-not $iscc) {
-            throw "Inno Setup 6 is not installed. Get it from https://jrsoftware.org/isdl.php, or pass -SkipInstaller."
+            throw "Inno Setup 6 or 7 is not installed. Get it from https://jrsoftware.org/isdl.php, or pass -SkipInstaller."
         }
         & $iscc "/DVersion=$Version" (Join-Path $here "dikte.iss")
         if ($LASTEXITCODE -ne 0) { throw "Inno Setup failed" }

--- a/packaging/windows/dikte.iss
+++ b/packaging/windows/dikte.iss
@@ -169,7 +169,11 @@ begin
     RemoveFromPath(ExpandConstant('{app}'));
     // Asked rather than assumed, and answered no by default: what is in there
     // is somebody's dictation history and their API keys.
-    if MsgBox(CustomMessage('RemoveData'), mbConfirmation, MB_YESNO or MB_DEFBUTTON2) = IDYES then
+    // A silent uninstall must remain truly unattended. Preserve user data in
+    // that mode; deleting it always requires an explicit interactive choice.
+    if (not UninstallSilent) and
+       (MsgBox(CustomMessage('RemoveData'), mbConfirmation,
+               MB_YESNO or MB_DEFBUTTON2) = IDYES) then
       DeleteUserData();
   end;
 end;

--- a/packaging/windows/dikte.iss
+++ b/packaging/windows/dikte.iss
@@ -88,8 +88,8 @@ Name: "addtopath"; Description: "{cm:PathTask}"; Flags: unchecked
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#TrayExe}"
-Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#TrayExe}"; Tasks: desktopicon
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#TrayExe}"; Parameters: "settings"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#TrayExe}"; Parameters: "settings"; Tasks: desktopicon
 
 [Registry]
 ; The Run key is how Windows starts a program when its user signs in. Under
@@ -102,7 +102,7 @@ Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
     Tasks: not autostart
 
 [Run]
-Filename: "{app}\{#TrayExe}"; Description: "{cm:LaunchApp}"; \
+Filename: "{app}\{#TrayExe}"; Parameters: "settings"; Description: "{cm:LaunchApp}"; \
     Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]

--- a/packaging/windows/dikte.iss
+++ b/packaging/windows/dikte.iss
@@ -1,0 +1,188 @@
+; Inno Setup script for Dikte on Windows.
+;
+; Installed for one user, into %LOCALAPPDATA%, with no administrator prompt.
+; Dikte holds a global shortcut and types into other people's windows, and
+; Windows will not let a program running as administrator send input to one
+; that is not — so an installation that needed elevation would be an
+; application that could not do its job.
+;
+; What it removes on uninstall is the program. Settings, history, meetings and
+; downloaded models are somebody's work and their API keys; they are left where
+; they are unless the box is ticked.
+;
+;   iscc /DVersion=1.0.0 packaging\windows\dikte.iss
+
+#ifndef Version
+  #define Version "1.0.0"
+#endif
+#ifndef SourceDir
+  #define SourceDir "..\..\dist\Dikte"
+#endif
+
+#define AppName "Dikte"
+#define AppPublisher "Dikte"
+#define AppUrl "https://github.com/yusufipk/dikte"
+#define TrayExe "DikteApp.exe"
+#define CliExe "dikte.exe"
+
+[Setup]
+AppId={{7C2F5C4E-6C1B-4F55-9B4A-1B8C2E5D9A31}
+AppName={#AppName}
+AppVersion={#Version}
+AppPublisher={#AppPublisher}
+AppPublisherURL={#AppUrl}
+AppSupportURL={#AppUrl}
+VersionInfoVersion={#Version}
+
+; Per user, everywhere. PrivilegesRequired=lowest is what keeps the elevation
+; prompt away; without it the whole install would run as administrator and the
+; shortcut would be registered for the wrong account.
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+DefaultDirName={autopf}\{#AppName}
+UsePreviousAppDir=yes
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+AllowNoIcons=yes
+
+OutputDir=..\..\dist
+OutputBaseFilename=Dikte-{#Version}-setup
+SetupIconFile=dikte.ico
+UninstallDisplayIcon={app}\{#TrayExe}
+WizardStyle=modern
+Compression=lzma2/max
+SolidCompression=yes
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+; Windows 10 22H2 and later: WASAPI loopback and the shortcut work further
+; back, but nothing older has been tested and saying so beats finding out.
+MinVersion=10.0.19045
+LicenseFile=..\..\LICENSE
+CloseApplications=yes
+CloseApplicationsFilter=*.exe
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "turkish"; MessagesFile: "compiler:Languages\Turkish.isl"
+
+[CustomMessages]
+english.AutostartTask=Start Dikte when I sign in
+english.PathTask=Add the dikte command to my PATH
+english.LaunchApp=Start Dikte
+english.RemoveData=Also delete my settings, history, meetings and downloaded models
+english.RemoveDataTitle=Removing Dikte
+english.RemoveDataSubtitle=What should be left behind?
+turkish.AutostartTask=Oturum açtığımda Dikte'yi başlat
+turkish.PathTask=dikte komutunu PATH'e ekle
+turkish.LaunchApp=Dikte'yi başlat
+turkish.RemoveData=Ayarlarımı, geçmişimi, toplantılarımı ve indirdiğim modelleri de sil
+turkish.RemoveDataTitle=Dikte kaldırılıyor
+turkish.RemoveDataSubtitle=Geriye ne kalsın?
+
+[Tasks]
+Name: "autostart"; Description: "{cm:AutostartTask}"
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; Flags: unchecked
+Name: "addtopath"; Description: "{cm:PathTask}"; Flags: unchecked
+
+[Files]
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#TrayExe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#TrayExe}"; Tasks: desktopicon
+
+[Registry]
+; The Run key is how Windows starts a program when its user signs in. Under
+; HKCU, so it is this account's business and needs no administrator.
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
+    ValueType: string; ValueName: "Dikte"; ValueData: """{app}\{#TrayExe}"""; \
+    Flags: uninsdeletevalue; Tasks: autostart
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; \
+    ValueType: none; ValueName: "Dikte"; Flags: deletevalue uninsdeletevalue; \
+    Tasks: not autostart
+
+[Run]
+Filename: "{app}\{#TrayExe}"; Description: "{cm:LaunchApp}"; \
+    Flags: nowait postinstall skipifsilent
+
+[UninstallDelete]
+; The one thing under {app} that is not ours to leave: PyInstaller's caches.
+Type: filesandordirs; Name: "{app}\__pycache__"
+
+[Code]
+
+// --- PATH, for the console half ------------------------------------------
+
+function PathHas(const Needle: string): Boolean;
+var
+  Existing: string;
+begin
+  Result := False;
+  if RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Existing) then
+    Result := Pos(';' + Uppercase(Needle) + ';', ';' + Uppercase(Existing) + ';') > 0;
+end;
+
+procedure AddToPath(const Folder: string);
+var
+  Existing: string;
+begin
+  if PathHas(Folder) then
+    Exit;
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Existing) then
+    Existing := '';
+  if (Existing <> '') and (Existing[Length(Existing)] <> ';') then
+    Existing := Existing + ';';
+  RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path',
+                            Existing + Folder);
+end;
+
+procedure RemoveFromPath(const Folder: string);
+var
+  Existing: string;
+  At: Integer;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Existing) then
+    Exit;
+  At := Pos(Uppercase(Folder) + ';', Uppercase(Existing + ';'));
+  if At = 0 then
+    Exit;
+  Delete(Existing, At, Length(Folder) + 1);
+  if (Existing <> '') and (Existing[Length(Existing)] = ';') then
+    Delete(Existing, Length(Existing), 1);
+  RegWriteExpandStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', Existing);
+end;
+
+// --- uninstalling ---------------------------------------------------------
+
+procedure DeleteUserData();
+begin
+  // %APPDATA%\Dikte holds config.json, %LOCALAPPDATA%\Dikte the models,
+  // the history, the meetings and the recordings.
+  DelTree(ExpandConstant('{userappdata}\Dikte'), True, True, True);
+  DelTree(ExpandConstant('{localappdata}\Dikte'), True, True, True);
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if CurUninstallStep = usUninstall then
+  begin
+    RemoveFromPath(ExpandConstant('{app}'));
+    // Asked rather than assumed, and answered no by default: what is in there
+    // is somebody's dictation history and their API keys.
+    if MsgBox(CustomMessage('RemoveData'), mbConfirmation, MB_YESNO or MB_DEFBUTTON2) = IDYES then
+      DeleteUserData();
+  end;
+end;
+
+// --- installing -----------------------------------------------------------
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+  begin
+    if WizardIsTaskSelected('addtopath') then
+      AddToPath(ExpandConstant('{app}'))
+    else
+      RemoveFromPath(ExpandConstant('{app}'));
+  end;
+end;

--- a/packaging/windows/dikte.spec
+++ b/packaging/windows/dikte.spec
@@ -1,0 +1,122 @@
+# PyInstaller spec: one folder holding both faces of Dikte.
+#
+#     DikteApp.exe   the tray application, with no console behind it
+#     dikte.exe      the command line, which needs one
+#
+# One folder rather than one file, because a one-file build unpacks itself into
+# a temporary directory on every start: Qt, the sound library and a hundred
+# small files, before the tray icon appears. Dikte is started once per login
+# and asked for a key press a second later, so the start is what matters.
+#
+# The two executables share everything else. PyInstaller collects the libraries
+# once and both EXEs sit in the same directory beside them, which is also what
+# lets `dikte restart` hand over to DikteApp.exe without knowing where it is.
+#
+#     pyinstaller --noconfirm packaging/windows/dikte.spec
+
+import pathlib
+import sys
+
+ROOT = pathlib.Path(SPECPATH).resolve().parents[1]
+ICON = str(pathlib.Path(SPECPATH) / "dikte.ico")
+
+
+def conda_dlls():
+    """The libraries a conda interpreter keeps somewhere PyInstaller misses.
+
+    A conda environment puts its C libraries in Library\\bin rather than beside
+    the interpreter, and PyInstaller's dependency walk does not go there. The
+    one that matters is libffi: without it `import ctypes` fails inside the
+    packaged build, which is every Win32 call Dikte makes, and the failure
+    arrives as an unhandled exception before the tray icon appears.
+    """
+    library = pathlib.Path(sys.base_prefix) / "Library" / "bin"
+    if not library.is_dir():
+        return []
+    wanted = ("ffi-8.dll", "ffi-7.dll", "ffi.dll", "libcrypto-3-x64.dll",
+              "libssl-3-x64.dll")
+    return [(str(library / name), ".") for name in wanted
+            if (library / name).is_file()]
+
+# Everything Dikte imports by name at run time rather than at the top of a
+# file. The platform adapters are chosen through importlib, so nothing that
+# reads the source can see that they are needed.
+HIDDEN = [
+    "platforms.windows.audio",
+    "platforms.windows.clipboard",
+    "platforms.windows.hotkeys",
+    "platforms.windows.runtime",
+    "platforms.windows.resample",
+    "platforms.common.pcm",
+    "platforms.common.shortcuts",
+    "pyaudiowpatch",
+]
+
+# The Qt pieces Dikte never touches. Left in, a build carries WebEngine, 3D and
+# the SQL drivers — several hundred megabytes of installer for an application
+# that draws a rounded rectangle and a waveform.
+EXCLUDED = [
+    "PyQt6.QtWebEngineCore", "PyQt6.QtWebEngineWidgets", "PyQt6.QtWebChannel",
+    "PyQt6.Qt3DCore", "PyQt6.Qt3DRender", "PyQt6.QtQuick", "PyQt6.QtQml",
+    "PyQt6.QtSql", "PyQt6.QtTest", "PyQt6.QtDesigner", "PyQt6.QtPdf",
+    "PyQt6.QtMultimedia", "PyQt6.QtCharts", "PyQt6.QtDataVisualization",
+    "tkinter", "unittest", "pydoc_data", "test",
+]
+
+analysis = Analysis(
+    [str(ROOT / "dikte.py")],
+    pathex=[str(ROOT)],
+    binaries=conda_dlls(),
+    datas=[(ICON, ".")],
+    hiddenimports=HIDDEN,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=EXCLUDED,
+    noarchive=False,
+)
+
+pyz = PYZ(analysis.pure)
+
+# The tray application. console=False is what keeps a black window from opening
+# behind it at every login.
+tray = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="DikteApp",
+    icon=ICON,
+    console=False,
+    debug=False,
+    strip=False,
+    upx=False,
+    # Dikte is installed for one user and asks for nothing it does not have;
+    # an application that requested elevation could not send a key press to
+    # anything running without it either.
+    uac_admin=False,
+)
+
+# The same program with a console, so that `dikte transcribe talk.mp4` can
+# print what it did into the terminal it was typed in.
+console = EXE(
+    pyz,
+    analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="dikte",
+    icon=ICON,
+    console=True,
+    debug=False,
+    strip=False,
+    upx=False,
+)
+
+COLLECT(
+    tray,
+    console,
+    analysis.binaries,
+    analysis.datas,
+    strip=False,
+    upx=False,
+    name="Dikte",
+)

--- a/packaging/windows/fetch_ffmpeg.py
+++ b/packaging/windows/fetch_ffmpeg.py
@@ -1,0 +1,99 @@
+"""Fetch the pinned FFmpeg build for the Windows package, and check it.
+
+FFmpeg is what turns somebody's .mp4 into something a transcription model will
+take, and what a Windows user should not have to install by hand before Dikte
+works. It is fetched once at package time from the release named in
+ffmpeg.json and refused unless its sha256 is the one written there. That is the
+same rule ggml.py holds every downloaded program to, for the same reason: this
+is a program the application then runs.
+
+    python packaging/windows/fetch_ffmpeg.py [into/]
+
+Leaves ffmpeg.exe and ffprobe.exe in `into` (default: vendor/ next to this
+file). Already there and already the right size, it does nothing.
+"""
+
+import hashlib
+import json
+import pathlib
+import shutil
+import sys
+import tempfile
+import urllib.request
+import zipfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+MANIFEST = HERE / "ffmpeg.json"
+CHUNK = 1 << 20
+
+
+def load():
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def fetch(url, target, expected, total):
+    digest = hashlib.sha256()
+    done = 0
+    request = urllib.request.Request(url, headers={"User-Agent": "dikte-build/1.0"})
+    with urllib.request.urlopen(request, timeout=120) as response, \
+            open(target, "wb") as out:
+        while True:
+            block = response.read(CHUNK)
+            if not block:
+                break
+            out.write(block)
+            digest.update(block)
+            done += len(block)
+            if total:
+                sys.stderr.write(f"\r  {done / total:6.1%} of {total >> 20} MB")
+                sys.stderr.flush()
+    sys.stderr.write("\n")
+    if digest.hexdigest() != expected:
+        raise SystemExit(
+            f"ffmpeg does not match its pinned checksum.\n"
+            f"  expected {expected}\n  got      {digest.hexdigest()}\n"
+            "Nothing was unpacked. Update ffmpeg.json deliberately, or find out "
+            "why the bytes changed."
+        )
+
+
+def unpack(archive, wanted, into):
+    """Take the named programs out, wherever in the archive they happen to be."""
+    found = []
+    with zipfile.ZipFile(archive) as zf:
+        for member in zf.infolist():
+            name = member.filename.replace("\\", "/").rsplit("/", 1)[-1]
+            if name not in wanted:
+                continue
+            target = into / name
+            with zf.open(member) as source, open(target, "wb") as out:
+                shutil.copyfileobj(source, out)
+            found.append(name)
+    missing = set(wanted) - set(found)
+    if missing:
+        raise SystemExit(f"not in the archive: {', '.join(sorted(missing))}")
+    return found
+
+
+def main(argv):
+    manifest = load()
+    into = pathlib.Path(argv[0]) if argv else (HERE / "vendor")
+    into.mkdir(parents=True, exist_ok=True)
+
+    wanted = list(manifest["wanted"])
+    if all((into / name).is_file() for name in wanted):
+        print(f"ffmpeg already in {into}")
+        return 0
+
+    print(f"fetching {manifest['name']}")
+    with tempfile.TemporaryDirectory() as scratch:
+        archive = pathlib.Path(scratch) / manifest["name"]
+        fetch(manifest["url"], archive, manifest["sha256"], manifest.get("size", 0))
+        found = unpack(archive, wanted, into)
+    print(f"unpacked {', '.join(found)} into {into}")
+    print(f"licence: {manifest['license']}, {manifest['license_url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/packaging/windows/ffmpeg.json
+++ b/packaging/windows/ffmpeg.json
@@ -1,0 +1,23 @@
+{
+  "_comment": [
+    "The FFmpeg build the Windows installer carries. Pinned by digest rather",
+    "than by 'latest': a build fetched at package time is a build nobody has",
+    "run, and 'whatever was on the server that afternoon' is not a thing to",
+    "ship a signed installer with.",
+    "",
+    "This is the static GPL build, one ffmpeg.exe with no DLLs beside it, from",
+    "BtbN/FFmpeg-Builds. GPL rather than LGPL because Dikte is GPL-3.0 itself,",
+    "and the licence notice goes into the installer beside Dikte's own.",
+    "",
+    "To move to a newer one: pick a dated autobuild tag, take the digest the",
+    "GitHub API publishes for the asset, and put both here. Nothing else in",
+    "the build reads a version number."
+  ],
+  "name": "ffmpeg-N-125907-ga7e72069f1-win64-gpl.zip",
+  "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-02-13-17/ffmpeg-N-125907-ga7e72069f1-win64-gpl.zip",
+  "sha256": "336b99f961a2b69dff75193d161dfa7c091705225b8b0b20e6015af7d58df9bc",
+  "size": 169715536,
+  "wanted": ["ffmpeg.exe", "ffprobe.exe"],
+  "license": "GPL-3.0-or-later",
+  "license_url": "https://www.ffmpeg.org/legal.html"
+}

--- a/packaging/windows/make_icon.py
+++ b/packaging/windows/make_icon.py
@@ -1,0 +1,93 @@
+"""Render the application icon into a .ico for the .exe and the installer.
+
+Drawn from the same microphone the tray icon uses, so the taskbar, the Start
+menu, the installer and the tray are one picture rather than four. Written as
+an icon file here rather than carried in the repository as a binary, because
+the drawing is the source and a checked-in .ico is a copy of it that nobody
+would notice going stale.
+
+The colour is fixed rather than taken from the system: this one goes on a
+window frame, a Start menu tile and a setup dialogue, none of which follow the
+tray's light-or-dark question.
+
+    python packaging/windows/make_icon.py [path/to/dikte.ico]
+"""
+
+import os
+import pathlib
+import struct
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtCore import QBuffer, QIODevice  # noqa: E402
+from PyQt6.QtGui import QColor  # noqa: E402
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+import icons  # noqa: E402
+
+# What Windows asks for: the small ones for a list, 32 and 48 for the desktop
+# and Alt-Tab, 256 for the large icon view and the installer.
+SIZES = (16, 20, 24, 32, 40, 48, 64, 128, 256)
+
+# Dikte's own blue, dark enough to read on a light background and light enough
+# to read on a dark one.
+COLOUR = QColor(64, 132, 214)
+
+
+def png_for(size):
+    icon = icons.tray_icon("audio-input-microphone")
+    pixmap = icon.pixmap(size, size)
+    buffer = QBuffer()
+    buffer.open(QIODevice.OpenModeFlag.WriteOnly)
+    pixmap.save(buffer, "PNG")
+    return bytes(buffer.data())
+
+
+def write_ico(path, images):
+    """An .ico holding PNG entries, which Windows has taken since Vista.
+
+    Written by hand because Qt's icon writer is a plugin that may or may not
+    have been shipped, and a build that silently produces no icon is worse than
+    forty lines of struct.
+    """
+    header = struct.pack("<HHH", 0, 1, len(images))
+    directory = b""
+    body = b""
+    offset = len(header) + 16 * len(images)
+    for size, payload in images:
+        directory += struct.pack(
+            "<BBBBHHII",
+            0 if size >= 256 else size,   # 0 means 256
+            0 if size >= 256 else size,
+            0,          # no colour palette
+            0,          # reserved
+            1,          # colour planes
+            32,         # bits per pixel
+            len(payload),
+            offset,
+        )
+        body += payload
+        offset += len(payload)
+    pathlib.Path(path).write_bytes(header + directory + body)
+
+
+def main(argv):
+    target = pathlib.Path(argv[0]) if argv else (
+        pathlib.Path(__file__).with_name("dikte.ico"))
+    app = QApplication(sys.argv[:1])       # noqa: F841 - QPixmap needs one
+    icons.forget()
+    # The tray icon asks the palette what colour to be; this one does not.
+    icons.DRAWINGS["audio-input-microphone"] = (
+        icons.DRAWINGS["audio-input-microphone"][0], COLOUR)
+    images = [(size, png_for(size)) for size in SIZES]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    write_ico(target, images)
+    print(f"{target}: {len(images)} sizes, {target.stat().st_size} bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/paste.py
+++ b/paste.py
@@ -440,3 +440,29 @@ def press(shortcut="", delay=0.12):
     """Press a paste combination, e.g. 'ctrl+v', or this desktop's own."""
     here = desktop()
     here.press(shortcut or here.shortcuts[0], delay)
+
+
+if sys.platform.startswith("win"):
+    from platforms import adapter as _platform_adapter
+
+    _windows_clipboard = _platform_adapter("clipboard", "windows")
+    PasteError = _windows_clipboard.PasteError
+    read_clipboard = _windows_clipboard.read_clipboard
+    copy = _windows_clipboard.copy
+    copy_bytes = _windows_clipboard.copy_bytes
+    paste_ready = _windows_clipboard.paste_ready
+    press = _windows_clipboard.press
+
+    WINDOWS = Desktop(
+        clipboard="Windows Clipboard",
+        packages="",
+        read_command=[],
+        copy_command=[],
+        shortcuts=["ctrl+v", "ctrl+shift+v", "shift+insert"],
+        keyboard="SendInput",
+        ready=_windows_clipboard.paste_ready,
+        press=_windows_clipboard.press,
+    )
+
+    def desktop():
+        return WINDOWS

--- a/paste.py
+++ b/paste.py
@@ -442,16 +442,18 @@ def press(shortcut="", delay=0.12):
     here.press(shortcut or here.shortcuts[0], delay)
 
 
+_LegacyPasteError = PasteError
+_legacy_desktop = desktop
+_legacy_read_clipboard = read_clipboard
+_legacy_copy = copy
+_legacy_copy_bytes = copy_bytes
+_legacy_paste_ready = paste_ready
+_legacy_press = press
+
 if sys.platform.startswith("win"):
     from platforms import adapter as _platform_adapter
 
     _windows_clipboard = _platform_adapter("clipboard", "windows")
-    PasteError = _windows_clipboard.PasteError
-    read_clipboard = _windows_clipboard.read_clipboard
-    copy = _windows_clipboard.copy
-    copy_bytes = _windows_clipboard.copy_bytes
-    paste_ready = _windows_clipboard.paste_ready
-    press = _windows_clipboard.press
 
     WINDOWS = Desktop(
         clipboard="Windows Clipboard",
@@ -465,4 +467,36 @@ if sys.platform.startswith("win"):
     )
 
     def desktop():
-        return WINDOWS
+        return WINDOWS if sys.platform.startswith("win") else _legacy_desktop()
+
+    def read_clipboard():
+        return (_windows_clipboard.read_clipboard()
+                if sys.platform.startswith("win") else _legacy_read_clipboard())
+
+    def _windows_call(function, *args, **kwargs):
+        try:
+            return function(*args, **kwargs)
+        except _windows_clipboard.PasteError as exc:
+            raise PasteError(str(exc)) from exc
+
+    def copy(text):
+        if sys.platform.startswith("win"):
+            return _windows_call(_windows_clipboard.copy, text)
+        return _legacy_copy(text)
+
+    def copy_bytes(data):
+        if isinstance(data, _MAC_SNAPSHOT):
+            return _legacy_copy_bytes(data)
+        if sys.platform.startswith("win"):
+            return _windows_call(_windows_clipboard.copy_bytes, data)
+        return _legacy_copy_bytes(data)
+
+    def paste_ready():
+        return (_windows_clipboard.paste_ready() if sys.platform.startswith("win")
+                else _legacy_paste_ready())
+
+    def press(shortcut="", delay=0.12):
+        if sys.platform.startswith("win"):
+            return _windows_call(_windows_clipboard.press,
+                                 shortcut or WINDOWS.shortcuts[0], delay)
+        return _legacy_press(shortcut, delay)

--- a/platforms/__init__.py
+++ b/platforms/__init__.py
@@ -26,15 +26,13 @@ import sys
 
 WINDOWS = "windows"
 LINUX = "linux"
+MACOS = "macos"
 
 IS_WINDOWS = sys.platform.startswith("win")
 IS_LINUX = sys.platform.startswith("linux")
+IS_MACOS = sys.platform == "darwin"
 
-# Nothing else is ported. macOS and the BSDs land on the Linux adapters, which
-# is right for the parts that go through POSIX and wrong for the parts that go
-# through PipeWire; the failure is then a missing program with its name in the
-# message rather than an import error at startup.
-NAME = WINDOWS if IS_WINDOWS else LINUX
+NAME = WINDOWS if IS_WINDOWS else MACOS if IS_MACOS else LINUX
 
 _loaded = {}
 

--- a/platforms/__init__.py
+++ b/platforms/__init__.py
@@ -1,0 +1,67 @@
+"""Which operating system this is, and the adapter that speaks to it.
+
+Everything Dikte does that a desktop can refuse is written once per operating
+system under here, behind one contract each: capturing a microphone, owning the
+clipboard, pressing a key in somebody else's window, registering a shortcut the
+whole session sees, naming a socket only this user may open.
+
+The modules above this line (audio.py, paste.py, hotkey.py, config.py) are the
+contract. They pick an adapter at import and hand its functions on under the
+names the rest of Dikte has always called them by, so worker.py, meeting.py and
+dikte.py never learn which desktop they are on.
+
+Four parts, the same four on every platform:
+
+    audio       capturing the microphone and what the speakers are playing
+    clipboard   owning the clipboard and pressing a key combination
+    hotkeys     a shortcut the session delivers even when Dikte has no focus
+    runtime     directories, secrets, process lifetime, single instance
+
+An adapter may leave out what its platform has no answer for; the contract
+module is where that is turned into a refusal the interface can show.
+"""
+
+import importlib
+import sys
+
+WINDOWS = "windows"
+LINUX = "linux"
+
+IS_WINDOWS = sys.platform.startswith("win")
+IS_LINUX = sys.platform.startswith("linux")
+
+# Nothing else is ported. macOS and the BSDs land on the Linux adapters, which
+# is right for the parts that go through POSIX and wrong for the parts that go
+# through PipeWire; the failure is then a missing program with its name in the
+# message rather than an import error at startup.
+NAME = WINDOWS if IS_WINDOWS else LINUX
+
+_loaded = {}
+
+
+def adapter(part, name=""):
+    """The module implementing `part`, on this platform unless another is named.
+
+    Imported on demand and remembered: a test that asks for the other
+    platform's adapter gets it without the import cost being paid twice, and a
+    machine that never records never imports the sound library.
+
+    `NAME` is read here rather than baked into the signature, so that a test
+    can point the whole application at the other platform's adapters and load
+    them: half of what a port breaks is only visible from the other side.
+    """
+    name = name or NAME
+    key = (name, part)
+    if key not in _loaded:
+        _loaded[key] = importlib.import_module(f"platforms.{name}.{part}")
+    return _loaded[key]
+
+
+def take(part, *names, name=""):
+    """The named attributes of an adapter, for a contract module to re-export.
+
+    Missing ones come back as None rather than raising, so that a contract can
+    offer what this platform has and answer for what it does not.
+    """
+    module = adapter(part, name)
+    return tuple(getattr(module, attribute, None) for attribute in names)

--- a/platforms/__init__.py
+++ b/platforms/__init__.py
@@ -36,6 +36,18 @@ NAME = WINDOWS if IS_WINDOWS else MACOS if IS_MACOS else LINUX
 
 _loaded = {}
 
+# The macOS implementations still live in the original contract modules.  The
+# Windows port moved Linux and Windows behind dedicated adapter packages, but
+# routing macOS through a package that only contains ``runtime`` made calls
+# such as adapter("hotkeys") try to import modules that do not exist.  Keep the
+# established native implementations as the macOS adapters until they are
+# split out in their own right.
+_MACOS_LEGACY = {
+    "audio": "audio",
+    "clipboard": "paste",
+    "hotkeys": "hotkey",
+}
+
 
 def adapter(part, name=""):
     """The module implementing `part`, on this platform unless another is named.
@@ -51,7 +63,10 @@ def adapter(part, name=""):
     name = name or NAME
     key = (name, part)
     if key not in _loaded:
-        _loaded[key] = importlib.import_module(f"platforms.{name}.{part}")
+        module = (_MACOS_LEGACY.get(part)
+                  if name == MACOS else None)
+        _loaded[key] = importlib.import_module(
+            module or f"platforms.{name}.{part}")
     return _loaded[key]
 
 

--- a/platforms/common/__init__.py
+++ b/platforms/common/__init__.py
@@ -1,0 +1,1 @@
+"""What both platforms share: PCM arithmetic and the shape of a recording."""

--- a/platforms/common/pcm.py
+++ b/platforms/common/pcm.py
@@ -1,0 +1,59 @@
+"""The format a recording is in, the level meter, and the WAV writer.
+
+None of this is platform work: signed 16-bit little-endian at 16 kHz is what
+whisper wants wherever it runs, and the arithmetic over it is the same on every
+desktop. It lives below the adapters so that both of them can measure a block
+the same way, and so audio.py can go on offering these names unchanged.
+"""
+
+import array
+import math
+import tempfile
+import wave
+
+RATE = 16000
+CHANNELS = 1
+SAMPLE_WIDTH = 2  # s16
+CHUNK_FRAMES = 1024
+CHUNK_BYTES = CHUNK_FRAMES * SAMPLE_WIDTH * CHANNELS
+CHUNK_LATENCY_MS = round(CHUNK_FRAMES / RATE * 1000)
+MIN_FRAMES = int(RATE * 0.25)
+
+
+def chunk_levels(chunk):
+    """(peak, rms) in 0..1. Peak drives the waveform, RMS drives the silence check."""
+    samples = array.array("h")
+    usable = len(chunk) - (len(chunk) % 2)
+    if usable <= 0:
+        return 0.0, 0.0
+    samples.frombytes(chunk[:usable])
+    peak = max(abs(min(samples)), abs(max(samples))) / 32768.0
+    rms = math.sqrt(sum(s * s for s in samples) / len(samples)) / 32768.0
+    return min(1.0, peak), min(1.0, rms)
+
+
+def stereo_levels(chunk):
+    """(left peak, right peak) in 0..1 from interleaved stereo s16."""
+    samples = array.array("h")
+    usable = len(chunk) - (len(chunk) % 4)
+    if usable <= 0:
+        return 0.0, 0.0
+    samples.frombytes(chunk[:usable])
+    left, right = samples[0::2], samples[1::2]
+    return peak_of(left), peak_of(right)
+
+
+def peak_of(samples):
+    if not samples:
+        return 0.0
+    return min(1.0, max(abs(min(samples)), abs(max(samples))) / 32768.0)
+
+
+def write_wav(pcm, rate=RATE, channels=CHANNELS, width=SAMPLE_WIDTH):
+    fd, path = tempfile.mkstemp(prefix="dikte-", suffix=".wav")
+    with open(fd, "wb") as raw, wave.open(raw, "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(width)
+        wav.setframerate(rate)
+        wav.writeframes(pcm)
+    return path

--- a/platforms/common/shortcuts.py
+++ b/platforms/common/shortcuts.py
@@ -1,0 +1,30 @@
+"""The four global shortcuts, named once.
+
+There are four of them and the command line, the settings window, the installer
+and both platform adapters each used to want their own copy of the list. The
+id is what every platform files a shortcut under: a .desktop file name on
+Linux, and on Windows just the key the registration is remembered by.
+"""
+
+import collections
+
+DESKTOP_ID = "dikte-toggle.desktop"
+CANCEL_DESKTOP_ID = "dikte-cancel.desktop"
+MEETING_DESKTOP_ID = "dikte-meeting.desktop"
+ASK_DESKTOP_ID = "dikte-ask.desktop"
+
+Shortcut = collections.namedtuple("Shortcut", "verb desktop_id name setting fallback")
+
+# `fallback` is what to register when the setting is empty: only the toggle has
+# one, since it is the key the application is unusable without.
+SHORTCUTS = {
+    "toggle": Shortcut("toggle", DESKTOP_ID, "Dikte: start/stop recording",
+                       "shortcut", "Ctrl+Space"),
+    "cancel": Shortcut("cancel", CANCEL_DESKTOP_ID, "Dikte: discard the recording",
+                       "cancel_shortcut", ""),
+    "ask": Shortcut("ask", ASK_DESKTOP_ID, "Dikte: ask Claude Code",
+                    "assistant_shortcut", ""),
+    "meeting": Shortcut("meeting", MEETING_DESKTOP_ID,
+                        "Dikte: start/end a meeting recording",
+                        "meeting_shortcut", ""),
+}

--- a/platforms/linux/__init__.py
+++ b/platforms/linux/__init__.py
@@ -1,0 +1,1 @@
+"""The Linux desktop: PipeWire/PulseAudio, wl-clipboard/X11, KDE/GNOME, XDG."""

--- a/platforms/linux/audio.py
+++ b/platforms/linux/audio.py
@@ -1,27 +1,17 @@
-"""Raw PCM capture with a live level meter.
+"""Raw PCM capture on the Linux desktop, through the sound server's own tools.
 
-Dictation records one source. A meeting records two of them at once, the
-microphone and what comes out of the speakers, and for that it goes through
-ffmpeg: one process reading both devices and merging them into the two channels
-of a single stream, which is the only way the two stay aligned with each other
-over an hour.
-
-Which programs do the capturing is a property of the machine, not of the code
-above: PulseAudio or PipeWire on Linux, AVFoundation through ffmpeg on macOS.
-They are gathered into one group each near the bottom of this file, and a
-chooser picks between them.
+Dictation records one source through parec or pw-record. A meeting records two
+of them at once, the microphone and what comes out of the speakers, and for
+that it goes through ffmpeg instead: one process reading both devices and
+merging them into the two channels of a single stream, which is the only way
+the two stay aligned with each other over an hour.
 """
 
-import array
-import collections
 import json
-import math
 import os
-import re
 import shutil
 import signal
 import subprocess
-import sys
 import tempfile
 import threading
 import wave
@@ -29,14 +19,18 @@ import wave
 from PyQt6.QtCore import QObject, pyqtSignal
 
 from i18n import t
-
-RATE = 16000
-CHANNELS = 1
-SAMPLE_WIDTH = 2  # s16
-CHUNK_FRAMES = 1024
-CHUNK_BYTES = CHUNK_FRAMES * SAMPLE_WIDTH * CHANNELS
-CHUNK_LATENCY_MS = round(CHUNK_FRAMES / RATE * 1000)
-MIN_FRAMES = int(RATE * 0.25)
+from platforms.common.pcm import (
+    CHUNK_BYTES,
+    CHUNK_FRAMES,
+    CHUNK_LATENCY_MS,
+    CHANNELS,
+    MIN_FRAMES,
+    RATE,
+    SAMPLE_WIDTH,
+    chunk_levels,
+    stereo_levels,
+    write_wav,
+)
 
 
 class Recorder(QObject):
@@ -65,7 +59,9 @@ class Recorder(QObject):
             return
         cmd = recording_command(target)
         if not cmd:
-            self.failed.emit(t(sound().missing))
+            self.failed.emit(t(
+                "No audio recorder found. Install pulseaudio-utils or pipewire-audio."
+            ))
             return
 
         try:
@@ -170,24 +166,37 @@ class Recorder(QObject):
         self.stopped.emit(path, frames / RATE, rms)
 
 
-def write_wav(pcm, rate=RATE, channels=CHANNELS, width=SAMPLE_WIDTH):
-    fd, path = tempfile.mkstemp(prefix="dikte-", suffix=".wav")
-    with open(fd, "wb") as raw, wave.open(raw, "wb") as wav:
-        wav.setnchannels(channels)
-        wav.setsampwidth(width)
-        wav.setframerate(rate)
-        wav.writeframes(pcm)
-    return path
-
-
 def recording_command(target=""):
-    """A raw-s16 capture command for the sound system on this machine."""
-    return sound().record(target)
+    """Return a raw-s16 capture command for the sound server on this desktop.
 
-
-def meeting_command(mic_target, system_target):
-    """One ffmpeg reading both devices and merging them into two channels."""
-    return sound().meeting(mic_target, system_target)
+    parec works with both PulseAudio and PipeWire's PulseAudio compatibility
+    service, and its source names are the same ones shown by list_sources().
+    Keep pw-record as the fallback for minimal native-PipeWire installations.
+    """
+    if shutil.which("parec"):
+        cmd = [
+            "parec", "--record", "--raw", f"--rate={RATE}",
+            f"--channels={CHANNELS}", "--format=s16le",
+            # Left alone, parec holds about two seconds before handing anything
+            # over, and then hands over all of it at once: the level meter sits
+            # still and jumps, and the tail of a recording can be lost on the
+            # way out. A chunk of the meter is the unit the rest of this file
+            # is measured in, so ask for that.
+            f"--latency-msec={CHUNK_LATENCY_MS}",
+        ]
+        if target:
+            cmd.append(f"--device={target}")
+        return cmd
+    if shutil.which("pw-record"):
+        cmd = [
+            "pw-record", "--raw", f"--rate={RATE}",
+            f"--channels={CHANNELS}", "--format=s16",
+        ]
+        if target:
+            cmd.append(f"--target={target}")
+        cmd.append("-")
+        return cmd
+    return []
 
 
 class MeetingRecorder(QObject):
@@ -234,7 +243,18 @@ class MeetingRecorder(QObject):
                                "Pick one in Settings → Meeting."))
             return
 
-        cmd = meeting_command(mic_target, system_target)
+        merge = (
+            "[0:a]aresample={rate}:async=1,aformat=sample_fmts=s16:channel_layouts=mono[m];"
+            "[1:a]aresample={rate}:async=1,aformat=sample_fmts=s16:channel_layouts=mono[s];"
+            "[m][s]amerge=inputs=2[out]"
+        ).format(rate=RATE)
+        cmd = [
+            "ffmpeg", "-hide_banner", "-nostdin", "-loglevel", "error",
+            "-f", "pulse", "-thread_queue_size", "4096", "-i", mic_target or "default",
+            "-f", "pulse", "-thread_queue_size", "4096", "-i", system_target,
+            "-filter_complex", merge, "-map", "[out]",
+            "-f", "s16le", "-ar", str(RATE), "-",
+        ]
 
         try:
             os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -382,112 +402,10 @@ class MeetingRecorder(QObject):
             self._log = None
 
 
-def chunk_levels(chunk):
-    """(peak, rms) in 0..1. Peak drives the waveform, RMS drives the silence check."""
-    samples = array.array("h")
-    usable = len(chunk) - (len(chunk) % 2)
-    if usable <= 0:
-        return 0.0, 0.0
-    samples.frombytes(chunk[:usable])
-    peak = max(abs(min(samples)), abs(max(samples))) / 32768.0
-    rms = math.sqrt(sum(s * s for s in samples) / len(samples)) / 32768.0
-    return min(1.0, peak), min(1.0, rms)
+# --- the devices ----------------------------------------------------------
 
 
-def stereo_levels(chunk):
-    """(left peak, right peak) in 0..1 from interleaved stereo s16."""
-    samples = array.array("h")
-    usable = len(chunk) - (len(chunk) % 4)
-    if usable <= 0:
-        return 0.0, 0.0
-    samples.frombytes(chunk[:usable])
-    left, right = samples[0::2], samples[1::2]
-    return _peak(left), _peak(right)
-
-
-def _peak(samples):
-    if not samples:
-        return 0.0
-    return min(1.0, max(abs(min(samples)), abs(max(samples))) / 32768.0)
-
-
-# --- the sound system, one group per machine -------------------------------
-
-# Both meeting commands merge the same way: each input down to mono at our own
-# rate, then the two of them into the left and right of one stream.
-MERGE_FILTER = (
-    f"[0:a]aresample={RATE}:async=1,aformat=sample_fmts=s16:channel_layouts=mono[m];"
-    f"[1:a]aresample={RATE}:async=1,aformat=sample_fmts=s16:channel_layouts=mono[s];"
-    "[m][s]amerge=inputs=2[out]"
-)
-
-
-def _pulse_record(target):
-    """parec, or pw-record where PulseAudio's tools were left out.
-
-    parec works with both PulseAudio and PipeWire's PulseAudio compatibility
-    service, and its source names are the same ones shown by list_sources().
-    Keep pw-record as the fallback for minimal native-PipeWire installations.
-    """
-    if shutil.which("parec"):
-        cmd = [
-            "parec", "--record", "--raw", f"--rate={RATE}",
-            f"--channels={CHANNELS}", "--format=s16le",
-            # Left alone, parec holds about two seconds before handing anything
-            # over, and then hands over all of it at once: the level meter sits
-            # still and jumps, and the tail of a recording can be lost on the
-            # way out. A chunk of the meter is the unit the rest of this file
-            # is measured in, so ask for that.
-            f"--latency-msec={CHUNK_LATENCY_MS}",
-        ]
-        if target:
-            cmd.append(f"--device={target}")
-        return cmd
-    if shutil.which("pw-record"):
-        cmd = [
-            "pw-record", *_pw_record_raw_option(), f"--rate={RATE}",
-            f"--channels={CHANNELS}", "--format=s16",
-        ]
-        if target:
-            cmd.append(f"--target={target}")
-        cmd.append("-")
-        return cmd
-    return []
-
-
-def _pw_record_raw_option():
-    """Use --raw only on pw-record releases that provide it.
-
-    PipeWire gained --raw in 1.4, and in the same release stopped treating a
-    filename of "-" as raw on its own: before it, the option is refused and the
-    recorder dies before any sound arrives; after it, leaving the option out
-    wraps the stream in a container the rest of this file would read as noise.
-    Ubuntu 24.04 and anything else still on 1.0 or 1.2 sit on the near side of
-    that line, so ask the installed binary which form it understands.
-    """
-    try:
-        result = subprocess.run(
-            ["pw-record", "--help"], capture_output=True, text=True, timeout=2
-        )
-        help_text = (result.stdout or "") + (result.stderr or "")
-    except (subprocess.SubprocessError, OSError):
-        return ["--raw"]  # preserve the existing command when probing itself fails
-    if not help_text.strip():
-        return ["--raw"]
-    return ["--raw"] if "--raw" in help_text else []
-
-
-def _pulse_meeting(mic_target, system_target):
-    return [
-        "ffmpeg", "-hide_banner", "-nostdin", "-loglevel", "error",
-        "-f", "pulse", "-thread_queue_size", "4096", "-i", mic_target or "default",
-        "-f", "pulse", "-thread_queue_size", "4096", "-i", system_target,
-        "-filter_complex", MERGE_FILTER, "-map", "[out]",
-        "-f", "s16le", "-ar", str(RATE), "-",
-    ]
-
-
-def _pactl_sources():
+def _sources():
     if not shutil.which("pactl"):
         return []
     try:
@@ -500,23 +418,30 @@ def _pactl_sources():
         return []
 
 
-def _pulse_inputs():
+def list_sources():
+    """[(name, description)] for every real input source."""
     return [
         (src.get("name", ""), src.get("description") or src.get("name", ""))
-        for src in _pactl_sources()
+        for src in _sources()
         if not src.get("name", "").endswith(".monitor")
     ]
 
 
-def _pulse_outputs():
+def list_monitors():
+    """[(name, description)] for the monitor of every output.
+
+    Recording a monitor is recording whatever is being played, which in a
+    meeting is the other participants and nothing of your own microphone.
+    """
     return [
         (src.get("name", ""), src.get("description") or src.get("name", ""))
-        for src in _pactl_sources()
+        for src in _sources()
         if src.get("name", "").endswith(".monitor")
     ]
 
 
-def _pulse_default_output():
+def default_monitor():
+    """The monitor of the output sound is currently going to, or ''."""
     if not shutil.which("pactl"):
         return ""
     try:
@@ -529,145 +454,5 @@ def _pulse_default_output():
     if not sink:
         return ""
     monitor = f"{sink}.monitor"
-    names = {name for name, _ in _pulse_outputs()}
+    names = {name for name, _ in list_monitors()}
     return monitor if not names or monitor in names else ""
-
-
-# macOS hands out no monitor of its own: what the speakers are playing is not
-# an input, and the only way to record it is a driver that pretends to be one.
-# These are the three people install.
-LOOPBACK_DEVICES = ("blackhole", "loopback", "soundflower")
-
-
-def _avfoundation_record(target):
-    if not shutil.which("ffmpeg"):
-        return []
-    return [
-        "ffmpeg", "-hide_banner", "-nostdin", "-loglevel", "error",
-        # AVFoundation names an input "video:audio", so the empty half in front
-        # of the colon is what says this recording has no picture in it.
-        "-f", "avfoundation", "-i", f":{target or 'default'}",
-        "-ac", str(CHANNELS), "-ar", str(RATE), "-f", "s16le", "-",
-    ]
-
-
-def _avfoundation_meeting(mic_target, system_target):
-    return [
-        "ffmpeg", "-hide_banner", "-nostdin", "-loglevel", "error",
-        "-thread_queue_size", "4096",
-        "-f", "avfoundation", "-i", f":{mic_target or 'default'}",
-        "-thread_queue_size", "4096",
-        "-f", "avfoundation", "-i", f":{system_target}",
-        "-filter_complex", MERGE_FILTER, "-map", "[out]",
-        "-f", "s16le", "-ar", str(RATE), "-",
-    ]
-
-
-def _avfoundation_inputs():
-    """[(index, name)] for every capture device AVFoundation offers.
-
-    The index is what the recorder is given, because that is what ffmpeg takes;
-    it changes when devices are plugged in, which is why the name is shown.
-    """
-    if not shutil.which("ffmpeg"):
-        return []
-    try:
-        # Listing devices is not a thing ffmpeg can do without an input, so it
-        # is asked for one it cannot open: the list comes out on stderr and the
-        # command then fails, which is the documented way of doing this.
-        result = subprocess.run(
-            ["ffmpeg", "-hide_banner", "-f", "avfoundation",
-             "-list_devices", "true", "-i", ""],
-            capture_output=True, text=True, timeout=8, check=False,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return []
-
-    devices, listing = [], False
-    for line in result.stderr.splitlines():
-        if "AVFoundation audio devices:" in line:
-            listing = True
-            continue
-        if not listing:
-            continue
-        match = re.search(r"\[(\d+)\]\s+(.+)$", line)
-        if match:
-            devices.append((match.group(1), match.group(2).strip()))
-    return devices
-
-
-def _avfoundation_default_output():
-    for name, description in _avfoundation_inputs():
-        if any(word in description.lower() for word in LOOPBACK_DEVICES):
-            return name
-    return ""
-
-
-Sound = collections.namedtuple(
-    "Sound",
-    # How to capture one source and two at once, the two device lists, which
-    # device a meeting records the far side from, and what to say when the
-    # programs for any of it are not installed.
-    "record meeting inputs outputs default_output missing",
-)
-
-PULSE = Sound(
-    record=_pulse_record,
-    meeting=_pulse_meeting,
-    inputs=_pulse_inputs,
-    outputs=_pulse_outputs,
-    default_output=_pulse_default_output,
-    missing="No audio recorder found. Install pulseaudio-utils or pipewire-audio.",
-)
-
-COREAUDIO = Sound(
-    record=_avfoundation_record,
-    meeting=_avfoundation_meeting,
-    inputs=_avfoundation_inputs,
-    # Every macOS capture device is offered as the far side of a meeting, the
-    # loopback driver among them: there is no way to tell them apart, and an
-    # empty list would leave nothing to pick.
-    outputs=_avfoundation_inputs,
-    default_output=_avfoundation_default_output,
-    missing="ffmpeg not found. Install it with: brew install ffmpeg",
-)
-
-
-def sound():
-    """The programs this machine records through."""
-    return COREAUDIO if sys.platform == "darwin" else PULSE
-
-
-def list_sources():
-    """[(name, description)] for every real input source."""
-    return sound().inputs()
-
-
-def list_monitors():
-    """[(name, description)] for whatever can be recorded as the other side.
-
-    On Linux that is the monitor of an output, and recording it is recording
-    whatever is being played: in a meeting the other participants, and nothing
-    of your own microphone.
-    """
-    return sound().outputs()
-
-
-def default_monitor():
-    """The device the far side of a meeting comes from, or ''."""
-    return sound().default_output()
-
-
-# Windows is implemented behind the same public contract while the established
-# Linux/macOS implementations above remain untouched.  Keeping this dispatch
-# at the boundary avoids regressing the newer macOS backend while the desktop
-# services are progressively moved into dedicated adapters.
-if sys.platform.startswith("win"):
-    from platforms import adapter as _platform_adapter
-
-    _windows_audio = _platform_adapter("audio", "windows")
-    Recorder = _windows_audio.Recorder
-    MeetingRecorder = _windows_audio.MeetingRecorder
-    list_sources = _windows_audio.list_sources
-    list_monitors = _windows_audio.list_monitors
-    default_monitor = _windows_audio.default_monitor

--- a/platforms/linux/clipboard.py
+++ b/platforms/linux/clipboard.py
@@ -1,0 +1,171 @@
+"""Clipboard and key injection, through whichever pair of programs is here.
+
+A Wayland session has wl-clipboard and ydotool, an X11 one has xclip and
+xdotool, and a session is one or the other. Which it is gets decided in one
+place, and each desktop is a small group of functions below it: another desktop
+adds a group and a line to the chooser rather than a branch inside every
+function here.
+"""
+
+import collections
+import os
+import shutil
+import subprocess
+import time
+
+from i18n import t
+
+# Linux input event codes (linux/input-event-codes.h), which is what ydotool
+# takes. They are also the list of keys a paste shortcut may be built from, so
+# xdotool is held to the same table rather than being handed the text as typed.
+KEYCODES = {
+    "ctrl": 29, "control": 29, "shift": 42, "alt": 56, "super": 125, "meta": 125,
+    "v": 47, "insert": 110, "enter": 28, "return": 28,
+}
+
+# xdotool speaks X keysyms, which spell some of those differently.
+KEYSYMS = {"control": "ctrl", "meta": "super", "insert": "Insert",
+           "enter": "Return", "return": "Return"}
+
+
+class PasteError(Exception):
+    pass
+
+
+def _keys(shortcut):
+    """'Ctrl+V' -> ['ctrl', 'v'], every one of them a key we know."""
+    parts = [key.strip().lower() for key in str(shortcut).split("+") if key.strip()]
+    for key in parts:
+        if key not in KEYCODES:
+            raise PasteError(t("Unknown key: {key}", key=key))
+    return parts
+
+
+def _ydotool_command(shortcut):
+    """ydotool wants a press event per key, then a release in reverse."""
+    codes = [KEYCODES[key] for key in _keys(shortcut)]
+    return ["ydotool", "key", *[f"{code}:1" for code in codes],
+            *[f"{code}:0" for code in reversed(codes)]]
+
+
+def _xdotool_command(shortcut):
+    """xdotool takes the whole combination as one argument."""
+    keys = [KEYSYMS.get(key, key) for key in _keys(shortcut)]
+    return ["xdotool", "key", "--clearmodifiers", "+".join(keys)]
+
+
+Desktop = collections.namedtuple(
+    "Desktop",
+    # The two programs, the packages to install them from, how to build the key
+    # press, and what else to say when the key press fails.
+    "clipboard keyboard packages read_command copy_command key_command key_hint",
+)
+
+WAYLAND = Desktop(
+    clipboard="wl-copy",
+    keyboard="ydotool",
+    packages="wl-clipboard and ydotool",
+    read_command=["wl-paste", "--no-newline"],
+    copy_command=["wl-copy"],
+    key_command=_ydotool_command,
+    key_hint="Is ydotoold running? (systemctl --user status ydotool)",
+)
+
+X11 = Desktop(
+    clipboard="xclip",
+    keyboard="xdotool",
+    packages="xclip and xdotool",
+    read_command=["xclip", "-selection", "clipboard", "-out"],
+    copy_command=["xclip", "-selection", "clipboard", "-in"],
+    key_command=_xdotool_command,
+    key_hint="",
+)
+
+
+def desktop():
+    """The pair of programs this session's clipboard and keyboard go through.
+
+    Read every time rather than settled at import: a session started before the
+    display server was up would otherwise be stuck with the wrong answer, and a
+    test would have nowhere to say which one it means.
+    """
+    if os.environ.get("XDG_SESSION_TYPE") == "x11":
+        return X11
+    if os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        return X11
+    return WAYLAND
+
+
+# --- the clipboard ---------------------------------------------------------
+
+def read_clipboard():
+    here = desktop()
+    if not shutil.which(here.read_command[0]):
+        return None
+    try:
+        res = subprocess.run(here.read_command, capture_output=True, timeout=5)
+    except (subprocess.SubprocessError, OSError):
+        return None
+    return res.stdout if res.returncode == 0 else None
+
+
+def _run_copy(payload):
+    """The clipboard owner forks to keep holding the selection; leaving its
+    pipes open makes subprocess.run wait for EOF forever, hence DEVNULL."""
+    return subprocess.run(
+        desktop().copy_command,
+        input=payload,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+    )
+
+
+def copy(text):
+    here = desktop()
+    if not shutil.which(here.clipboard):
+        raise PasteError(t("{tool} not found. Install {packages}.",
+                           tool=here.clipboard, packages=here.packages))
+    try:
+        res = _run_copy(text.encode("utf-8"))
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise PasteError(t("Could not copy to clipboard: {error}", error=exc)) from exc
+    if res.returncode != 0:
+        raise PasteError(t("{tool} exited with code {code}.",
+                           tool=here.clipboard, code=res.returncode))
+
+
+def copy_bytes(data):
+    if data is None or not shutil.which(desktop().clipboard):
+        return
+    try:
+        _run_copy(data)
+    except (subprocess.SubprocessError, OSError):
+        pass
+
+
+# --- the key press ---------------------------------------------------------
+
+def paste_ready():
+    return shutil.which(desktop().keyboard) is not None
+
+
+def press(shortcut="ctrl+v", delay=0.12):
+    """Press a key combination, e.g. 'ctrl+v'."""
+    here = desktop()
+    if not paste_ready():
+        raise PasteError(t("{tool} not found, cannot paste automatically.",
+                           tool=here.keyboard))
+
+    command = here.key_command(shortcut)
+    time.sleep(delay)  # let the selection settle and focus come back
+    try:
+        res = subprocess.run(command, capture_output=True, text=True, timeout=10)
+    except (subprocess.SubprocessError, OSError) as exc:
+        raise PasteError(t("Could not run {tool}: {error}",
+                           tool=here.keyboard, error=exc)) from exc
+    if res.returncode != 0:
+        message = t("{tool} failed: {error}", tool=here.keyboard,
+                    error=res.stderr.strip() or "unknown error")
+        raise PasteError(f"{message}\n{t(here.key_hint)}" if here.key_hint
+                         else message)

--- a/platforms/linux/hotkeys.py
+++ b/platforms/linux/hotkeys.py
@@ -1,17 +1,6 @@
-"""Global shortcuts: the desktop's own registry, plus a listener of our own.
-
-Two things have to happen for a key combination to reach Dikte. Somewhere has
-to be told about it, and something has to be listening. On Linux that is the
-desktop's shortcut registry (KDE's file, GNOME's gsettings) and a reader of
-/dev/input for the wait until the registry is live. macOS has no registry to
-write into: the application asks Carbon for the combination while it runs, so
-there the listener is not a fallback but the whole mechanism.
-"""
+"""GNOME/KDE global-shortcut installation plus a built-in evdev listener."""
 
 import ast
-import collections
-import ctypes
-import ctypes.util
 import glob
 import os
 import pathlib
@@ -20,41 +9,23 @@ import select
 import shutil
 import struct
 import subprocess
-import sys
 import threading
 
 from PyQt6.QtCore import QObject, pyqtSignal
 
 from i18n import t
+from platforms.common.shortcuts import (  # noqa: F401
+    ASK_DESKTOP_ID,
+    CANCEL_DESKTOP_ID,
+    DESKTOP_ID,
+    MEETING_DESKTOP_ID,
+)
 
-DESKTOP_ID = "dikte-toggle.desktop"
-CANCEL_DESKTOP_ID = "dikte-cancel.desktop"
-MEETING_DESKTOP_ID = "dikte-meeting.desktop"
-ASK_DESKTOP_ID = "dikte-ask.desktop"
 APPLICATIONS_DIR = pathlib.Path.home() / ".local/share/applications"
 DESKTOP_FILE = APPLICATIONS_DIR / DESKTOP_ID
 SHORTCUTS_FILE = pathlib.Path.home() / ".config/kglobalshortcutsrc"
 GNOME_MEDIA_SCHEMA = "org.gnome.settings-daemon.plugins.media-keys"
 GNOME_BINDING_SCHEMA = "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding"
-
-Shortcut = collections.namedtuple("Shortcut", "verb desktop_id name setting fallback")
-
-# Every global shortcut in one place, because there are four of them and the
-# command line, the settings window and the installer each used to carry their
-# own copy of the list. `fallback` is what to register when the setting is
-# empty: only the toggle has one, since it is the key the application is
-# unusable without.
-SHORTCUTS = {
-    "toggle": Shortcut("toggle", DESKTOP_ID, "Dikte: start/stop recording",
-                       "shortcut", "Ctrl+Space"),
-    "cancel": Shortcut("cancel", CANCEL_DESKTOP_ID, "Dikte: discard the recording",
-                       "cancel_shortcut", ""),
-    "ask": Shortcut("ask", ASK_DESKTOP_ID, "Dikte: ask Claude Code",
-                    "assistant_shortcut", ""),
-    "meeting": Shortcut("meeting", MEETING_DESKTOP_ID,
-                        "Dikte: start/end a meeting recording",
-                        "meeting_shortcut", ""),
-}
 
 # --- evdev key codes (linux/input-event-codes.h) --------------------------
 
@@ -208,221 +179,12 @@ class EvdevHotkey(QObject):
         return True
 
 
-# --- macOS: Carbon's hotkey service ---------------------------------------
-
-# Apple virtual key codes: where a key sits, not what is printed on it.
-MAC_KEYS = {
-    "space": 49, "tab": 48, "enter": 36, "return": 36, "esc": 53, "escape": 53,
-    "backspace": 51, "delete": 117, "home": 115, "end": 119,
-    "pgup": 116, "pgdown": 121, "up": 126, "down": 125, "left": 123, "right": 124,
-    "1": 18, "2": 19, "3": 20, "4": 21, "5": 23, "6": 22, "7": 26,
-    "8": 28, "9": 25, "0": 29,
-    "a": 0, "b": 11, "c": 8, "d": 2, "e": 14, "f": 3, "g": 5, "h": 4,
-    "i": 34, "j": 38, "k": 40, "l": 37, "m": 46, "n": 45, "o": 31,
-    "p": 35, "q": 12, "r": 15, "s": 1, "t": 17, "u": 32, "v": 9,
-    "w": 13, "x": 7, "y": 16, "z": 6,
-    "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
-    "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
-}
-# Carbon's own modifier bits, which are not the ones CoreGraphics uses in
-# paste.py: the same four modifiers, numbered differently by two APIs.
-MAC_MODS = {
-    "cmd": 1 << 8, "command": 1 << 8, "meta": 1 << 8, "super": 1 << 8,
-    "shift": 1 << 9,
-    "alt": 1 << 11, "option": 1 << 11,
-    "ctrl": 1 << 12, "control": 1 << 12,
-}
-HOTKEY_SIGNATURE = "Dikt"          # what our registrations are labelled with
-KEYBOARD_EVENT_CLASS = "keyb"
-HOTKEY_PRESSED = 5                 # kEventHotKeyPressed
-PARAMETER_ANY = "----"             # kEventParamDirectObject / typeWildCard
-HOTKEY_ID_PARAMETER = "hkid"
-
-# What the running listener holds. This is the whole of "installed" on macOS,
-# and it lasts as long as the process does: there is no file, and no other
-# program to read one. Written by CarbonHotkey.start(), read by the status
-# line, so what Settings shows is what the Mac actually gave us.
-_REGISTERED = {}
-
-
-def parse_macos_shortcut(text):
-    """'Cmd+Space' -> (256, 49), or (None, None) when unusable."""
-    parts = [part.strip().lower() for part in str(text).split("+") if part.strip()]
-    modifiers, key = 0, None
-    for part in parts:
-        if part in MAC_MODS:
-            modifiers |= MAC_MODS[part]
-        elif key is None and part in MAC_KEYS:
-            key = MAC_KEYS[part]
-        else:
-            return None, None
-    if key is None:
-        return None, None
-    return modifiers, key
-
-
-def _fourcc(text):
-    """A Carbon four-character code, which is those four bytes as a number."""
-    return int.from_bytes(text.encode("ascii"), "big")
-
-
-class _EventTypeSpec(ctypes.Structure):
-    _fields_ = [("eventClass", ctypes.c_uint32), ("eventKind", ctypes.c_uint32)]
-
-
-class _EventHotKeyID(ctypes.Structure):
-    _fields_ = [("signature", ctypes.c_uint32), ("id", ctypes.c_uint32)]
-
-
-class CarbonHotkey(QObject):
-    """Catches global shortcuts through macOS's own hotkey service.
-
-    RegisterEventHotKey asks for one combination rather than reading the
-    keyboard, so it needs no permission at all. Accessibility is a separate
-    matter, and only for the Cmd+V that puts the text back (see paste.py).
-
-    Unlike the evdev listener this one does swallow the key: while Dikte holds
-    a combination, nothing else on the Mac receives it.
-    """
-
-    triggered = pyqtSignal(str)   # the name the binding was registered under
-    failed = pyqtSignal(str)
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self._carbon = None
-        self._callback = None
-        self._handler = ctypes.c_void_p()
-        self._registrations = []
-        self._names = {}
-
-    @property
-    def running(self):
-        return bool(self._registrations)
-
-    def start(self, bindings):
-        """`bindings` is {name: 'Cmd+Space'}; an empty combination is skipped."""
-        self.stop()
-        try:
-            self._carbon = _carbon()
-        except OSError as exc:
-            self.failed.emit(t("Could not reach the macOS shortcut service: "
-                               "{error}", error=exc))
-            return False
-        if not self._install_handler():
-            return False
-
-        for identifier, (name, shortcut) in enumerate(bindings.items(), 1):
-            if not shortcut:
-                continue
-            modifiers, key = parse_macos_shortcut(shortcut)
-            if key is None:
-                self.failed.emit(
-                    t("Could not parse the shortcut: {shortcut}", shortcut=shortcut)
-                )
-                continue
-            reference = ctypes.c_void_p()
-            code = self._carbon.RegisterEventHotKey(
-                key, modifiers,
-                _EventHotKeyID(_fourcc(HOTKEY_SIGNATURE), identifier),
-                self._carbon.GetApplicationEventTarget(), 0, ctypes.byref(reference),
-            )
-            if code != 0:
-                # This is the conflict warning on macOS: there is no list to
-                # read beforehand, the answer comes from asking for the key.
-                self.failed.emit(t(
-                    "macOS would not give Dikte {shortcut}; another application "
-                    "already holds it.", shortcut=shortcut))
-                continue
-            self._registrations.append(reference)
-            self._names[identifier] = name
-            spec = SHORTCUTS.get(name)
-            if spec:
-                _REGISTERED[spec.desktop_id] = shortcut
-        return bool(self._registrations)
-
-    def stop(self):
-        if self._carbon:
-            for reference in self._registrations:
-                self._carbon.UnregisterEventHotKey(reference)
-            if self._handler:
-                self._carbon.RemoveEventHandler(self._handler)
-        self._registrations = []
-        self._names = {}
-        self._handler = ctypes.c_void_p()
-        self._callback = None
-        _REGISTERED.clear()
-
-    def _install_handler(self):
-        carbon = self._carbon
-        callback_type = ctypes.CFUNCTYPE(
-            ctypes.c_int32, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
-        )
-
-        def pressed(_next_handler, event, _user_data):
-            wanted = _EventHotKeyID()
-            size = ctypes.c_uint32()
-            code = carbon.GetEventParameter(
-                event, _fourcc(PARAMETER_ANY), _fourcc(HOTKEY_ID_PARAMETER), None,
-                ctypes.sizeof(wanted), ctypes.byref(size), ctypes.byref(wanted),
-            )
-            if code == 0:
-                name = self._names.get(wanted.id)
-                if name:
-                    self.triggered.emit(name)
-            return 0
-
-        # Kept on self: Carbon holds the address of this function, and nothing
-        # on the Python side would otherwise stop it being collected.
-        self._callback = callback_type(pressed)
-        event_type = _EventTypeSpec(_fourcc(KEYBOARD_EVENT_CLASS), HOTKEY_PRESSED)
-        code = carbon.InstallEventHandler(
-            carbon.GetApplicationEventTarget(), self._callback, 1,
-            ctypes.byref(event_type), None, ctypes.byref(self._handler),
-        )
-        if code != 0:
-            self.failed.emit(t("Could not reach the macOS shortcut service: "
-                               "{error}", error=code))
-            self._callback = None
-            return False
-        return True
-
-
-def _carbon():
-    """Carbon, with its calls typed the way they are used above."""
-    path = (ctypes.util.find_library("Carbon")
-            or "/System/Library/Frameworks/Carbon.framework/Carbon")
-    carbon = ctypes.CDLL(path)
-    carbon.GetApplicationEventTarget.restype = ctypes.c_void_p
-    carbon.InstallEventHandler.restype = ctypes.c_int32
-    carbon.InstallEventHandler.argtypes = [
-        ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32,
-        ctypes.POINTER(_EventTypeSpec), ctypes.c_void_p,
-        ctypes.POINTER(ctypes.c_void_p),
-    ]
-    carbon.RegisterEventHotKey.restype = ctypes.c_int32
-    carbon.RegisterEventHotKey.argtypes = [
-        ctypes.c_uint32, ctypes.c_uint32, _EventHotKeyID, ctypes.c_void_p,
-        ctypes.c_uint32, ctypes.POINTER(ctypes.c_void_p),
-    ]
-    carbon.UnregisterEventHotKey.restype = ctypes.c_int32
-    carbon.UnregisterEventHotKey.argtypes = [ctypes.c_void_p]
-    carbon.RemoveEventHandler.restype = ctypes.c_int32
-    carbon.RemoveEventHandler.argtypes = [ctypes.c_void_p]
-    carbon.GetEventParameter.restype = ctypes.c_int32
-    carbon.GetEventParameter.argtypes = [
-        ctypes.c_void_p, ctypes.c_uint32, ctypes.c_uint32,
-        ctypes.POINTER(ctypes.c_uint32), ctypes.c_uint32,
-        ctypes.POINTER(ctypes.c_uint32), ctypes.c_void_p,
-    ]
-    return carbon
+# The listener the application starts when the desktop's own shortcut is not
+# live yet. Windows has no equivalent and registers its combinations directly.
+Listener = EvdevHotkey
 
 
 # --- the desktop's own shortcut -------------------------------------------
-
-def _macos():
-    return sys.platform == "darwin"
-
 
 def _gnome():
     desktop = os.environ.get("XDG_CURRENT_DESKTOP", "").lower()
@@ -546,69 +308,26 @@ def gnome_shortcut_status(desktop_id=DESKTOP_ID):
         return None
 
 
-def listener(parent=None):
-    """The thing that hears the key, for whichever system this is."""
-    return CarbonHotkey(parent) if _macos() else EvdevHotkey(parent)
-
-
-def valid_shortcut(text):
-    """Whether this machine can bind the combination as it was typed."""
-    parse = parse_macos_shortcut if _macos() else parse_shortcut
-    return parse(text)[1] is not None
-
-
-def installs_shortcuts():
-    """Whether this system keeps a shortcut registry to write into.
-
-    KDE and GNOME do, and something outside Dikte reads it, so the combination
-    survives Dikte being closed. macOS does not: there is nothing to install,
-    nothing to remove, and Settings should not offer either.
-    """
-    return not _macos()
-
-
-def shortcut_needs_restart():
-    """Whether an installed shortcut waits for the next login before it works.
-
-    KWin reads kglobalshortcutsrc once, when it starts. GNOME picks a binding
-    up as it is written, and macOS never had one to write.
-    """
-    return not _macos() and not _gnome()
-
-
 def install_shortcut(shortcut, exec_command, name="Dikte: start/stop recording",
                      desktop_id=DESKTOP_ID):
-    if _macos():
-        _REGISTERED[desktop_id] = shortcut
-        return True, t(
-            "Shortcut saved: {shortcut}\nDikte holds this one itself while it "
-            "is running, so it works as soon as the settings are saved.",
-            shortcut=shortcut,
-        )
     if _gnome():
         return install_gnome_shortcut(shortcut, exec_command, name, desktop_id)
     return install_kde_shortcut(shortcut, exec_command, name, desktop_id)
 
 
 def remove_shortcut(desktop_id=DESKTOP_ID):
-    if _macos():
-        _REGISTERED.pop(desktop_id, None)
-    elif _gnome():
+    if _gnome():
         remove_gnome_shortcut(desktop_id)
     else:
         remove_kde_shortcut(desktop_id)
 
 
 def shortcut_status(desktop_id=DESKTOP_ID):
-    if _macos():
-        return _REGISTERED.get(desktop_id)
     return (gnome_shortcut_status(desktop_id) if _gnome()
             else kde_shortcut_status(desktop_id))
 
 
 def desktop_name():
-    if _macos():
-        return "macOS"
     return "GNOME" if _gnome() else "KDE"
 
 
@@ -693,10 +412,6 @@ def kde_shortcut_status(desktop_id=DESKTOP_ID):
 
 def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
     """Names of other KDE entries bound to the same combination."""
-    if _macos():
-        # There is no list to read: macOS answers the question by refusing the
-        # registration, which CarbonHotkey reports when it asks for the key.
-        return []
     try:
         text = SHORTCUTS_FILE.read_text(encoding="utf-8")
     except OSError:
@@ -715,29 +430,3 @@ def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
                  for part in re.split(r"[,\t]", value)):
             hits.append(f"{section} → {key}")
     return hits
-
-
-if sys.platform.startswith("win"):
-    from platforms import adapter as _platform_adapter
-
-    _windows_hotkeys = _platform_adapter("hotkeys", "windows")
-    parse_shortcut = _windows_hotkeys.parse_shortcut
-    install_shortcut = _windows_hotkeys.install_shortcut
-    remove_shortcut = _windows_hotkeys.remove_shortcut
-    shortcut_status = _windows_hotkeys.shortcut_status
-    conflicting_shortcuts = _windows_hotkeys.conflicting_shortcuts
-    desktop_name = _windows_hotkeys.desktop_name
-
-    def listener(parent=None):
-        return _windows_hotkeys.Listener(parent)
-
-    def valid_shortcut(text):
-        return parse_shortcut(text)[1] is not None
-
-    def installs_shortcuts():
-        # RegisterHotKey lives in this process; there is no desktop registry
-        # which can deliver a shortcut while Dikte is closed.
-        return False
-
-    def shortcut_needs_restart():
-        return False

--- a/platforms/linux/runtime.py
+++ b/platforms/linux/runtime.py
@@ -1,0 +1,198 @@
+"""Where things live on Linux, and how a process behaves there.
+
+Directories follow the XDG basedir spec. A secret is a secret because of the
+mode on the file holding it, the socket is named after the numeric user id,
+and a session ending arrives as a signal.
+"""
+
+import contextlib
+import os
+import pathlib
+import shutil
+import signal
+import socket
+import subprocess
+
+# What a subprocess is started with so that no console window appears. Nothing
+# on Linux does, so there is nothing to ask for.
+NO_WINDOW = {}
+
+# The programs this platform expects to find on the PATH, for `dikte doctor` to
+# report on. Recording, the clipboard, the key press and the shortcut all go
+# through one of these here.
+PROGRAMS = ("pw-record", "wl-copy", "ydotool", "ffmpeg", "pactl", "kwriteconfig6")
+
+# The name of the directory Dikte keeps its things in, under each of the three
+# roots below. Lowercase, because that is what the rest of ~/.config looks like,
+# and so are the two directories inside it.
+APP_DIR = "dikte"
+RECORDINGS_NAME = "recordings"
+MEETINGS_NAME = "meetings"
+
+
+def _home(var, default):
+    return pathlib.Path(os.environ.get(var) or os.path.expanduser(default))
+
+
+def config_home():
+    return _home("XDG_CONFIG_HOME", "~/.config")
+
+
+def data_home():
+    return _home("XDG_DATA_HOME", "~/.local/share")
+
+
+def cache_home():
+    return _home("XDG_CACHE_HOME", "~/.cache")
+
+
+def config_dir():
+    return config_home() / APP_DIR
+
+
+def data_dir():
+    return data_home() / APP_DIR
+
+
+def cache_dir():
+    return cache_home() / APP_DIR
+
+
+# --- who this is ----------------------------------------------------------
+
+
+def user_id():
+    """A token for the current user, to keep one user's socket out of another's."""
+    return str(os.getuid())
+
+
+def single_instance(name):
+    """A handle proving this is the only Dikte running, or None when it is not.
+
+    On Linux the local socket already answers that question: a second instance
+    fails to bind it and talks to the first one instead. Nothing further is
+    needed, so this always succeeds and the caller falls through to the socket.
+    """
+    return _Held()
+
+
+class _Held:
+    def release(self):
+        pass
+
+
+# --- secrets --------------------------------------------------------------
+
+
+def protect(text):
+    """What to write into config.json for an API key.
+
+    On Linux the file itself is the protection: mode 600 in the user's own
+    config directory, which is where every other program on the machine keeps
+    the same kind of thing.
+    """
+    return text
+
+
+def unprotect(value):
+    return value
+
+
+def secure_file(path):
+    """Keep a file holding secrets to its owner."""
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o600)
+
+
+# --- processes ------------------------------------------------------------
+
+
+def adopt(proc):
+    """Tie a child's lifetime to ours. Nothing to do here.
+
+    Linux has no job objects, and the pid file plus ggml.sweep() is what covers
+    a Dikte that was killed outright.
+    """
+    return False
+
+
+def is_our_process(pid, needles):
+    """Whether that pid is a process whose command line holds all of `needles`.
+
+    Asked because pids are handed out again: by the time anyone looks, the
+    number could belong to something else entirely, and killing it would be a
+    good deal worse than the leak being cleaned up.
+    """
+    try:
+        blob = pathlib.Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return False
+    return all(str(needle).encode() in blob for needle in needles)
+
+
+def terminate(pid):
+    """Ask a process to end. True when the signal went out."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return False
+    return True
+
+
+# --- the session ----------------------------------------------------------
+
+
+def signals():
+    """The signals a session end arrives as."""
+    return (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+
+
+def wakeup_socketpair():
+    """A pair of sockets for set_wakeup_fd, so Qt hears a signal while blocked."""
+    reader, writer = socket.socketpair()
+    reader.setblocking(False)
+    writer.setblocking(False)
+    return reader, writer
+
+
+def cuda_driver_version():
+    """Nothing to ask: neither project publishes a CUDA build for Linux.
+
+    A graphics card is reached through Vulkan here, and a Vulkan build either
+    finds a loader or does not; there is no runtime version to match up.
+    """
+    return None
+
+
+def prepare_console():
+    """Nothing to do: a Linux terminal has been UTF-8 for twenty years."""
+    return False
+
+
+def abort_socket(sock):
+    """Make a read another thread is blocked on return, now.
+
+    A half-close is enough here: the reader wakes with nothing left to read and
+    the call comes back rather than waiting for bytes that are no longer on
+    their way.
+    """
+    with contextlib.suppress(OSError):
+        sock.shutdown(socket.SHUT_RDWR)
+    return True
+
+
+def relaunch(command):
+    """Start Dikte again in place of this process. Does not return."""
+    os.execv(command[0], list(command))
+
+
+def open_folder(path):
+    """Show a directory in the file manager. True when something was launched."""
+    if not shutil.which("xdg-open"):
+        return False
+    try:
+        subprocess.Popen(["xdg-open", str(path)],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except OSError:
+        return False
+    return True

--- a/platforms/macos/__init__.py
+++ b/platforms/macos/__init__.py
@@ -1,0 +1,1 @@
+"""macOS runtime adapter package."""

--- a/platforms/macos/runtime.py
+++ b/platforms/macos/runtime.py
@@ -1,0 +1,134 @@
+"""macOS directories, process lifetime and session integration.
+
+Audio, clipboard and global shortcuts remain in their established native
+implementations while the cross-platform runtime contract is shared with the
+Windows port.
+"""
+
+import contextlib
+import os
+import pathlib
+import shutil
+import signal
+import socket
+import subprocess
+
+NO_WINDOW = {}
+PROGRAMS = ("ffmpeg",)
+APP_DIR = "Dikte"
+RECORDINGS_NAME = "recordings"
+MEETINGS_NAME = "meetings"
+
+
+def config_home():
+    return pathlib.Path.home() / "Library/Application Support"
+
+
+def data_home():
+    return config_home()
+
+
+def cache_home():
+    return pathlib.Path.home() / "Library/Caches"
+
+
+def config_dir():
+    return config_home() / APP_DIR
+
+
+def data_dir():
+    return data_home() / APP_DIR
+
+
+def cache_dir():
+    return cache_home() / APP_DIR
+
+
+def user_id():
+    return str(os.getuid())
+
+
+class _Held:
+    def release(self):
+        pass
+
+
+def single_instance(name):
+    return _Held()
+
+
+def protect(text):
+    return text
+
+
+def unprotect(value):
+    return value
+
+
+def secure_file(path):
+    with contextlib.suppress(OSError):
+        os.chmod(path, 0o600)
+
+
+def adopt(proc):
+    return False
+
+
+def is_our_process(pid, needles):
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=2, check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and all(
+        str(needle) in result.stdout for needle in needles)
+
+
+def terminate(pid):
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return False
+    return True
+
+
+def signals():
+    return (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+
+
+def wakeup_socketpair():
+    reader, writer = socket.socketpair()
+    reader.setblocking(False)
+    writer.setblocking(False)
+    return reader, writer
+
+
+def cuda_driver_version():
+    return None
+
+
+def prepare_console():
+    return False
+
+
+def abort_socket(sock):
+    with contextlib.suppress(OSError):
+        sock.shutdown(socket.SHUT_RDWR)
+    return True
+
+
+def relaunch(command):
+    os.execv(command[0], list(command))
+
+
+def open_folder(path):
+    if not shutil.which("open"):
+        return False
+    try:
+        subprocess.Popen(["open", str(path)], stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL)
+    except OSError:
+        return False
+    return True

--- a/platforms/windows/__init__.py
+++ b/platforms/windows/__init__.py
@@ -1,0 +1,1 @@
+"""Windows: WASAPI, the Win32 clipboard and SendInput, RegisterHotKey, AppData."""

--- a/platforms/windows/audio.py
+++ b/platforms/windows/audio.py
@@ -1,0 +1,649 @@
+"""Capturing sound on Windows, through WASAPI.
+
+Dictation opens the microphone. A meeting opens the microphone and a loopback
+of whatever is being played at the same time, which is what Windows offers
+instead of PulseAudio's monitor sources: no "Stereo Mix" device has to exist
+and nothing has to be enabled in a driver panel.
+
+The two meeting streams are not simply written side by side. They are two
+devices with two clocks, started a few tens of milliseconds apart, and either
+of them can stall: a loopback in particular hands over nothing at all while
+the speakers are idle on some machines. So each side is converted to the same
+16 kHz timeline and a mixer writes the file against the wall clock: a side with
+nothing to give gets silence for that stretch, and a side whose clock runs fast
+has its backlog trimmed rather than allowed to grow. Over an hour the two stay
+inside a mixer block of each other rather than sliding apart, which is the
+whole reason a meeting can be split by channel afterwards.
+
+Everything is written to the file as it arrives. An hour is not held in memory,
+and a crash costs the tail of the meeting rather than all of it.
+"""
+
+import array
+import os
+import threading
+import time
+import wave
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from i18n import t
+from platforms.common.pcm import (
+    CHUNK_FRAMES,
+    CHANNELS,
+    MIN_FRAMES,
+    RATE,
+    SAMPLE_WIDTH,
+    chunk_levels,
+    peak_of,
+    write_wav,
+)
+from platforms.windows.resample import Converter
+
+try:
+    import pyaudiowpatch as pyaudio
+except ImportError:      # pragma: no cover - depends on what is installed
+    pyaudio = None
+
+# How often the meeting mixer writes, and how far behind the wall clock a side
+# may fall before what it owes is written as silence. Short enough that the
+# level meter moves, long enough that it is not a busy loop.
+MIX_INTERVAL = 0.05
+
+# A side whose device clock runs ahead of the wall clock builds up a backlog.
+# Half a second of it is kept as slack for scheduling jitter; past that, the
+# oldest audio is dropped, which is what keeps the two channels together over
+# an hour instead of one of them sliding late.
+MAX_BACKLOG = int(RATE * 0.5)
+
+SILENCE = b"\x00\x00"
+
+_engine = None
+_engine_lock = threading.Lock()
+
+
+class AudioError(Exception):
+    pass
+
+
+def _audio():
+    """The one PyAudio instance, made the first time something needs it.
+
+    Creating it initialises COM and enumerates every endpoint on the machine,
+    which is not something to do at import: a command line that only reads the
+    history should not touch the sound system at all.
+    """
+    global _engine
+    if pyaudio is None:
+        raise AudioError(t(
+            "The Windows sound support is missing. Reinstall Dikte, or run: "
+            "pip install PyAudioWPatch"
+        ))
+    with _engine_lock:
+        if _engine is None:
+            _engine = pyaudio.PyAudio()
+        return _engine
+
+
+def _forget():
+    """Drop the cached instance so the next question re-enumerates the devices."""
+    global _engine
+    with _engine_lock:
+        engine, _engine = _engine, None
+    if engine is not None:
+        try:
+            engine.terminate()
+        except Exception:      # noqa: BLE001 - it is being thrown away anyway
+            pass
+
+
+def _wasapi_devices():
+    """Every WASAPI endpoint, as the dictionaries PyAudio hands out."""
+    try:
+        engine = _audio()
+        host = engine.get_host_api_info_by_type(pyaudio.paWASAPI)
+    except (AudioError, OSError, ValueError):
+        return []
+    found = []
+    for slot in range(int(host.get("deviceCount", 0))):
+        try:
+            found.append(engine.get_device_info_by_host_api_device_index(
+                host["index"], slot))
+        except (OSError, ValueError):
+            continue
+    return found
+
+
+def _inputs():
+    return [d for d in _wasapi_devices()
+            if int(d.get("maxInputChannels", 0)) > 0
+            and not d.get("isLoopbackDevice")]
+
+
+def _loopbacks():
+    return [d for d in _wasapi_devices()
+            if int(d.get("maxInputChannels", 0)) > 0
+            and d.get("isLoopbackDevice")]
+
+
+def list_sources():
+    """[(name, description)] for every microphone.
+
+    The name is what gets stored in the settings, and it is the device's own
+    name rather than its index: indices are renumbered whenever something is
+    plugged in, and a microphone chosen last week has to still be the one
+    chosen this week.
+    """
+    return [(d["name"], d["name"]) for d in _inputs()]
+
+
+def list_monitors():
+    """[(name, description)] for every speaker output that can be recorded back.
+
+    Windows exposes one loopback endpoint per output device, named after it, so
+    recording a meeting means recording the loopback of whichever output the
+    call is being played through.
+    """
+    return [(d["name"], _monitor_label(d["name"])) for d in _loopbacks()]
+
+
+def _monitor_label(name):
+    """'Speakers [Loopback]' shown the way the rest of the interface reads."""
+    trimmed = name.replace("[Loopback]", "").strip()
+    return t("Whatever {device} is playing", device=trimmed) if trimmed else name
+
+
+def default_monitor():
+    """The loopback of the output sound is going to right now, or ''."""
+    try:
+        engine = _audio()
+        host = engine.get_host_api_info_by_type(pyaudio.paWASAPI)
+        speakers = engine.get_device_info_by_index(host["defaultOutputDevice"])
+    except (AudioError, OSError, ValueError, KeyError):
+        return ""
+    wanted = str(speakers.get("name", "")).strip()
+    if not wanted:
+        return ""
+    loopbacks = _loopbacks()
+    for device in loopbacks:
+        if device["name"].startswith(wanted):
+            return device["name"]
+    for device in loopbacks:
+        if wanted in device["name"]:
+            return device["name"]
+    return loopbacks[0]["name"] if loopbacks else ""
+
+
+def _match(devices, wanted):
+    """The device the settings name, or the default when they name nothing."""
+    wanted = (wanted or "").strip()
+    if wanted:
+        for device in devices:
+            if device["name"] == wanted:
+                return device
+        for device in devices:
+            if wanted in device["name"]:
+                return device
+        return None
+    return devices[0] if devices else None
+
+
+def _default_input():
+    try:
+        engine = _audio()
+        host = engine.get_host_api_info_by_type(pyaudio.paWASAPI)
+        return engine.get_device_info_by_index(host["defaultInputDevice"])
+    except (AudioError, OSError, ValueError, KeyError):
+        return None
+
+
+def _microphone(target):
+    if not (target or "").strip():
+        device = _default_input()
+        if device is not None and int(device.get("maxInputChannels", 0)) > 0:
+            return device
+    return _match(_inputs(), target)
+
+
+def _blocked_message(device, exc):
+    """What to say when Windows refused a device.
+
+    Nearly always the privacy setting rather than anything technical: a
+    microphone switched off under Settings → Privacy fails to open with an
+    access error, and the number PortAudio reports for it means nothing to
+    anybody. Say where the switch is.
+    """
+    text = str(exc)
+    denied = "denied" in text.lower() or "-9996" in text or "-9999" in text
+    if denied:
+        return t(
+            "Windows would not open {device}. Check Settings → Privacy & "
+            "security → Microphone: desktop apps need microphone access "
+            "turned on. ({error})", device=device, error=text,
+        )
+    return t("Could not start recording on {device}: {error}",
+             device=device, error=text)
+
+
+class _Stream:
+    """One WASAPI input stream, converted to 16 kHz mono as it arrives."""
+
+    def __init__(self, device):
+        engine = _audio()
+        self.name = device["name"]
+        self.rate = int(device.get("defaultSampleRate") or RATE)
+        self.channels = max(1, int(device.get("maxInputChannels") or 1))
+        # A block of roughly the length the level meter reads, in the device's
+        # own sample rate, so one read is one update of the waveform.
+        self.block = max(256, round(self.rate * CHUNK_FRAMES / RATE))
+        self.stream = engine.open(
+            format=pyaudio.paInt16,
+            channels=self.channels,
+            rate=self.rate,
+            input=True,
+            input_device_index=int(device["index"]),
+            frames_per_buffer=self.block,
+        )
+        self.converter = Converter(self.rate, self.channels, RATE)
+
+    @property
+    def latency(self):
+        try:
+            return float(self.stream.get_input_latency())
+        except (OSError, ValueError, AttributeError):
+            return 0.0
+
+    def read(self):
+        """The next block as 16 kHz mono s16 bytes, or b'' when there is none."""
+        raw = self.stream.read(self.block, exception_on_overflow=False)
+        return self.converter.feed(raw)
+
+    def close(self):
+        try:
+            self.stream.stop_stream()
+        except (OSError, ValueError):
+            pass
+        try:
+            self.stream.close()
+        except (OSError, ValueError):
+            pass
+
+
+class Recorder(QObject):
+    """The microphone, for one dictation."""
+
+    level = pyqtSignal(float)                 # 0.0 - 1.0, for the waveform
+    stopped = pyqtSignal(str, float, object)  # wav path, duration (s), per-chunk RMS
+    failed = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._stream = None
+        self._thread = None
+        self._buffer = bytearray()
+        self._rms = []
+        self._cancelled = False
+        self._stopping = False
+        self._error = ""
+        self._lock = threading.Lock()
+
+    @property
+    def active(self):
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self, target="", max_seconds=300):
+        if self.active:
+            return
+        device = _microphone(target)
+        if device is None:
+            self.failed.emit(
+                t("No microphone found. Plug one in, or pick another under "
+                  "Settings → General.")
+                if not target else
+                t("The microphone {device} is not there any more. Pick another "
+                  "one under Settings → General.", device=target)
+            )
+            return
+        try:
+            self._stream = _Stream(device)
+        except AudioError as exc:
+            self.failed.emit(str(exc))
+            return
+        except (OSError, ValueError) as exc:
+            # The device list is stale once an endpoint has gone; the next
+            # attempt should ask Windows again rather than the cache.
+            _forget()
+            self.failed.emit(_blocked_message(device["name"], exc))
+            return
+
+        self._buffer = bytearray()
+        self._rms = []
+        self._cancelled = False
+        self._stopping = False
+        self._error = ""
+        self._max_bytes = int(max_seconds * RATE * SAMPLE_WIDTH * CHANNELS)
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+        self._thread.start()
+
+    def _pump(self):
+        stream = self._stream
+        try:
+            while not self._stopping and not self._cancelled:
+                chunk = stream.read()
+                if not chunk:
+                    continue
+                peak, rms = chunk_levels(chunk)
+                with self._lock:
+                    self._buffer.extend(chunk)
+                    self._rms.append(rms)
+                    too_long = len(self._buffer) >= self._max_bytes
+                self.level.emit(peak)
+                if too_long:
+                    self._stopping = True
+                    break
+        except (OSError, ValueError) as exc:
+            self._error = str(exc)
+        # Nobody asked it to end and it captured nothing: the device was taken
+        # away, or Windows refused it after the open. Said out loud here,
+        # because stop() would otherwise report it as a recording that was too
+        # short, which sends the user looking in the wrong place.
+        with self._lock:
+            captured = bool(self._buffer)
+        if self._stopping or self._cancelled or captured:
+            return
+        self.failed.emit(t(
+            "The microphone stopped before any sound arrived: {error}",
+            error=self._error or t("the device went away"),
+        ))
+
+    def _finish(self):
+        self._stopping = True
+        if self._thread:
+            self._thread.join(timeout=2)
+        self._thread = None
+        if self._stream is not None:
+            self._stream.close()
+            self._stream = None
+
+    def cancel(self):
+        self._cancelled = True
+        self._finish()
+        with self._lock:
+            self._buffer = bytearray()
+
+    def stop(self):
+        """End the recording and write the WAV file."""
+        if self._stream is None and self._thread is None:
+            return
+        self._finish()
+
+        with self._lock:
+            pcm = bytes(self._buffer)
+            rms = list(self._rms)
+            self._buffer = bytearray()
+
+        if self._cancelled:
+            return
+
+        frames = len(pcm) // (SAMPLE_WIDTH * CHANNELS)
+        if frames < MIN_FRAMES:  # a stray keypress, not speech
+            self.failed.emit(t("Recording too short, speak for at least 0.3 s"))
+            return
+
+        path = write_wav(pcm)
+        self.stopped.emit(path, frames / RATE, rms)
+
+
+class _Side:
+    """One half of a meeting: a stream, what it has produced, and where it is."""
+
+    def __init__(self, label):
+        self.label = label
+        self.stream = None
+        self.thread = None
+        self.buffer = bytearray()
+        self.lock = threading.Lock()
+        self.primed = False
+        self.alive = True
+        self.error = ""
+
+    def close(self):
+        if self.stream is not None:
+            self.stream.close()
+            self.stream = None
+
+
+def _interleave(left, right):
+    """Two equal-length mono buffers into one stereo buffer."""
+    first, second = array.array("h"), array.array("h")
+    first.frombytes(left)
+    second.frombytes(right)
+    out = array.array("h")
+    for mine, theirs in zip(first, second):
+        out.append(mine)
+        out.append(theirs)
+    return out.tobytes(), peak_of(first), peak_of(second)
+
+
+class MeetingRecorder(QObject):
+    """Microphone and speaker output into one stereo file: left is you, right is
+    everyone else.
+
+    Who said what then needs no guessing at all, because the two voices never
+    shared a channel to begin with.
+    """
+
+    levels = pyqtSignal(float, float)      # mine, theirs
+    stopped = pyqtSignal(str, float)       # wav path, duration (s)
+    died = pyqtSignal()                    # a device went away on its own
+    failed = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._mic = _Side("microphone")
+        self._system = _Side("system")
+        self._mixer = None
+        self._wav = None
+        self._path = ""
+        self._frames = 0
+        self._max_frames = 0
+        self._cancelled = False
+        self._stopping = False
+        self._fault = ""
+        self._lock = threading.Lock()
+
+    @property
+    def active(self):
+        return self._mixer is not None and self._mixer.is_alive()
+
+    def start(self, path, mic_target="", system_target="", max_seconds=14400):
+        if self.active:
+            return
+        microphone = _microphone(mic_target)
+        if microphone is None:
+            self.failed.emit(t("No microphone found. Plug one in, or pick "
+                               "another under Settings → General."))
+            return
+        loopback = _match(_loopbacks(), system_target or default_monitor())
+        if loopback is None:
+            self.failed.emit(t("Could not work out which speaker output to "
+                               "record. Pick one in Settings → Meeting."))
+            return
+
+        self._mic = _Side("microphone")
+        self._system = _Side("system")
+        try:
+            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+            self._wav = wave.open(path, "wb")
+            self._wav.setnchannels(2)
+            self._wav.setsampwidth(SAMPLE_WIDTH)
+            self._wav.setframerate(RATE)
+        except (OSError, wave.Error) as exc:
+            self._close_file()
+            self.failed.emit(t("Could not start recording: {error}", error=exc))
+            return
+
+        try:
+            self._mic.stream = _Stream(microphone)
+            self._system.stream = _Stream(loopback)
+        except AudioError as exc:
+            self._abandon(path)
+            self.failed.emit(str(exc))
+            return
+        except (OSError, ValueError) as exc:
+            failed = (microphone["name"] if self._mic.stream is None
+                      else loopback["name"])
+            self._abandon(path)
+            _forget()
+            self.failed.emit(_blocked_message(failed, exc))
+            return
+
+        self._path = path
+        self._frames = 0
+        self._cancelled = False
+        self._stopping = False
+        self._max_frames = int(max_seconds * RATE)
+
+        # The clock both sides are written against. Taken after both streams
+        # are open, so that neither one's opening cost is charged to the other.
+        started = time.perf_counter()
+        for side in (self._mic, self._system):
+            side.thread = threading.Thread(
+                target=self._pump, args=(side, started), daemon=True)
+            side.thread.start()
+        self._mixer = threading.Thread(target=self._mix, args=(started,),
+                                       daemon=True)
+        self._mixer.start()
+
+    def _abandon(self, path):
+        """Give up before anything was recorded, leaving no empty header behind."""
+        self._mic.close()
+        self._system.close()
+        self._close_file()
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+    def _pump(self, side, started):
+        """Read one device until it is done, onto the common timeline."""
+        try:
+            while not self._stopping:
+                chunk = side.stream.read()
+                if not chunk:
+                    continue
+                with side.lock:
+                    if not side.primed:
+                        side.primed = True
+                        # Where this block belongs: it was captured a stream's
+                        # latency ago, and it is one block long. Whatever comes
+                        # before that on the shared clock is silence this
+                        # device was not there for.
+                        span = len(chunk) / (SAMPLE_WIDTH * RATE)
+                        lead = (time.perf_counter() - side.stream.latency
+                                - span - started)
+                        side.buffer += SILENCE * max(0, int(lead * RATE))
+                    side.buffer += chunk
+        except (OSError, ValueError) as exc:
+            side.error = str(exc)
+        finally:
+            side.alive = False
+
+    def _take(self, side, frames):
+        """The next `frames` of that side, padded with silence when it is short."""
+        want = frames * SAMPLE_WIDTH
+        with side.lock:
+            # A device clock running ahead of the wall clock: keep half a
+            # second of slack for scheduling and drop what is older, which is
+            # what stops the two channels sliding apart over an hour.
+            excess = len(side.buffer) - want - MAX_BACKLOG * SAMPLE_WIDTH
+            if excess > 0:
+                del side.buffer[:excess - (excess % SAMPLE_WIDTH)]
+            data = bytes(side.buffer[:want])
+            del side.buffer[:len(data)]
+        if len(data) < want:
+            data += SILENCE * ((want - len(data)) // SAMPLE_WIDTH)
+        return data
+
+    def _mix(self, started):
+        """Write the file against the wall clock, whatever the devices do."""
+        while not self._stopping:
+            time.sleep(MIX_INTERVAL)
+            if self._stopping:
+                break
+            frames = int((time.perf_counter() - started) * RATE) - self._frames
+            if frames <= 0:
+                continue
+            block, mine, theirs = _interleave(self._take(self._mic, frames),
+                                              self._take(self._system, frames))
+            with self._lock:
+                if self._wav is None:
+                    break
+                try:
+                    self._wav.writeframes(block)
+                except (OSError, ValueError, wave.Error) as exc:
+                    self._fault = str(exc)
+                    break
+                self._frames += frames
+                too_long = self._frames >= self._max_frames
+            self.levels.emit(mine, theirs)
+            if too_long:
+                self._stopping = True
+                break
+            # A device that went away is the end of the recording: an hour into
+            # a meeting that has to be said out loud rather than discovered
+            # afterwards.
+            if not (self._mic.alive and self._system.alive):
+                self._stopping = True
+                self.died.emit()
+                break
+
+    def _close_file(self):
+        with self._lock:
+            wav, self._wav = self._wav, None
+        if wav is not None:
+            try:
+                wav.close()
+            except (OSError, wave.Error):
+                pass
+
+    def _finish(self):
+        self._stopping = True
+        for side in (self._mic, self._system):
+            if side.thread:
+                side.thread.join(timeout=3)
+            side.thread = None
+            side.close()
+        if self._mixer:
+            self._mixer.join(timeout=3)
+        self._mixer = None
+        self._close_file()
+
+    def cancel(self):
+        self._cancelled = True
+        self._finish()
+        try:
+            os.unlink(self._path)
+        except OSError:
+            pass
+
+    def stop(self):
+        if self._mixer is None and self._wav is None:
+            return
+        self._finish()
+        frames = self._frames
+        if self._cancelled:
+            return
+
+        if frames < MIN_FRAMES:
+            trouble = self._fault or self._mic.error or self._system.error
+            try:
+                os.unlink(self._path)
+            except OSError:
+                pass
+            self.failed.emit(
+                t("Nothing was recorded: {error}", error=trouble) if trouble
+                else t("Recording too short, speak for at least 0.3 s")
+            )
+            return
+        self.stopped.emit(self._path, frames / RATE)

--- a/platforms/windows/clipboard.py
+++ b/platforms/windows/clipboard.py
@@ -1,0 +1,362 @@
+"""The Win32 clipboard, and a key combination sent with SendInput.
+
+Two things about the Windows clipboard shape this file. It is opened rather
+than written to: one process at a time owns it, so anything else that reaches
+for it at the same moment, and a great many programs watch it, makes the open
+fail, which is a wait and another go rather than an error. And what is on it is
+a set of formats rather than a string, so putting back what was there before
+means putting back all of them, not only the text.
+
+The key press goes through SendInput, which is what Windows offers a program
+that wants to type into somebody else's window. Two limits come with it. The
+combination has to be released in the reverse of the order it was pressed, or
+the target sees a modifier that never came back up. And a program running at a
+lower integrity level cannot send input to a higher one, so a paste into an
+application started as administrator is refused by Windows itself; the text is
+still on the clipboard, and saying so is better than looking like a hang.
+"""
+
+import ctypes
+import time
+from ctypes import wintypes
+
+from i18n import t
+
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+# Every one of these hands back or takes a handle, and a handle is 64 bits
+# here. ctypes assumes a C int for a function nobody described to it, so an
+# undeclared GetClipboardData would quietly cut the top half off the handle it
+# returns and the clipboard would appear to be empty on any machine unlucky
+# enough to get a high address. Declared, all of them.
+user32.OpenClipboard.argtypes = [wintypes.HWND]
+user32.OpenClipboard.restype = wintypes.BOOL
+user32.CloseClipboard.restype = wintypes.BOOL
+user32.EmptyClipboard.restype = wintypes.BOOL
+user32.GetClipboardData.argtypes = [wintypes.UINT]
+user32.GetClipboardData.restype = wintypes.HANDLE
+user32.SetClipboardData.argtypes = [wintypes.UINT, wintypes.HANDLE]
+user32.SetClipboardData.restype = wintypes.HANDLE
+user32.IsClipboardFormatAvailable.argtypes = [wintypes.UINT]
+user32.IsClipboardFormatAvailable.restype = wintypes.BOOL
+user32.RegisterClipboardFormatW.argtypes = [wintypes.LPCWSTR]
+user32.RegisterClipboardFormatW.restype = wintypes.UINT
+user32.MapVirtualKeyW.argtypes = [wintypes.UINT, wintypes.UINT]
+user32.MapVirtualKeyW.restype = wintypes.UINT
+user32.SendInput.argtypes = [wintypes.UINT, ctypes.c_void_p, ctypes.c_int]
+user32.SendInput.restype = wintypes.UINT
+
+kernel32.GlobalAlloc.argtypes = [wintypes.UINT, ctypes.c_size_t]
+kernel32.GlobalAlloc.restype = wintypes.HGLOBAL
+kernel32.GlobalLock.argtypes = [wintypes.HGLOBAL]
+kernel32.GlobalLock.restype = ctypes.c_void_p
+kernel32.GlobalUnlock.argtypes = [wintypes.HGLOBAL]
+kernel32.GlobalUnlock.restype = wintypes.BOOL
+kernel32.GlobalSize.argtypes = [wintypes.HGLOBAL]
+kernel32.GlobalSize.restype = ctypes.c_size_t
+kernel32.GlobalFree.argtypes = [wintypes.HGLOBAL]
+kernel32.GlobalFree.restype = wintypes.HGLOBAL
+
+CF_TEXT = 1
+CF_UNICODETEXT = 13
+
+GMEM_MOVEABLE = 0x0002
+
+# Only the ones worth putting back. A snapshot of every format on the clipboard
+# would include the ones a program registered for its own use, several of which
+# are handles into that program rather than bytes.
+EXTRA_FORMATS = ("HTML Format", "Rich Text Format")
+
+# What a saved clipboard looks like when it held more than plain text. The
+# contract with the rest of Dikte is bytes in and bytes out, so the formats are
+# packed into one buffer behind a marker; anything without it is text, which is
+# also what a snapshot taken on Linux looks like.
+SNAPSHOT_MAGIC = b"\x00dikte-clipboard\x00"
+
+ERROR_ACCESS_DENIED = 5
+
+# Windows is asked for the clipboard for about a second in total. A program
+# holding it for longer than that is not going to let go because we waited.
+OPEN_ATTEMPTS = 12
+OPEN_DELAY = 0.02
+
+
+class PasteError(Exception):
+    pass
+
+
+# --- the keys ---------------------------------------------------------------
+
+# Virtual-key codes. The names are the ones the Linux side takes, so a shortcut
+# stored on one machine means the same thing on the other.
+KEYCODES = {
+    "ctrl": 0x11, "control": 0x11, "shift": 0x10, "alt": 0x12,
+    "super": 0x5B, "meta": 0x5B,
+    "v": 0x56, "insert": 0x2D, "enter": 0x0D, "return": 0x0D,
+}
+
+# Keys that live on the extended part of the keyboard. Sent without this flag
+# they arrive as their numeric-keypad twins, so Insert would be a 0.
+EXTENDED = {0x2D, 0x5B}
+
+KEYEVENTF_EXTENDEDKEY = 0x0001
+KEYEVENTF_KEYUP = 0x0002
+INPUT_KEYBOARD = 1
+MAPVK_VK_TO_VSC = 0
+
+
+class _MouseInput(ctypes.Structure):
+    _fields_ = [("dx", wintypes.LONG), ("dy", wintypes.LONG),
+                ("mouseData", wintypes.DWORD), ("dwFlags", wintypes.DWORD),
+                ("time", wintypes.DWORD),
+                ("dwExtraInfo", ctypes.POINTER(ctypes.c_ulong))]
+
+
+class _KeyboardInput(ctypes.Structure):
+    _fields_ = [("wVk", wintypes.WORD), ("wScan", wintypes.WORD),
+                ("dwFlags", wintypes.DWORD), ("time", wintypes.DWORD),
+                ("dwExtraInfo", ctypes.POINTER(ctypes.c_ulong))]
+
+
+class _HardwareInput(ctypes.Structure):
+    _fields_ = [("uMsg", wintypes.DWORD), ("wParamL", wintypes.WORD),
+                ("wParamH", wintypes.WORD)]
+
+
+class _InputUnion(ctypes.Union):
+    _fields_ = [("mi", _MouseInput), ("ki", _KeyboardInput), ("hi", _HardwareInput)]
+
+
+class _Input(ctypes.Structure):
+    _anonymous_ = ("u",)
+    _fields_ = [("type", wintypes.DWORD), ("u", _InputUnion)]
+
+
+def _keys(shortcut):
+    """'Ctrl+V' -> [0x11, 0x56], every one of them a key we know."""
+    parts = [key.strip().lower() for key in str(shortcut).split("+") if key.strip()]
+    codes = []
+    for key in parts:
+        if key not in KEYCODES:
+            raise PasteError(t("Unknown key: {key}", key=key))
+        codes.append(KEYCODES[key])
+    return codes
+
+
+def _event(code, up):
+    flags = KEYEVENTF_KEYUP if up else 0
+    if code in EXTENDED:
+        flags |= KEYEVENTF_EXTENDEDKEY
+    event = _Input(type=INPUT_KEYBOARD)
+    event.ki = _KeyboardInput(
+        wVk=code,
+        # The scan code as well as the virtual key: an application reading raw
+        # scan codes rather than translated keys, which is games, terminal
+        # emulators and some remote-desktop clients, sees nothing without it.
+        wScan=user32.MapVirtualKeyW(code, MAPVK_VK_TO_VSC),
+        dwFlags=flags, time=0, dwExtraInfo=None,
+    )
+    return event
+
+
+def key_events(shortcut):
+    """The press-then-release sequence for a combination, as virtual-key codes.
+
+    Down in the order written, up in the reverse: releasing Ctrl before V would
+    leave the application with a plain V, and releasing nothing at all leaves a
+    modifier stuck down for whatever the user types next.
+    """
+    codes = _keys(shortcut)
+    return [(code, False) for code in codes] + [
+        (code, True) for code in reversed(codes)]
+
+
+# --- owning the clipboard ---------------------------------------------------
+
+
+def _open():
+    """Open the clipboard, waiting out whoever else has it. True when open."""
+    for attempt in range(OPEN_ATTEMPTS):
+        if user32.OpenClipboard(None):
+            return True
+        time.sleep(OPEN_DELAY * (attempt + 1))
+    return False
+
+
+def _format_id(name):
+    return user32.RegisterClipboardFormatW(name)
+
+
+def _read_format(fmt):
+    handle = user32.GetClipboardData(fmt)
+    if not handle:
+        return b""
+    pointer = kernel32.GlobalLock(handle)
+    if not pointer:
+        return b""
+    try:
+        size = kernel32.GlobalSize(handle)
+        return ctypes.string_at(pointer, size) if size else b""
+    finally:
+        kernel32.GlobalUnlock(handle)
+
+
+def _write_format(fmt, payload):
+    """Hand a buffer to the clipboard, which then owns the memory."""
+    handle = kernel32.GlobalAlloc(GMEM_MOVEABLE, len(payload) or 1)
+    if not handle:
+        return False
+    pointer = kernel32.GlobalLock(handle)
+    if not pointer:
+        kernel32.GlobalFree(handle)
+        return False
+    try:
+        ctypes.memmove(pointer, payload, len(payload))
+    finally:
+        kernel32.GlobalUnlock(handle)
+    if not user32.SetClipboardData(fmt, handle):
+        kernel32.GlobalFree(handle)
+        return False
+    return True
+
+
+def _pack(parts):
+    """[(format name, bytes)] -> one buffer, for copy_bytes to unpack later."""
+    out = bytearray(SNAPSHOT_MAGIC)
+    for name, payload in parts:
+        encoded = name.encode("utf-8")
+        out += len(encoded).to_bytes(4, "little") + encoded
+        out += len(payload).to_bytes(8, "little") + payload
+    return bytes(out)
+
+
+def _unpack(data):
+    """The inverse, or None when this is not one of ours.
+
+    Strict about lengths: a snapshot that was cut short is not half a
+    clipboard, it is something that did not come from here, and putting the
+    readable part of it back would be inventing what somebody had copied.
+    """
+    if not data.startswith(SNAPSHOT_MAGIC):
+        return None
+    parts = []
+    at = len(SNAPSHOT_MAGIC)
+
+    def take(count):
+        nonlocal at
+        if at + count > len(data):
+            raise ValueError("short")
+        chunk = data[at:at + count]
+        at += count
+        return chunk
+
+    try:
+        while at < len(data):
+            name = take(int.from_bytes(take(4), "little")).decode("utf-8")
+            parts.append((name, take(int.from_bytes(take(8), "little"))))
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return parts
+
+
+# --- the contract -----------------------------------------------------------
+
+
+def read_clipboard():
+    """What is on the clipboard now, as bytes to hand back to copy_bytes.
+
+    Plain UTF-8 when there is only text on it, which is what a dictation
+    replaces, and a packed snapshot when there is more than that, so restoring
+    it afterwards gives back the formatting somebody had copied rather than a
+    flattened version of it.
+    """
+    if not _open():
+        return None
+    try:
+        text = _read_format(CF_UNICODETEXT)
+        if not text:
+            return None
+        parts = []
+        for name in EXTRA_FORMATS:
+            fmt = _format_id(name)
+            if fmt and user32.IsClipboardFormatAvailable(fmt):
+                payload = _read_format(fmt)
+                if payload:
+                    parts.append((name, payload))
+        # A UTF-16 buffer arrives with its terminator; the bytes handed out
+        # here are text, and a stray NUL at the end of a dictation would be
+        # pasted along with it.
+        plain = text.decode("utf-16-le", "replace").split("\x00", 1)[0]
+        if not parts:
+            return plain.encode("utf-8")
+        return _pack([("text", plain.encode("utf-8"))] + parts)
+    finally:
+        user32.CloseClipboard()
+
+
+def _put(parts):
+    """Own the clipboard and write every format in one go."""
+    if not _open():
+        return False
+    try:
+        user32.EmptyClipboard()
+        for name, payload in parts:
+            fmt = CF_UNICODETEXT if name == "text" else _format_id(name)
+            if not fmt:
+                continue
+            if name == "text":
+                payload = payload.decode("utf-8", "replace").encode("utf-16-le") + b"\x00\x00"
+            _write_format(fmt, payload)
+        return True
+    finally:
+        user32.CloseClipboard()
+
+
+def copy(text):
+    if not _put([("text", str(text).encode("utf-8"))]):
+        raise PasteError(t(
+            "Could not open the Windows clipboard: another program is holding "
+            "it. Try again in a moment."
+        ))
+
+
+def copy_bytes(data):
+    """Put a snapshot back. Never raises: it runs after the paste went in."""
+    if data is None:
+        return
+    parts = _unpack(data)
+    if parts is None:
+        parts = [("text", bytes(data))]
+    try:
+        _put(parts)
+    except OSError:
+        pass
+
+
+def paste_ready():
+    """Windows can always send input; whether it lands is another question."""
+    return True
+
+
+def press(shortcut="ctrl+v", delay=0.12):
+    """Press a key combination, e.g. 'ctrl+v'."""
+    events = key_events(shortcut)          # raises before anything is sent
+    time.sleep(delay)                      # let the clipboard settle and focus return
+
+    array = (_Input * len(events))(*[_event(code, up) for code, up in events])
+    ctypes.set_last_error(0)
+    sent = user32.SendInput(len(events), ctypes.byref(array),
+                            ctypes.sizeof(_Input))
+    if sent == len(events):
+        return
+
+    error = ctypes.get_last_error()
+    if error == ERROR_ACCESS_DENIED:
+        raise PasteError(t(
+            "Windows would not let Dikte type into that window, because it is "
+            "running as administrator and Dikte is not. The text is on the "
+            "clipboard: press {shortcut} yourself.", shortcut=shortcut.upper(),
+        ))
+    raise PasteError(t("Could not send the key press: Windows error {code}.",
+                       code=error or "unknown"))

--- a/platforms/windows/hotkeys.py
+++ b/platforms/windows/hotkeys.py
@@ -1,0 +1,328 @@
+"""Global shortcuts on Windows: RegisterHotKey and the message that follows.
+
+Nothing is written to a file for a desktop to read later. A Windows program
+asks the system for a combination while it runs, gets it or does not, and hands
+it back on the way out. So Dikte's shortcuts are live exactly as long as Dikte
+is, and the settings are the only record of what they should be.
+
+The registration belongs to the thread that made it, and WM_HOTKEY is posted to
+that thread's own message queue, so all of it happens on a thread of ours with
+a message loop on it. Qt never sees the message; what crosses back is a signal.
+
+Two things RegisterHotKey does that the Linux listener does not. It takes the
+key away from whoever had focus, so Ctrl+Space no longer reaches the editor
+underneath. And it refuses a combination somebody else already holds, which is
+the only conflict report Windows offers: it will not say who.
+"""
+
+import ctypes
+import json
+import threading
+from ctypes import wintypes
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from i18n import t
+from platforms.common.shortcuts import (  # noqa: F401
+    ASK_DESKTOP_ID,
+    CANCEL_DESKTOP_ID,
+    DESKTOP_ID,
+    MEETING_DESKTOP_ID,
+)
+from platforms.windows import runtime
+
+user32 = ctypes.WinDLL("user32", use_last_error=True)
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+# Described rather than guessed at: ctypes assumes a C int for anything it was
+# not told about, and a message pointer cut to 32 bits is a crash rather than a
+# wrong answer. GetMessageW is the one that also answers -1, which is why its
+# result is checked for that and not only for zero.
+user32.RegisterHotKey.argtypes = [wintypes.HWND, ctypes.c_int, wintypes.UINT,
+                                  wintypes.UINT]
+user32.RegisterHotKey.restype = wintypes.BOOL
+user32.UnregisterHotKey.argtypes = [wintypes.HWND, ctypes.c_int]
+user32.UnregisterHotKey.restype = wintypes.BOOL
+user32.GetMessageW.argtypes = [ctypes.c_void_p, wintypes.HWND, wintypes.UINT,
+                               wintypes.UINT]
+user32.GetMessageW.restype = ctypes.c_int
+user32.PeekMessageW.argtypes = [ctypes.c_void_p, wintypes.HWND, wintypes.UINT,
+                                wintypes.UINT, wintypes.UINT]
+user32.PeekMessageW.restype = wintypes.BOOL
+user32.PostThreadMessageW.argtypes = [wintypes.DWORD, wintypes.UINT,
+                                      ctypes.c_void_p, ctypes.c_void_p]
+user32.PostThreadMessageW.restype = wintypes.BOOL
+kernel32.GetCurrentThreadId.restype = wintypes.DWORD
+
+MOD_ALT = 0x0001
+MOD_CONTROL = 0x0002
+MOD_SHIFT = 0x0004
+MOD_WIN = 0x0008
+# Holding the key down repeats it at the keyboard's own rate, which for a
+# start/stop toggle means starting and stopping several times a second.
+MOD_NOREPEAT = 0x4000
+
+WM_QUIT = 0x0012
+WM_HOTKEY = 0x0312
+WM_USER = 0x0400
+PM_NOREMOVE = 0x0000
+
+ERROR_HOTKEY_ALREADY_REGISTERED = 1409
+
+# The name Dikte's own bookkeeping goes under. RegisterHotKey has nothing to
+# read back, so what was installed is remembered here for the command line,
+# which asks about it from a process that is not the one holding the key.
+REGISTRY_NAME = "shortcuts.json"
+
+MODS = {
+    "ctrl": MOD_CONTROL, "control": MOD_CONTROL,
+    "shift": MOD_SHIFT,
+    "alt": MOD_ALT,
+    "meta": MOD_WIN, "super": MOD_WIN,
+}
+
+# Virtual-key codes. The names are the ones the settings store, so a
+# combination typed on Linux means the same key here.
+KEYS = {
+    "space": 0x20, "tab": 0x09, "enter": 0x0D, "return": 0x0D,
+    "esc": 0x1B, "escape": 0x1B, "backspace": 0x08,
+    "insert": 0x2D, "delete": 0x2E, "home": 0x24, "end": 0x23,
+    "pgup": 0x21, "pgdown": 0x22,
+    "up": 0x26, "down": 0x28, "left": 0x25, "right": 0x27,
+    "0": 0x30, "1": 0x31, "2": 0x32, "3": 0x33, "4": 0x34,
+    "5": 0x35, "6": 0x36, "7": 0x37, "8": 0x38, "9": 0x39,
+    "f1": 0x70, "f2": 0x71, "f3": 0x72, "f4": 0x73, "f5": 0x74, "f6": 0x75,
+    "f7": 0x76, "f8": 0x77, "f9": 0x78, "f10": 0x79, "f11": 0x7A, "f12": 0x7B,
+}
+KEYS.update({letter: 0x41 + index
+             for index, letter in enumerate("abcdefghijklmnopqrstuvwxyz")})
+
+
+def parse_shortcut(text):
+    """'Ctrl+Space' -> ({'ctrl'}, 0x20), or (None, None) when unparsable."""
+    parts = [p.strip().lower() for p in str(text).split("+") if p.strip()]
+    if not parts:
+        return None, None
+    mods, key = set(), None
+    for part in parts:
+        if part in MODS:
+            mods.add("ctrl" if part == "control" else "super" if part == "meta"
+                     else part)
+        else:
+            key = KEYS.get(part)
+            if key is None:
+                return None, None
+    if key is None:
+        return None, None
+    return mods, key
+
+
+def _modifier_flags(mods):
+    flags = 0
+    for name in mods:
+        flags |= MODS.get(name, 0)
+    return flags
+
+
+# --- the listener ---------------------------------------------------------
+
+
+class WindowsHotkeys(QObject):
+    """Holds the combinations for as long as it runs, on a thread of its own.
+
+    RegisterHotKey binds to the calling thread and WM_HOTKEY comes back to the
+    same one, so the registration, the message loop and the unregistration all
+    happen on the thread this starts; what leaves it is a Qt signal, which
+    crosses back to the main thread the way any queued connection does.
+    """
+
+    triggered = pyqtSignal(str)   # the name the binding was registered under
+    failed = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._thread = None
+        self._thread_id = 0
+        self._live = {}          # name -> combination, as registered
+
+    @property
+    def running(self):
+        return self._thread is not None and self._thread.is_alive()
+
+    def registered(self):
+        """{name: combination} for what the system is actually delivering."""
+        return dict(self._live)
+
+    def start(self, bindings):
+        """`bindings` is {name: 'Ctrl+Space'}; an empty combination is skipped."""
+        self.stop()
+        wanted = []
+        for name, shortcut in bindings.items():
+            if not shortcut:
+                continue
+            mods, key = parse_shortcut(shortcut)
+            if key is None:
+                self.failed.emit(
+                    t("Could not parse the shortcut: {shortcut}", shortcut=shortcut)
+                )
+                continue
+            wanted.append((name, shortcut, _modifier_flags(mods), key))
+        if not wanted:
+            return False
+
+        ready = threading.Event()
+        self._live = {}
+        self._thread = threading.Thread(
+            target=self._loop, args=(wanted, ready), daemon=True)
+        self._thread.start()
+        # The registration happens on that thread; waiting for it here is what
+        # lets start() answer whether the keys are live, the way the caller
+        # expects, rather than "a thread was started".
+        ready.wait(timeout=5)
+        return bool(self._live)
+
+    def stop(self):
+        if self._thread_id:
+            user32.PostThreadMessageW(self._thread_id, WM_QUIT, 0, 0)
+        if self._thread:
+            self._thread.join(timeout=2)
+        self._thread = None
+        self._thread_id = 0
+        self._live = {}
+
+    def _loop(self, wanted, ready):
+        message = wintypes.MSG()
+        # A thread has no message queue until something asks for one, and
+        # PostThreadMessage to a thread without one is dropped. This makes it.
+        user32.PeekMessageW(ctypes.byref(message), None, WM_USER, WM_USER,
+                            PM_NOREMOVE)
+        self._thread_id = kernel32.GetCurrentThreadId()
+
+        ids = {}
+        for index, (name, shortcut, flags, key) in enumerate(wanted, start=1):
+            ctypes.set_last_error(0)
+            if user32.RegisterHotKey(None, index, flags | MOD_NOREPEAT, key):
+                ids[index] = name
+                self._live[name] = shortcut
+                continue
+            error = ctypes.get_last_error()
+            self.failed.emit(
+                t("{shortcut} is already taken by another application.",
+                  shortcut=shortcut)
+                if error == ERROR_HOTKEY_ALREADY_REGISTERED else
+                t("Windows refused the shortcut {shortcut} (error {code}).",
+                  shortcut=shortcut, code=error)
+            )
+        # Set last, so that start() coming back means every combination has
+        # been asked for and every refusal already said out loud.
+        ready.set()
+
+        try:
+            while True:
+                got = user32.GetMessageW(ctypes.byref(message), None, 0, 0)
+                if got in (0, -1):        # WM_QUIT, or the queue went wrong
+                    break
+                if message.message == WM_HOTKEY:
+                    name = ids.get(int(message.wParam))
+                    if name:
+                        self.triggered.emit(name)
+        finally:
+            for index in ids:
+                user32.UnregisterHotKey(None, index)
+
+
+Listener = WindowsHotkeys
+
+
+# --- what was installed ---------------------------------------------------
+
+
+def _registry_path():
+    return runtime.data_dir() / REGISTRY_NAME
+
+
+def _stored():
+    try:
+        found = json.loads(_registry_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return found if isinstance(found, dict) else {}
+
+
+def _store(rows):
+    path = _registry_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(rows, ensure_ascii=False, indent=2),
+                        encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _free(flags, key):
+    """Whether Windows would hand that combination over right now.
+
+    Asked by registering it and giving it straight back, which is the only way
+    to find out: there is nothing to read that lists what is taken.
+    """
+    ctypes.set_last_error(0)
+    if not user32.RegisterHotKey(None, 0xBFFF, flags | MOD_NOREPEAT, key):
+        return ctypes.get_last_error() != ERROR_HOTKEY_ALREADY_REGISTERED
+    user32.UnregisterHotKey(None, 0xBFFF)
+    return True
+
+
+def conflicting_shortcuts(shortcut, desktop_id=DESKTOP_ID):
+    """Whether something else holds that combination.
+
+    Windows will not say what, only that the answer is no, so the one line
+    this can return says exactly that rather than inventing a name.
+    """
+    mods, key = parse_shortcut(shortcut)
+    if key is None:
+        return []
+    # Dikte's own registration would otherwise look like somebody else's.
+    if _stored().get(desktop_id) == shortcut:
+        return []
+    if _free(_modifier_flags(mods), key):
+        return []
+    return [t("another application (Windows does not say which)")]
+
+
+def install_shortcut(shortcut, exec_command="", name="", desktop_id=DESKTOP_ID):
+    """Take the combination, and remember that Dikte has it.
+
+    `exec_command` is what Linux writes into a .desktop file for the session to
+    run. Nothing launches Dikte here: the running instance holds the key
+    itself, so the argument is accepted and ignored.
+    """
+    mods, key = parse_shortcut(shortcut)
+    if key is None:
+        return False, t("Could not parse the shortcut: {shortcut}",
+                        shortcut=shortcut)
+    if (_stored().get(desktop_id) != shortcut
+            and not _free(_modifier_flags(mods), key)):
+        return False, t(
+            "{shortcut} is already taken by another application. Windows only "
+            "gives a combination to one program at a time; pick another one.",
+            shortcut=shortcut,
+        )
+    rows = _stored()
+    rows[desktop_id] = shortcut
+    _store(rows)
+    return True, t("Shortcut saved: {shortcut}", shortcut=shortcut)
+
+
+def remove_shortcut(desktop_id=DESKTOP_ID):
+    rows = _stored()
+    if rows.pop(desktop_id, None) is not None:
+        _store(rows)
+
+
+def shortcut_status(desktop_id=DESKTOP_ID):
+    """The combination Dikte holds for that verb, or None."""
+    return _stored().get(desktop_id) or None
+
+
+def desktop_name():
+    return "Windows"

--- a/platforms/windows/resample.py
+++ b/platforms/windows/resample.py
@@ -1,0 +1,106 @@
+"""Turning what a sound card hands over into what whisper wants.
+
+WASAPI in shared mode gives a stream in the device's own format and will not
+convert: a microphone runs at 44.1 or 48 kHz, in mono or stereo, and asking it
+for 16 kHz mono is refused rather than resampled. So the conversion happens
+here, in the same standard library the rest of Dikte is written in.
+
+Rate conversion is an integer accumulator rather than floating-point stepping,
+which is the whole point: a float phase accumulated a thousand times a second
+for an hour drifts, and drift between the two halves of a meeting is exactly
+the thing that must not happen. Adding `dst` per input sample and emitting one
+output sample per `src` of credit cannot drift, because the error is carried
+rather than rounded away.
+
+Downsampling averages the samples that fall into each output window instead of
+picking one of them. It is a crude low-pass, but a real one: point-sampling
+48 kHz down to 16 kHz folds everything above 8 kHz back into the speech band,
+and a transcription model hears that as noise.
+"""
+
+import array
+
+
+def to_mono(raw, channels):
+    """Interleaved s16 bytes -> one array('h') of mono samples."""
+    samples = array.array("h")
+    usable = len(raw) - (len(raw) % (2 * max(1, channels)))
+    if usable <= 0:
+        return samples
+    samples.frombytes(raw[:usable])
+    if channels <= 1:
+        return samples
+    if channels == 2:
+        return array.array("h", [(left + right) // 2
+                                 for left, right in zip(samples[0::2],
+                                                        samples[1::2])])
+    return array.array("h", [
+        sum(samples[at:at + channels]) // channels
+        for at in range(0, len(samples), channels)
+    ])
+
+
+class Resampler:
+    """One channel from `src` Hz to `dst` Hz, keeping its remainder between blocks.
+
+    A stream arrives in blocks of a few hundred samples, and a converter that
+    started each block from zero would round the same fraction of a sample off
+    a thousand times a second. The credit left over from the last block is what
+    makes the whole stream come out at exactly the rate it should.
+    """
+
+    def __init__(self, src, dst):
+        self.src = max(1, int(src))
+        self.dst = max(1, int(dst))
+        self._credit = 0
+        self._total = 0
+        self._count = 0
+
+    @property
+    def passthrough(self):
+        return self.src == self.dst
+
+    def feed(self, samples):
+        """array('h') in, array('h') out."""
+        if self.passthrough:
+            return samples
+        out = array.array("h")
+        if self.src > self.dst:
+            credit, total, count = self._credit, self._total, self._count
+            src, dst = self.src, self.dst
+            for sample in samples:
+                total += sample
+                count += 1
+                credit += dst
+                if credit >= src:
+                    credit -= src
+                    # Truncating rather than flooring: floor pulls a quiet
+                    # signal half a bit negative, and a constant offset on a
+                    # recording is a click at every join.
+                    out.append(int(total / count))
+                    total = 0
+                    count = 0
+            self._credit, self._total, self._count = credit, total, count
+            return out
+        # Upsampling, for the rare device that runs below 16 kHz: hold each
+        # sample for as long as it is owed. Nothing worth filtering is being
+        # added, so there is nothing to filter.
+        credit, src, dst = self._credit, self.src, self.dst
+        for sample in samples:
+            credit += dst
+            while credit >= src:
+                credit -= src
+                out.append(sample)
+        self._credit = credit
+        return out
+
+
+class Converter:
+    """A device's blocks turned into 16 kHz mono s16 bytes."""
+
+    def __init__(self, rate, channels, target_rate):
+        self.channels = max(1, int(channels))
+        self._resampler = Resampler(rate, target_rate)
+
+    def feed(self, raw):
+        return self._resampler.feed(to_mono(raw, self.channels)).tobytes()

--- a/platforms/windows/runtime.py
+++ b/platforms/windows/runtime.py
@@ -1,0 +1,629 @@
+"""Where things live on Windows, and how a process behaves there.
+
+Four things are different enough from Linux to be worth saying out loud.
+
+Directories are the ones Windows publishes rather than XDG's: settings roam
+with the user under %APPDATA%, everything large stays on the machine under
+%LOCALAPPDATA%.
+
+A mode-600 file is not protection here. NTFS has an ACL rather than a mode, and
+`os.chmod` can only ever clear the read-only attribute, so an API key written in
+plain text sits there readable by anything running as this user. The keys are
+encrypted with DPAPI instead, which ties them to this Windows account: copied to
+another machine, or read by another account, the ciphertext is worthless.
+
+One instance is not settled by the socket. Two servers can bind the same named
+pipe on Windows, so both would appear to start; a named mutex is what actually
+answers the question, and the pipe is only how the two of them then talk.
+
+A child process here can outlive its parent by default. Model servers are put
+in a job object marked kill-on-close, so a Dikte that is force-quit takes the
+loaded model down with it instead of leaving gigabytes resident with nothing
+left alive to ask it anything.
+"""
+
+import base64
+import contextlib
+import ctypes
+import hashlib
+import os
+import pathlib
+import signal
+import socket
+import subprocess
+from ctypes import wintypes
+
+# No console window for whisper, llama, ffmpeg, Claude or Codex: without this
+# every subprocess flashes a black box on screen, and a packaged application has
+# no console for them to inherit in the first place.
+NO_WINDOW = {"creationflags": subprocess.CREATE_NO_WINDOW}
+
+# Windows applications are named the way they are shown, and these are
+# directories the user will see in Explorer.
+APP_DIR = "Dikte"
+RECORDINGS_NAME = "Recordings"
+MEETINGS_NAME = "Meetings"
+
+# The only outside program Windows needs. Recording, the clipboard, the key
+# press and the shortcuts all happen inside this process here; ffmpeg is what
+# turns somebody's .mp4 into something a transcription model will take.
+PROGRAMS = ("ffmpeg",)
+
+# Version and salt for a stored secret. The prefix is what tells a plain key
+# written by an older version apart from an encrypted one, and the salt is
+# extra entropy DPAPI mixes in, so that another program running as this user
+# cannot decrypt Dikte's keys by asking Windows nicely with no arguments.
+SECRET_PREFIX = "dpapi:1:"
+SECRET_SALT = b"dikte.config.v1"
+
+kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+ntdll = ctypes.WinDLL("ntdll", use_last_error=True)
+shell32 = ctypes.WinDLL("shell32", use_last_error=True)
+
+# Handles and pointers are 64 bits here and ctypes assumes a C int for anything
+# nobody described to it, so an undeclared OpenProcess would hand back a
+# truncated handle and every call taking it would fail for no visible reason.
+kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+kernel32.GetCurrentThreadId.restype = wintypes.DWORD
+kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+kernel32.CloseHandle.restype = wintypes.BOOL
+kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+kernel32.LocalFree.restype = wintypes.HLOCAL
+kernel32.CreateMutexW.argtypes = [ctypes.c_void_p, wintypes.BOOL, wintypes.LPCWSTR]
+kernel32.CreateMutexW.restype = wintypes.HANDLE
+kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+kernel32.OpenProcess.restype = wintypes.HANDLE
+kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
+kernel32.TerminateProcess.restype = wintypes.BOOL
+kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+kernel32.SetInformationJobObject.argtypes = [
+    wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.DWORD]
+kernel32.SetInformationJobObject.restype = wintypes.BOOL
+kernel32.ReadProcessMemory.argtypes = [
+    wintypes.HANDLE, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_size_t)]
+kernel32.ReadProcessMemory.restype = wintypes.BOOL
+kernel32.QueryFullProcessImageNameW.argtypes = [
+    wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+    ctypes.POINTER(wintypes.DWORD)]
+kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
+
+advapi32.OpenProcessToken.argtypes = [
+    wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)]
+advapi32.OpenProcessToken.restype = wintypes.BOOL
+advapi32.ConvertSidToStringSidW.argtypes = [
+    ctypes.c_void_p, ctypes.POINTER(wintypes.LPWSTR)]
+advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+
+crypt32.CryptProtectData.restype = wintypes.BOOL
+crypt32.CryptUnprotectData.restype = wintypes.BOOL
+
+ntdll.NtQueryInformationProcess.argtypes = [
+    wintypes.HANDLE, ctypes.c_int, ctypes.c_void_p, wintypes.ULONG,
+    ctypes.POINTER(wintypes.ULONG)]
+ntdll.NtQueryInformationProcess.restype = ctypes.c_long
+
+shell32.ShellExecuteW.argtypes = [
+    wintypes.HWND, wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.LPCWSTR,
+    wintypes.LPCWSTR, ctypes.c_int]
+shell32.ShellExecuteW.restype = wintypes.HINSTANCE
+
+
+def _home(var, fallback):
+    value = os.environ.get(var)
+    if value:
+        return pathlib.Path(value)
+    return pathlib.Path(os.path.expanduser("~")) / fallback
+
+
+def config_home():
+    """%APPDATA%: small settings, which roam with a domain profile."""
+    return _home("APPDATA", "AppData/Roaming")
+
+
+def data_home():
+    """%LOCALAPPDATA%: models, recordings, history, none of which should roam."""
+    return _home("LOCALAPPDATA", "AppData/Local")
+
+
+def cache_home():
+    return data_home()
+
+
+def config_dir():
+    return config_home() / APP_DIR
+
+
+def data_dir():
+    return data_home() / APP_DIR
+
+
+def cache_dir():
+    return data_dir() / "Cache"
+
+
+# --- who this is ----------------------------------------------------------
+
+
+class _SidHandle(ctypes.Structure):
+    _fields_ = [("Sid", ctypes.c_void_p), ("Attributes", wintypes.DWORD)]
+
+
+TOKEN_QUERY = 0x0008
+TokenUser = 1
+
+
+def _sid_string():
+    """The current user's SID as S-1-5-…, or "" when Windows will not say."""
+    token = wintypes.HANDLE()
+    if not advapi32.OpenProcessToken(kernel32.GetCurrentProcess(),
+                                     TOKEN_QUERY, ctypes.byref(token)):
+        return ""
+    try:
+        size = wintypes.DWORD(0)
+        advapi32.GetTokenInformation(token, TokenUser, None, 0, ctypes.byref(size))
+        if not size.value:
+            return ""
+        buffer = ctypes.create_string_buffer(size.value)
+        if not advapi32.GetTokenInformation(token, TokenUser, buffer,
+                                            size, ctypes.byref(size)):
+            return ""
+        sid = ctypes.cast(buffer, ctypes.POINTER(_SidHandle)).contents.Sid
+        text = wintypes.LPWSTR()
+        if not advapi32.ConvertSidToStringSidW(sid, ctypes.byref(text)):
+            return ""
+        try:
+            return text.value or ""
+        finally:
+            kernel32.LocalFree(text)
+    finally:
+        kernel32.CloseHandle(token)
+
+
+def user_id():
+    """A token for the current user, to keep one user's pipe out of another's.
+
+    The SID itself would do, but it is long and full of characters a pipe name
+    would rather not carry, so what goes into the name is a hash of it. The
+    username is the fallback: two accounts on one machine never share it.
+    """
+    sid = _sid_string() or os.environ.get("USERNAME", "") or "dikte"
+    return hashlib.sha256(sid.encode("utf-8")).hexdigest()[:16]
+
+
+ERROR_ALREADY_EXISTS = 183
+
+
+class _Mutex:
+    """A named mutex held for as long as this instance runs."""
+
+    def __init__(self, handle):
+        self._handle = handle
+
+    def release(self):
+        if self._handle:
+            kernel32.CloseHandle(self._handle)
+            self._handle = None
+
+
+def single_instance(name):
+    """A handle proving this is the only Dikte running, or None when it is not.
+
+    Local\\ rather than Global\\: the name is per session, so two users logged
+    into the same machine each get their own Dikte rather than the second one
+    finding the first one's mutex and quitting.
+    """
+    handle = kernel32.CreateMutexW(None, False, f"Local\\{name}")
+    if not handle:
+        return _Mutex(None)   # no mutex to be had; fall through to the pipe
+    if ctypes.get_last_error() == ERROR_ALREADY_EXISTS:
+        kernel32.CloseHandle(handle)
+        return None
+    return _Mutex(handle)
+
+
+# --- secrets --------------------------------------------------------------
+
+
+class _Blob(ctypes.Structure):
+    _fields_ = [("cbData", wintypes.DWORD),
+                ("pbData", ctypes.POINTER(ctypes.c_char))]
+
+
+def _blob(data):
+    buffer = ctypes.create_string_buffer(data, len(data))
+    return _Blob(len(data), ctypes.cast(buffer, ctypes.POINTER(ctypes.c_char))), buffer
+
+
+def _take(blob):
+    """Copy a blob Windows allocated, then give the memory back."""
+    try:
+        return ctypes.string_at(blob.pbData, blob.cbData)
+    finally:
+        kernel32.LocalFree(blob.pbData)
+
+
+CRYPTPROTECT_UI_FORBIDDEN = 0x01
+
+
+def protect(text):
+    """An API key as it should be written into config.json.
+
+    Encrypted to this Windows account, so a config file copied off the machine
+    hands over nothing. A key that cannot be encrypted is stored as it was
+    rather than lost: an unreadable settings file would be the worse failure,
+    and the file is still inside this user's profile.
+    """
+    if not text:
+        return text
+    data, _keepalive = _blob(text.encode("utf-8"))
+    entropy, _salt = _blob(SECRET_SALT)
+    out = _Blob()
+    ok = crypt32.CryptProtectData(
+        ctypes.byref(data), "dikte", ctypes.byref(entropy),
+        None, None, CRYPTPROTECT_UI_FORBIDDEN, ctypes.byref(out),
+    )
+    if not ok:
+        return text
+    return SECRET_PREFIX + base64.b64encode(_take(out)).decode("ascii")
+
+
+def unprotect(value):
+    """The key behind a stored value, encrypted or not.
+
+    A value with no prefix is a key written by a version of Dikte from before
+    this, or by hand; it is returned as it stands and re-encrypted the next time
+    the settings are saved.
+    """
+    if not value or not value.startswith(SECRET_PREFIX):
+        return value
+    try:
+        raw = base64.b64decode(value[len(SECRET_PREFIX):], validate=True)
+    except (ValueError, TypeError):
+        return ""
+    data, _keepalive = _blob(raw)
+    entropy, _salt = _blob(SECRET_SALT)
+    out = _Blob()
+    ok = crypt32.CryptUnprotectData(
+        ctypes.byref(data), None, ctypes.byref(entropy),
+        None, None, CRYPTPROTECT_UI_FORBIDDEN, ctypes.byref(out),
+    )
+    if not ok:
+        # Restored from a backup, or copied from another machine or account.
+        # The key is gone rather than wrong, and saying so as an empty key sends
+        # the user to the one place that can fix it.
+        return ""
+    return _take(out).decode("utf-8", "replace")
+
+
+def secure_file(path):
+    """Nothing to tighten, and nothing that would help if there were.
+
+    `os.chmod` on Windows only ever moves the read-only attribute, so the mode
+    the Linux side sets would be a comfortable-looking no-op here. What actually
+    keeps the keys is that they are encrypted before they are written, plus the
+    ACL %APPDATA% already carries, which denies other standard users.
+    """
+    return False
+
+
+# --- processes ------------------------------------------------------------
+
+
+JobObjectExtendedLimitInformation = 9
+JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000
+
+
+class _IoCounters(ctypes.Structure):
+    _fields_ = [("ReadOperationCount", ctypes.c_ulonglong),
+                ("WriteOperationCount", ctypes.c_ulonglong),
+                ("OtherOperationCount", ctypes.c_ulonglong),
+                ("ReadTransferCount", ctypes.c_ulonglong),
+                ("WriteTransferCount", ctypes.c_ulonglong),
+                ("OtherTransferCount", ctypes.c_ulonglong)]
+
+
+class _BasicLimits(ctypes.Structure):
+    _fields_ = [("PerProcessUserTimeLimit", ctypes.c_longlong),
+                ("PerJobUserTimeLimit", ctypes.c_longlong),
+                ("LimitFlags", wintypes.DWORD),
+                ("MinimumWorkingSetSize", ctypes.c_size_t),
+                ("MaximumWorkingSetSize", ctypes.c_size_t),
+                ("ActiveProcessLimit", wintypes.DWORD),
+                ("Affinity", ctypes.POINTER(ctypes.c_ulong)),
+                ("PriorityClass", wintypes.DWORD),
+                ("SchedulingClass", wintypes.DWORD)]
+
+
+class _ExtendedLimits(ctypes.Structure):
+    _fields_ = [("BasicLimitInformation", _BasicLimits),
+                ("IoInfo", _IoCounters),
+                ("ProcessMemoryLimit", ctypes.c_size_t),
+                ("JobMemoryLimit", ctypes.c_size_t),
+                ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                ("PeakJobMemoryUsed", ctypes.c_size_t)]
+
+
+PROCESS_SET_QUOTA = 0x0100
+PROCESS_TERMINATE = 0x0001
+PROCESS_QUERY_INFORMATION = 0x0400
+PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+PROCESS_VM_READ = 0x0010
+
+_job = None
+
+
+def _kill_on_close_job():
+    """One job object for the whole application, made the first time it is needed."""
+    global _job
+    if _job is not None:
+        return _job
+    handle = kernel32.CreateJobObjectW(None, None)
+    if not handle:
+        return None
+    limits = _ExtendedLimits()
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    if not kernel32.SetInformationJobObject(
+        handle, JobObjectExtendedLimitInformation,
+        ctypes.byref(limits), ctypes.sizeof(limits),
+    ):
+        kernel32.CloseHandle(handle)
+        return None
+    _job = handle
+    return _job
+
+
+def adopt(proc):
+    """Put a child in the job object, so it cannot outlive this process.
+
+    The last handle to a kill-on-close job closing is what kills its members,
+    and every handle a process holds is closed when it ends however it ends,
+    including a kill from Task Manager. That is the case the pid file cannot
+    cover, because nothing of ours runs to write one.
+    """
+    job = _kill_on_close_job()
+    if job is None:
+        return False
+    handle = kernel32.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE,
+                                  False, int(proc.pid))
+    if not handle:
+        return False
+    try:
+        return bool(kernel32.AssignProcessToJobObject(job, handle))
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+class _ProcessBasicInformation(ctypes.Structure):
+    _fields_ = [("Reserved1", ctypes.c_void_p),
+                ("PebBaseAddress", ctypes.c_void_p),
+                ("Reserved2", ctypes.c_void_p * 2),
+                ("UniqueProcessId", ctypes.c_void_p),
+                ("Reserved3", ctypes.c_void_p)]
+
+
+# Offsets into the 64-bit PEB and RTL_USER_PROCESS_PARAMETERS. Undocumented,
+# but unchanged for the whole life of x64 Windows, and the alternative is
+# spawning PowerShell for a question asked once at startup.
+_PEB_PROCESS_PARAMETERS = 0x20
+_PARAMS_COMMAND_LINE = 0x70
+
+
+def _remote_command_line(handle):
+    """The command line of another process, or "" when it cannot be read."""
+    info = _ProcessBasicInformation()
+    if ntdll.NtQueryInformationProcess(handle, 0, ctypes.byref(info),
+                                       ctypes.sizeof(info), None) != 0:
+        return ""
+    if not info.PebBaseAddress:
+        return ""
+
+    def read(address, size):
+        buffer = ctypes.create_string_buffer(size)
+        read_bytes = ctypes.c_size_t(0)
+        ok = kernel32.ReadProcessMemory(handle, ctypes.c_void_p(address), buffer,
+                                        size, ctypes.byref(read_bytes))
+        return buffer.raw if ok and read_bytes.value == size else b""
+
+    params = read(info.PebBaseAddress + _PEB_PROCESS_PARAMETERS, 8)
+    if not params:
+        return ""
+    params_address = int.from_bytes(params, "little")
+    header = read(params_address + _PARAMS_COMMAND_LINE, 16)
+    if not header:
+        return ""
+    length = int.from_bytes(header[0:2], "little")
+    buffer_address = int.from_bytes(header[8:16], "little")
+    if not length or not buffer_address:
+        return ""
+    raw = read(buffer_address, length)
+    return raw.decode("utf-16-le", "replace") if raw else ""
+
+
+def _image_path(handle):
+    size = wintypes.DWORD(32768)
+    buffer = ctypes.create_unicode_buffer(size.value)
+    if not kernel32.QueryFullProcessImageNameW(handle, 0, buffer,
+                                               ctypes.byref(size)):
+        return ""
+    return buffer.value
+
+
+def is_our_process(pid, needles):
+    """Whether that pid is a process whose command line holds all of `needles`.
+
+    Pids are handed out again here as well, and killing whatever inherited the
+    number would be a good deal worse than the leak being cleaned up. When the
+    command line cannot be read the image path is asked instead, and a needle
+    that names a directory is taken to be satisfied when the program itself
+    lives inside it, which for a whisper.cpp Dikte downloaded is the case.
+    """
+    handle = kernel32.OpenProcess(
+        PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ, False, int(pid))
+    if not handle:
+        return False
+    try:
+        line = _remote_command_line(handle)
+        if line:
+            lowered = line.lower()
+            return all(str(needle).lower() in lowered for needle in needles)
+        image = _image_path(handle).lower()
+        if not image:
+            return False
+        return all(str(needle).lower() in image for needle in needles)
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+def terminate(pid):
+    """Ask a process to end. Windows has no SIGTERM, so this is the kill."""
+    handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, int(pid))
+    if not handle:
+        return False
+    try:
+        return bool(kernel32.TerminateProcess(handle, 1))
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+# --- the session ----------------------------------------------------------
+
+
+def signals():
+    """The signals a session end arrives as.
+
+    No SIGHUP on Windows. SIGBREAK is what Ctrl+Break and a console shutdown
+    send, and a logout arrives as WM_ENDSESSION, which Qt turns into quitting
+    the application on its own.
+    """
+    found = [signal.SIGINT, signal.SIGTERM]
+    if hasattr(signal, "SIGBREAK"):
+        found.append(signal.SIGBREAK)
+    return tuple(found)
+
+
+def wakeup_socketpair():
+    """A pair of sockets for set_wakeup_fd.
+
+    Windows has no pipe a signal can be written to, only sockets, which is what
+    `signal.set_wakeup_fd` accepts here and what QSocketNotifier watches.
+    """
+    reader, writer = socket.socketpair()
+    reader.setblocking(False)
+    writer.setblocking(False)
+    return reader, writer
+
+
+ws2_32 = ctypes.WinDLL("ws2_32", use_last_error=True)
+# A SOCKET is a handle, not an int, and a truncated one closes nothing.
+ws2_32.closesocket.argtypes = [ctypes.c_void_p]
+ws2_32.closesocket.restype = ctypes.c_int
+
+
+def abort_socket(sock):
+    """Make a read another thread is blocked on return, now.
+
+    Winsock does not promise that a shutdown reaches a recv already in flight:
+    it disallows the ones that come after, and the thread sitting inside the
+    current one keeps sitting there. Closing the handle underneath it does end
+    it, with an error, which is what a cancelled request wants.
+
+    Python will not close it while the connection still holds a file object
+    over the socket, which is what the deferred close in socket.close() is for,
+    so the handle is taken out and closed directly. The read then fails with
+    "not a socket", which is exactly what happened to it.
+    """
+    with contextlib.suppress(OSError):
+        sock.shutdown(socket.SHUT_RDWR)
+    try:
+        handle = sock.detach()
+    except OSError:
+        return False
+    if handle == -1:
+        return False
+    ws2_32.closesocket(handle)
+    return True
+
+
+DETACHED_PROCESS = 0x00000008
+CREATE_NEW_PROCESS_GROUP = 0x00000200
+
+
+def relaunch(command):
+    """Start Dikte again, and let this process finish quitting.
+
+    `os.execv` exists on Windows but does not replace the process the way it
+    does on Unix: it starts a new one and ends this one immediately, which
+    would skip the shutdown that stops the model servers and takes down the
+    tray icon. A detached child plus an ordinary quit does the same job in the
+    right order. Detached so that closing the terminal a restart was typed in
+    does not take the new instance with it.
+    """
+    subprocess.Popen(
+        list(command), close_fds=True,
+        creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP,
+    )
+    return True
+
+
+def cuda_driver_version():
+    """(major, minor) of the CUDA the installed NVIDIA driver can run, or None.
+
+    A CUDA build of whisper.cpp or llama.cpp needs a driver at least as new as
+    the runtime it was built against, and both projects publish several. Asked
+    here so that the download can pick the newest one this machine will
+    actually load: installed the wrong way round, the server exits on a missing
+    DLL that names a CUDA version and nothing about what to do.
+
+    None when there is no NVIDIA driver, which is also an answer: a CUDA build
+    on a machine with no NVIDIA card is a download that cannot work.
+    """
+    try:
+        nvcuda = ctypes.WinDLL("nvcuda")
+    except OSError:
+        return None
+    version = ctypes.c_int(0)
+    try:
+        # Answered without cuInit, so asking costs nothing and starts nothing.
+        if nvcuda.cuDriverGetVersion(ctypes.byref(version)) != 0:
+            return None
+    except (OSError, AttributeError):
+        return None
+    if version.value <= 0:
+        return None
+    return version.value // 1000, (version.value % 1000) // 10
+
+
+CP_UTF8 = 65001
+
+
+def prepare_console():
+    """Let this console print what Dikte has to say.
+
+    A Windows console starts in the machine's ANSI codepage, which on a Turkish
+    install is cp1254: a check mark, an arrow, an ellipsis or the word
+    "değiştirildi" is not in it, and printing one raises instead of printing.
+    Asking for UTF-8 is what makes the answers legible; the streams are
+    reconfigured on top of this by the caller, so a console that refuses still
+    prints something rather than a traceback.
+    """
+    try:
+        kernel32.SetConsoleOutputCP(CP_UTF8)
+        kernel32.SetConsoleCP(CP_UTF8)
+    except OSError:
+        return False
+    return True
+
+
+def open_folder(path):
+    """Show a directory in Explorer. True when something was launched."""
+    try:
+        result = shell32.ShellExecuteW(None, "open", str(path), None, None, 1)
+    except OSError:
+        return False
+    return int(result) > 32

--- a/platforms/windows/runtime.py
+++ b/platforms/windows/runtime.py
@@ -31,6 +31,7 @@ import pathlib
 import signal
 import socket
 import subprocess
+import sys
 from ctypes import wintypes
 
 # No console window for whisper, llama, ffmpeg, Claude or Codex: without this
@@ -48,6 +49,21 @@ MEETINGS_NAME = "Meetings"
 # press and the shortcuts all happen inside this process here; ffmpeg is what
 # turns somebody's .mp4 into something a transcription model will take.
 PROGRAMS = ("ffmpeg",)
+
+
+def _expose_bundled_programs():
+    """Put executables shipped beside a frozen Dikte on its private PATH."""
+    if not getattr(sys, "frozen", False):
+        return
+    directory = str(pathlib.Path(sys.executable).resolve().parent)
+    parts = [part for part in os.environ.get("PATH", "").split(os.pathsep)
+             if part]
+    if not any(os.path.normcase(part) == os.path.normcase(directory)
+               for part in parts):
+        os.environ["PATH"] = os.pathsep.join([directory, *parts])
+
+
+_expose_bundled_programs()
 
 # Version and salt for a stored secret. The prefix is what tells a plain key
 # written by an older version apart from an encrypted one, and the salt is
@@ -235,6 +251,15 @@ class _Blob(ctypes.Structure):
                 ("pbData", ctypes.POINTER(ctypes.c_char))]
 
 
+crypt32.CryptProtectData.argtypes = [
+    ctypes.POINTER(_Blob), wintypes.LPCWSTR, ctypes.POINTER(_Blob),
+    ctypes.c_void_p, ctypes.c_void_p, wintypes.DWORD, ctypes.POINTER(_Blob)]
+crypt32.CryptUnprotectData.argtypes = [
+    ctypes.POINTER(_Blob), ctypes.POINTER(wintypes.LPWSTR),
+    ctypes.POINTER(_Blob), ctypes.c_void_p, ctypes.c_void_p, wintypes.DWORD,
+    ctypes.POINTER(_Blob)]
+
+
 def _blob(data):
     buffer = ctypes.create_string_buffer(data, len(data))
     return _Blob(len(data), ctypes.cast(buffer, ctypes.POINTER(ctypes.c_char))), buffer
@@ -299,6 +324,18 @@ def unprotect(value):
         # the user to the one place that can fix it.
         return ""
     return _take(out).decode("utf-8", "replace")
+
+
+def dpapi_available():
+    """Whether this login has a usable DPAPI master key.
+
+    Normal interactive Windows accounts do. Some service/sandbox accounts do
+    not have a loaded profile and CryptProtectData returns ERROR_FILE_NOT_FOUND;
+    callers can then explain that encryption is unavailable instead of
+    claiming a plaintext fallback was protected.
+    """
+    probe = protect("dikte-dpapi-probe")
+    return probe.startswith(SECRET_PREFIX) and unprotect(probe) == "dikte-dpapi-probe"
 
 
 def secure_file(path):

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -822,7 +822,16 @@ class SettingsWindow(QDialog):
 
         outer.addWidget(orr)
         outer.addStretch(1)
-        return page
+
+        # Local cleanup adds another program, model picker and its options to
+        # an already tall page.  On a short display that minimum height used to
+        # push the dialog's Save button below the screen with no way to reach
+        # it.  Scroll only this tab so the dialog footer stays put.
+        area = QScrollArea()
+        area.setWidgetResizable(True)
+        area.setFrameShape(QScrollArea.Shape.NoFrame)
+        area.setWidget(page)
+        return area
 
     def _prompt_tab(self):
         page = QWidget()

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -23,6 +23,7 @@ import ggml
 import hotkey
 import ipc
 import meeting
+import paste
 from filetranscribe import FileTranscriber
 from i18n import t
 from keycapture import ShortcutCatcher
@@ -110,7 +111,6 @@ REASONING_LEVELS = [
     ("Low", "low"), ("Medium", "medium"), ("High", "high"),
     ("Very high", "xhigh"), ("Maximum", "max"),
 ]
-PASTE_SHORTCUTS = ["ctrl+v", "ctrl+shift+v", "shift+insert"]
 # Offered for every global shortcut, which keeps them one kind of field rather
 # than four. The boxes stay editable: this is a shortlist of combinations that
 # are usually free, not the set of ones that work.
@@ -605,7 +605,10 @@ class SettingsWindow(QDialog):
         form.addRow("", self.auto_paste)
 
         self.paste_shortcut = QComboBox()
-        self.paste_shortcut.addItems(PASTE_SHORTCUTS)
+        # Offer this desktop's usual combinations while preserving a custom
+        # one already stored in the configuration.
+        self.paste_shortcut.setEditable(True)
+        self.paste_shortcut.addItems(paste.desktop().shortcuts)
         self.paste_shortcut.setToolTip(
             t("Terminals usually want ctrl+shift+v. Change this if pasting does nothing.")
         )

--- a/settings_ui.py
+++ b/settings_ui.py
@@ -23,9 +23,12 @@ import ggml
 import hotkey
 import ipc
 import meeting
-import paste
 from filetranscribe import FileTranscriber
 from i18n import t
+from keycapture import ShortcutCatcher
+from platforms import adapter
+
+runtime = adapter("runtime")
 
 UI_LANGUAGES = [("Automatic (system)", "auto"), ("Turkish", "tr"), ("English", "en")]
 LANGUAGES = [
@@ -107,22 +110,10 @@ REASONING_LEVELS = [
     ("Low", "low"), ("Medium", "medium"), ("High", "high"),
     ("Very high", "xhigh"), ("Maximum", "max"),
 ]
+PASTE_SHORTCUTS = ["ctrl+v", "ctrl+shift+v", "shift+insert"]
 # Offered for every global shortcut, which keeps them one kind of field rather
 # than four. The boxes stay editable: this is a shortlist of combinations that
 # are usually free, not the set of ones that work.
-SHORTCUTS = [
-    "Ctrl+Space", "Ctrl+Alt+Space", "Ctrl+Shift+Space", "Meta+Space",
-    "Ctrl+Alt+A", "Ctrl+Alt+D", "Ctrl+Alt+M", "Ctrl+Alt+Q",
-    "Meta+A", "Meta+D", "Meta+M",
-    "Ctrl+Alt+F1", "Ctrl+Alt+F2", "Ctrl+Alt+F3",
-]
-# Cmd+Space is Spotlight and Ctrl+Space switches input sources, so a Mac gets
-# its own shortlist. Option is what Alt is called on that keyboard.
-MAC_SHORTCUTS = [
-    "Ctrl+Option+Space", "Cmd+Shift+Space", "Ctrl+Shift+Space",
-    "Ctrl+Option+A", "Ctrl+Option+D", "Ctrl+Option+M",
-    "Cmd+Option+A", "Cmd+Option+D", "Cmd+Option+M",
-]
 AUDIO_FILTER = ("*.mp3 *.wav *.m4a *.ogg *.opus *.flac *.aac *.wma "
                 "*.mp4 *.mkv *.webm *.mov *.avi")
 
@@ -166,6 +157,25 @@ class LocalModelBox(QGroupBox):
         self.install_button.clicked.connect(self._install_program)
         form.addRow(t("Program"), self._side_by_side(self.program_label,
                                                      self.install_button))
+
+        # Which build to fetch. The projects publish a different set per
+        # platform, with no CUDA for Linux and no Vulkan whisper for Windows,
+        # so the box offers what there is rather than a fixed list, and it is
+        # left out entirely where the only answer is the processor.
+        self.backend = QComboBox(self)
+        choices = ggml.backend_choices(program)
+        for name in choices:
+            self.backend.addItem(t(ggml.BACKEND_LABELS[name]), name)
+        self.backend.setToolTip(t(
+            "Automatic downloads the build that runs on any machine, on the "
+            "processor. Pick a graphics card build to fetch that one instead; "
+            "if it fails to start, the reason is shown rather than swallowed."
+        ))
+        self.backend.currentIndexChanged.connect(self._show_program)
+        if len(choices) > 2:
+            form.addRow(t("Runs on"), self.backend)
+        else:
+            self.backend.setVisible(False)
 
         if self._repos is not None:
             self.repo = QComboBox()
@@ -263,17 +273,32 @@ class LocalModelBox(QGroupBox):
             self.program_label.setText(t("Not installed."))
             self.install_button.setVisible(True)
             return
-        self.install_button.setVisible(not ggml.installed_program(self.program)
-                                       and not ggml.system_program(self.program))
         if ggml.system_program(self.program):
             # Worth saying which one is running: a distribution package is built
             # for this machine and may reach the graphics card, while the
             # released binaries carry processor backends only.
+            self.install_button.setVisible(False)
             self.program_label.setText(t("Installed on the system: {path}", path=path))
-        else:
-            self.program_label.setText(
-                t("Downloaded, version {version}.",
-                  version=ggml.installed_version(self.program) or "?"))
+            return
+        installed = ggml.installed_backend(self.program)
+        # Asking for a different build is asking for it to be fetched: what is
+        # unpacked here decides whether the graphics card is reachable at all.
+        self.install_button.setVisible(installed != self.chosen_backend())
+        self.program_label.setText(t(
+            "Downloaded, version {version} ({backend}).",
+            version=ggml.installed_version(self.program) or "?",
+            backend=t(ggml.BACKEND_LABELS.get(installed, installed)),
+        ))
+
+    def chosen_backend(self):
+        return self.backend.currentData() or "auto"
+
+    def set_backend(self, name):
+        for index in range(self.backend.count()):
+            if self.backend.itemData(index) == name:
+                self.backend.setCurrentIndex(index)
+                return
+        self.backend.setCurrentIndex(0)
 
     # ---- the lists -------------------------------------------------------
 
@@ -355,9 +380,12 @@ class LocalModelBox(QGroupBox):
         self.install_button.setEnabled(False)
         self.program_label.setText(t("Downloading…"))
 
+        backend = self.chosen_backend()
+
         def work():
             try:
-                ggml.install_program(self.program, on_progress=self._report)
+                ggml.install_program(self.program, on_progress=self._report,
+                                     backend=backend)
                 self._installed.emit("", "")
             except ggml.LocalError as exc:
                 self._installed.emit("", str(exc))
@@ -461,6 +489,10 @@ class LocalModelBox(QGroupBox):
 
 class SettingsWindow(QDialog):
     applied = pyqtSignal()
+    # True while a shortcut is being read off the keyboard. The application
+    # gives up its own global shortcuts for that long, or the combination it
+    # already holds would never reach this window to be read.
+    capturing = pyqtSignal(bool)
 
     _models_loaded = pyqtSignal(list, str)
     _transcribe_models_loaded = pyqtSignal(list, str)
@@ -476,6 +508,12 @@ class SettingsWindow(QDialog):
         # global shortcuts. One dictionary is what lets install, remove and the
         # status line be written once instead of once per key.
         self._shortcut_rows = {}
+        # The "press a key" button beside each of them, so that closing the
+        # window can hand the keyboard back whatever it was in the middle of,
+        # and what each row is called, for saying which verb already has a
+        # combination somebody just pressed.
+        self._shortcut_catchers = {}
+        self._shortcut_labels = {}
         # Each provider keeps its own transcription model, so switching the
         # provider back and forth never overwrites the other one's.
         self._models = dict.fromkeys(cfg.TRANSCRIBERS, "")
@@ -528,6 +566,16 @@ class SettingsWindow(QDialog):
         if not conf.transcribe_ready():
             self.tabs.setCurrentIndex(self.api_tab_index)
 
+    def closeEvent(self, event):
+        # A window closed in the middle of reading a key would take the
+        # keyboard with it and leave the application's own shortcuts down.
+        self._stop_capturing()
+        super().closeEvent(event)
+
+    def done(self, result):
+        self._stop_capturing()
+        super().done(result)
+
     # ---- tabs ----------------------------------------------------------
 
     def _general_tab(self):
@@ -557,16 +605,10 @@ class SettingsWindow(QDialog):
         form.addRow("", self.auto_paste)
 
         self.paste_shortcut = QComboBox()
-        # A shortlist of the combinations that usually paste, not the set of
-        # them: a stored one this desktop does not offer is kept as it is
-        # rather than quietly replaced by the first item on the list.
-        self.paste_shortcut.setEditable(True)
-        self.paste_shortcut.addItems(paste.desktop().shortcuts)
-        self.paste_shortcut.setToolTip(t(
-            "macOS asks for Accessibility permission the first time this is sent."
-            if paste.desktop() is paste.MACOS else
-            "Terminals usually want ctrl+shift+v. Change this if pasting does nothing."
-        ))
+        self.paste_shortcut.addItems(PASTE_SHORTCUTS)
+        self.paste_shortcut.setToolTip(
+            t("Terminals usually want ctrl+shift+v. Change this if pasting does nothing.")
+        )
         form.addRow(t("Paste key"), self.paste_shortcut)
 
         self.restore_clipboard = QCheckBox(t("Restore the previous clipboard after pasting"))
@@ -605,10 +647,27 @@ class SettingsWindow(QDialog):
         form.addRow("", self.filter_hallucinations)
 
         self.keep_audio = QCheckBox(
-            t("Keep audio files ({path})", path=str(cfg.RECORDINGS_DIR))
-        )
+            t("Keep audio files ({path})", path=cfg.RECORDINGS_DIR))
         form.addRow("", self.keep_audio)
+
+        # Where all of it actually is. The two directories are not in the same
+        # place on the two platforms and on Windows neither is anywhere a user
+        # would go looking, so the window opens them rather than naming them.
+        settings_folder = QPushButton(t("Open the settings folder"))
+        settings_folder.clicked.connect(
+            lambda: self._open_folder(cfg.CONFIG_DIR))
+        data_folder = QPushButton(t("Open the data folder"))
+        data_folder.clicked.connect(lambda: self._open_folder(cfg.DATA_DIR))
+        form.addRow(t("Folders"), self._row(settings_folder, data_folder))
         return page
+
+    def _open_folder(self, path):
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+        if not runtime.open_folder(path):
+            QMessageBox.information(self, t("Folder"), str(path))
 
     def _api_tab(self):
         page = QWidget()
@@ -999,15 +1058,6 @@ class SettingsWindow(QDialog):
             self.meeting_system.addItem(desc, name)
         sources_form.addRow(t("The other participants"), self.meeting_system)
 
-        if audio.sound() is audio.COREAUDIO:
-            mac_note = QLabel(t(
-                "macOS does not offer what the speakers are playing as something "
-                "to record. Install BlackHole or Loopback, send the meeting's "
-                "sound through it, and pick it above."
-            ))
-            mac_note.setWordWrap(True)
-            sources_form.addRow(mac_note)
-
         note = QLabel(t(
             "Wear headphones if you can. Through speakers your microphone hears "
             "the other side as well, and although a line that lands on both "
@@ -1248,34 +1298,29 @@ class SettingsWindow(QDialog):
         layout.addLayout(form)
 
         self.evdev_enabled = QCheckBox(t(
-            "Use the built-in listener (/dev/input), for when the {desktop} "
-            "shortcut is not active yet", desktop=hotkey.desktop_name()
+            "Use the built-in listener (/dev/input), for when the KDE shortcut is "
+            "not active yet"
         ))
         self.evdev_enabled.setToolTip(t(
             "Works immediately, no session restart. The only difference: the key "
             "combination also reaches the focused application."
         ))
         layout.addWidget(self.evdev_enabled)
-        # Nothing to wait for where nothing is installed: there the listener is
-        # the mechanism, always on, and not a choice to offer.
-        self.evdev_enabled.setVisible(hotkey.installs_shortcuts())
+        # Windows has no desktop file for a session to read later and no
+        # /dev/input to read behind its back: Dikte registers the combination
+        # itself and holds it while it runs, so there is nothing to switch on.
+        self.evdev_enabled.setVisible(not hotkey.LISTENER_IS_PRIMARY)
 
-        if hotkey.shortcut_needs_restart():
-            explanation = t(
-                "KWin only reads shortcut settings at startup. After 'Install' the "
-                "shortcut shows up under System Settings → Shortcuts, but it will "
-                "not fire until you log out and back in. Until then, use the "
-                "built-in listener."
-            )
-        elif hotkey.installs_shortcuts():
-            explanation = t("The shortcut starts working as soon as it is installed.")
-        else:
-            explanation = t(
-                "Dikte asks macOS for these combinations itself, while it is "
-                "running. Nothing is installed, and no other application receives "
-                "them in the meantime."
-            )
-        note = QLabel(explanation)
+        note = QLabel(t(
+            "The shortcuts are held for as long as Dikte is running, and given "
+            "back when it quits. Windows hands a combination to one program at "
+            "a time: one that is already taken is refused, without saying by "
+            "whom, and the key no longer reaches the window underneath."
+        ) if hotkey.LISTENER_IS_PRIMARY else t(
+            "KWin only reads shortcut settings at startup. After 'Install' the "
+            "shortcut shows up under System Settings → Shortcuts, but it will not "
+            "fire until you log out and back in. Until then, use the built-in listener."
+        ))
         note.setWordWrap(True)
         layout.addWidget(note)
         layout.addStretch(1)
@@ -1345,14 +1390,10 @@ class SettingsWindow(QDialog):
 
     @staticmethod
     def _shortcut_box(placeholder=""):
-        """The field a global shortcut is typed or picked in."""
-        box = QComboBox()
-        box.setEditable(True)
-        box.addItems(MAC_SHORTCUTS if hotkey.desktop_name() == "macOS"
-                     else SHORTCUTS)
-        box.setCurrentText("")
+        """The field that shows a captured shortcut or accepts one typed in."""
+        box = QLineEdit()
         if placeholder:
-            box.lineEdit().setPlaceholderText(placeholder)
+            box.setPlaceholderText(placeholder)
         return box
 
     def _key_row(self, form, provider, placeholder, tester):
@@ -1383,31 +1424,63 @@ class SettingsWindow(QDialog):
         box = self._shortcut_box(placeholder or t("none"))
         if tooltip:
             box.setToolTip(tooltip)
-        form.addRow(label, self._row(box, *self._install_buttons(
-            lambda: self._install_shortcut(which),
-            lambda: self._remove_shortcut(which),
-        )))
+        # The box still takes a typed or picked combination, but pressing the
+        # keys is the obvious way to choose a key press and the only one that
+        # answers for the keyboard actually in front of you.
+        catcher = ShortcutCatcher()
+        catcher.captured.connect(
+            lambda combo: self._shortcut_captured(which, combo))
+        catcher.refused.connect(lambda why: self._shortcut_refused(which, why))
+        catcher.listening.connect(self.capturing)
+        install = QPushButton(t("Install as a {desktop} shortcut",
+                                desktop=hotkey.desktop_name()))
+        install.clicked.connect(lambda: self._install_shortcut(which))
+        remove = QPushButton(t("Remove"))
+        remove.clicked.connect(lambda: self._remove_shortcut(which))
+        form.addRow(label, self._row(box, catcher, install, remove))
         status = QLabel("")
         status.setWordWrap(True)
         form.addRow(status)
         self._shortcut_rows[which] = (box, status, missing)
+        self._shortcut_catchers[which] = catcher
+        self._shortcut_labels[which] = label
         return box
 
-    @staticmethod
-    def _install_buttons(install_handler, remove_handler):
-        """Install and Remove, where this system has somewhere to install into.
+    def _shortcut_captured(self, which, combo):
+        """A combination read off the keyboard lands in that verb's box."""
+        taken = self._verb_using(combo, except_for=which)
+        if taken:
+            self._shortcut_refused(which, t(
+                "The shortcut {shortcut} is already assigned to {verb}. Each "
+                "shortcut can only perform one action.", shortcut=combo,
+                verb=self._shortcut_labels.get(taken, taken),
+            ))
+            return
+        box, status, _missing = self._shortcut_rows[which]
+        box.setText(combo)
+        status.setText(t(
+            "Selected {shortcut}. Press Save to start using it.",
+            shortcut=combo))
 
-        macOS has not: Dikte asks for the combination itself while it runs, so
-        there is nothing to write down and nothing to take back out.
-        """
-        if not hotkey.installs_shortcuts():
-            return []
-        install = QPushButton(t("Install as a {desktop} shortcut",
-                                desktop=hotkey.desktop_name()))
-        install.clicked.connect(install_handler)
-        remove = QPushButton(t("Remove"))
-        remove.clicked.connect(remove_handler)
-        return [install, remove]
+    def _shortcut_refused(self, which, why):
+        _box, status, _missing = self._shortcut_rows[which]
+        status.setText(why)
+
+    def _verb_using(self, combo, except_for=""):
+        """Which other verb already has that combination in its box, or ''."""
+        wanted = hotkey.parse_shortcut(combo)
+        for name, (box, _status, _missing) in self._shortcut_rows.items():
+            if name == except_for:
+                continue
+            other = box.text().strip()
+            if other and hotkey.parse_shortcut(other) == wanted:
+                return name
+        return ""
+
+    def _stop_capturing(self):
+        """Give the keyboard back, whatever the window was in the middle of."""
+        for catcher in self._shortcut_catchers.values():
+            catcher.cancel()
 
     @staticmethod
     def _row(*widgets):
@@ -1446,6 +1519,7 @@ class SettingsWindow(QDialog):
         self.local_gpu.setChecked(conf["local_gpu"])
         self.local_preload.setChecked(conf["local_preload"])
         self.local_threads.setValue(int(conf["local_threads"]))
+        self.local_whisper.set_backend(conf["local_backend"])
         self.local_whisper.load(conf["local_model"])
 
         self.cleanup_enabled.setChecked(conf["cleanup_enabled"])
@@ -1460,6 +1534,7 @@ class SettingsWindow(QDialog):
         self.local_llm_gpu.setChecked(conf["local_llm_gpu"])
         self.local_llm_preload.setChecked(conf["local_llm_preload"])
         self._select_data(self.local_llm_reasoning, conf["local_llm_reasoning"])
+        self.local_llm.set_backend(conf["local_llm_backend"])
         self.local_llm.load(conf["local_llm_model"], conf["local_llm_repo"])
         self.cleanup_prompt.setPlainText(conf["cleanup_prompt"] or cfg.default_cleanup_prompt())
         self.file_cleanup_prompt.setPlainText(
@@ -1504,7 +1579,7 @@ class SettingsWindow(QDialog):
         self.file_path = ""
 
         for which, (box, _status, _missing) in self._shortcut_rows.items():
-            box.setCurrentText(conf[hotkey.SHORTCUTS[which].setting])
+            box.setText(conf[hotkey.SHORTCUTS[which].setting])
         self.evdev_enabled.setChecked(conf["evdev_hotkey"])
 
         self.history_limit.setValue(max(0, int(conf["history_limit"])))
@@ -1539,6 +1614,7 @@ class SettingsWindow(QDialog):
             conf[who.model] = self._models[name].strip() or cfg.DEFAULTS[who.model]
         conf["local_model"] = self.local_whisper.selected()
         conf["local_gpu"] = self.local_gpu.isChecked()
+        conf["local_backend"] = self.local_whisper.chosen_backend()
         conf["local_preload"] = self.local_preload.isChecked()
         conf["local_threads"] = self.local_threads.value()
 
@@ -1555,6 +1631,7 @@ class SettingsWindow(QDialog):
         conf["local_llm_model"] = self.local_llm.selected()
         conf["local_llm_repo"] = self.local_llm.repository()
         conf["local_llm_gpu"] = self.local_llm_gpu.isChecked()
+        conf["local_llm_backend"] = self.local_llm.chosen_backend()
         conf["local_llm_preload"] = self.local_llm_preload.isChecked()
         conf["local_llm_reasoning"] = self.local_llm_reasoning.currentData() or ""
 
@@ -1618,7 +1695,7 @@ class SettingsWindow(QDialog):
         # turns them off.
         for which, (box, _status, _missing) in self._shortcut_rows.items():
             spec = hotkey.SHORTCUTS[which]
-            conf[spec.setting] = box.currentText().strip() or spec.fallback
+            conf[spec.setting] = box.text().strip() or spec.fallback
         conf["evdev_hotkey"] = self.evdev_enabled.isChecked()
         conf["history_limit"] = self.history_limit.value()
         conf.save()
@@ -1864,7 +1941,7 @@ class SettingsWindow(QDialog):
     def _install_shortcut(self, which):
         spec = hotkey.SHORTCUTS[which]
         box, _status, _missing = self._shortcut_rows[which]
-        combo = box.currentText().strip() or spec.fallback
+        combo = box.text().strip() or spec.fallback
         if not combo:
             QMessageBox.information(self, t("Shortcut"),
                                     t("Type a key combination first."))

--- a/tests/support.py
+++ b/tests/support.py
@@ -24,6 +24,7 @@ from unittest import mock
 
 import assistant
 import config as cfg
+import ggml
 import i18n
 import platforms
 
@@ -98,6 +99,13 @@ class DikteTest(unittest.TestCase):
         # Resolved from cfg.DATA_DIR when assistant was imported, so it needs
         # moving on its own.
         self.patch_attr(assistant, "SESSION_FILE", data_dir / "assistant.json")
+        # ggml resolves these paths when it is imported. Keep model discovery,
+        # downloaded programs and server logs inside the same throwaway home;
+        # otherwise a developer downloading a model while the suite runs can
+        # change what a settings test sees.
+        self.patch_attr(ggml, "DATA_DIR", data_dir)
+        self.patch_attr(ggml, "BIN_DIR", data_dir / "bin")
+        self.patch_attr(ggml, "MODELS_DIR", data_dir / "models")
 
         i18n.set_language("en")
         self.addCleanup(i18n.set_language, "en")

--- a/tests/support.py
+++ b/tests/support.py
@@ -25,6 +25,7 @@ from unittest import mock
 import assistant
 import config as cfg
 import i18n
+import platforms
 
 # What the application is, rather than what it does: PipeWire, wl-clipboard,
 # ydotool, KDE's shortcut file, /dev/input. A port to another desktop replaces
@@ -39,6 +40,27 @@ linux_only = unittest.skipUnless(
     sys.platform.startswith("linux"),
     "covers the Linux desktop stack (PipeWire, wl-clipboard, ydotool, KDE)",
 )
+
+windows_only = unittest.skipUnless(
+    sys.platform.startswith("win"),
+    "covers the Windows stack (WASAPI, Win32 clipboard, RegisterHotKey, DPAPI)",
+)
+
+
+def sandbox_shortcuts(test):
+    """Keep a test's shortcut writing inside its own directory.
+
+    Each platform files a global shortcut somewhere of its own: .desktop files
+    and kglobalshortcutsrc on Linux, a small registry of its own on Windows.
+    A test that installs one must not write into the developer's session.
+    """
+    impl = platforms.adapter("hotkeys")
+    if hasattr(impl, "APPLICATIONS_DIR"):
+        test.patch_attr(impl, "APPLICATIONS_DIR", test.path("applications"))
+        test.patch_attr(impl, "SHORTCUTS_FILE", test.path("kglobalshortcutsrc"))
+    if hasattr(impl, "_registry_path"):
+        registry = test.path("shortcuts.json")
+        test.patch_attr(impl, "_registry_path", lambda: registry)
 
 
 def _no_network(*args, **kwargs):
@@ -82,8 +104,10 @@ class DikteTest(unittest.TestCase):
 
         # cli.launch_gui replaces this process with the application when no
         # instance is running. A test that reaches it would take the whole run
-        # with it and hang, so it fails loudly here instead.
+        # with it and hang, so it fails loudly here instead. Both halves: the
+        # exec on Linux, and the detached child Windows starts instead of one.
         self.patch_attr(os, "execv", _no_exec)
+        self.patch_attr(platforms.adapter("runtime"), "relaunch", _no_exec)
 
         # Every way out of here goes through urllib, so closing it is enough to
         # keep the suite offline. A test that means to answer a request patches

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,18 @@ class Doctor(DikteTest):
                       self.run_doctor(as_json=False, cleanup_provider="codex",
                                       cleanup_codex_model="gpt-5.4"))
 
+    def test_disabled_local_cleanup_needs_no_external_program(self):
+        text = self.run_doctor(as_json=False, cleanup_enabled=False,
+                               cleanup_provider="local")
+        self.assertIn("transcript cleanup disabled", text)
+
+    def test_local_cleanup_reports_its_downloaded_server(self):
+        with mock.patch.object(cfg.Config, "local_llm_ready", return_value=True):
+            text = self.run_doctor(as_json=False, cleanup_enabled=True,
+                                   cleanup_provider="local",
+                                   local_llm_model="gemma.gguf")
+        self.assertIn("local llama.cpp, cleaning up on gemma.gguf", text)
+
 
 class Finding(DikteTest):
     def test_no_history_at_all(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,6 +8,7 @@ config and now shadows the default.
 
 import json
 import os
+import pathlib
 import unittest
 from unittest import mock
 
@@ -486,6 +487,22 @@ class Directories(unittest.TestCase):
         with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/c"}):
             config_dir, _ = cfg._directories("darwin")
         self.assertNotIn("/c", str(config_dir))
+
+    def test_windows_uses_roaming_settings_and_local_data(self):
+        with mock.patch.dict(os.environ, {"APPDATA": "C:/Roaming",
+                                          "LOCALAPPDATA": "C:/Local"},
+                             clear=True):
+            config_dir, data_dir = cfg._directories("win32")
+        self.assertEqual(config_dir, pathlib.Path("C:/Roaming/Dikte"))
+        self.assertEqual(data_dir, pathlib.Path("C:/Local/Dikte"))
+
+    def test_windows_does_not_read_xdg_variables(self):
+        with mock.patch.dict(os.environ, {"APPDATA": "C:/Roaming",
+                                          "LOCALAPPDATA": "C:/Local",
+                                          "XDG_CONFIG_HOME": "C:/Wrong"},
+                             clear=True):
+            config_dir, _ = cfg._directories("win32")
+        self.assertNotIn("Wrong", str(config_dir))
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,9 @@ import ggml
 import i18n
 from tests.support import DikteTest, linux_only, windows_only
 
+DPAPI_AVAILABLE = (not hasattr(cfg.runtime, "SECRET_PREFIX")
+                   or cfg.runtime.dpapi_available())
+
 
 class Loading(DikteTest):
     def test_nothing_stored_yet(self):
@@ -130,6 +133,8 @@ class Secrets(DikteTest):
         self.write_config({"openai_api_key": "sk-written-by-hand"})
         self.assertEqual(cfg.Config()["openai_api_key"], "sk-written-by-hand")
 
+    @unittest.skipUnless(DPAPI_AVAILABLE,
+                         "this Windows login has no loaded DPAPI profile")
     def test_and_is_rewritten_the_way_this_platform_keeps_one(self):
         """Nobody has to migrate anything: the next save is the migration."""
         self.write_config({"openai_api_key": "sk-written-by-hand"})
@@ -141,6 +146,8 @@ class Secrets(DikteTest):
         self.assertEqual(cfg.Config()["openai_api_key"], "sk-written-by-hand")
 
     @windows_only
+    @unittest.skipUnless(DPAPI_AVAILABLE,
+                         "this Windows login has no loaded DPAPI profile")
     def test_on_windows_the_key_is_not_on_disk_in_plain_text(self):
         """The file's permissions are not the protection here, so the key is
         encrypted to this Windows account before it is written."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,6 @@ config and now shadows the default.
 
 import json
 import os
-import pathlib
 import unittest
 from unittest import mock
 
@@ -17,8 +16,7 @@ import cleanup
 import config as cfg
 import ggml
 import i18n
-import paste
-from tests.support import DikteTest
+from tests.support import DikteTest, linux_only, windows_only
 
 
 class Loading(DikteTest):
@@ -90,10 +88,82 @@ class Saving(DikteTest):
         cfg.Config().save()
         self.assertTrue(cfg.CONFIG_FILE.exists())
 
+    @linux_only
     def test_the_file_is_readable_by_nobody_else(self):
-        """It holds two API keys."""
+        """It holds two API keys, and on Linux the mode is what keeps them."""
         cfg.Config().save()
         self.assertEqual(cfg.CONFIG_FILE.stat().st_mode & 0o777, 0o600)
+
+
+class Secrets(DikteTest):
+    """API keys through whatever this platform keeps a secret in.
+
+    A mode on the file is the whole protection on Linux and none of it on
+    Windows, where `os.chmod` can only move the read-only attribute. The
+    contract above the platform is the same either way: what goes into a
+    setting is what comes back out of it.
+    """
+
+    def test_a_key_survives_the_round_trip(self):
+        conf = cfg.Config()
+        conf["openai_api_key"] = "sk-secret-key"
+        conf.save()
+        self.assertEqual(cfg.Config()["openai_api_key"], "sk-secret-key")
+
+    def test_every_key_setting_goes_through_the_same_door(self):
+        conf = cfg.Config()
+        for key in cfg.SECRET_KEYS:
+            conf[key] = f"value-for-{key}"
+        conf.save()
+        reloaded = cfg.Config()
+        for key in cfg.SECRET_KEYS:
+            with self.subTest(key=key):
+                self.assertEqual(reloaded[key], f"value-for-{key}")
+
+    def test_an_empty_key_stays_empty_rather_than_becoming_ciphertext(self):
+        cfg.Config().save()
+        for key in cfg.SECRET_KEYS:
+            with self.subTest(key=key):
+                self.assertEqual(self.read_config_file()[key], "")
+
+    def test_a_key_written_in_plain_text_by_an_older_version_is_still_read(self):
+        self.write_config({"openai_api_key": "sk-written-by-hand"})
+        self.assertEqual(cfg.Config()["openai_api_key"], "sk-written-by-hand")
+
+    def test_and_is_rewritten_the_way_this_platform_keeps_one(self):
+        """Nobody has to migrate anything: the next save is the migration."""
+        self.write_config({"openai_api_key": "sk-written-by-hand"})
+        cfg.Config().save()
+        stored = self.read_config_file()["openai_api_key"]
+        self.assertTrue(stored.startswith(cfg.runtime.SECRET_PREFIX)
+                        if hasattr(cfg.runtime, "SECRET_PREFIX")
+                        else stored == "sk-written-by-hand")
+        self.assertEqual(cfg.Config()["openai_api_key"], "sk-written-by-hand")
+
+    @windows_only
+    def test_on_windows_the_key_is_not_on_disk_in_plain_text(self):
+        """The file's permissions are not the protection here, so the key is
+        encrypted to this Windows account before it is written."""
+        conf = cfg.Config()
+        conf["openai_api_key"] = "sk-secret-key"
+        conf.save()
+        text = cfg.CONFIG_FILE.read_text(encoding="utf-8")
+        self.assertNotIn("sk-secret-key", text)
+        self.assertIn("dpapi:", self.read_config_file()["openai_api_key"])
+
+    @windows_only
+    def test_a_key_from_another_machine_reads_as_missing_rather_than_wrong(self):
+        """Restored from a backup, the ciphertext cannot be decrypted here. An
+        empty key sends the user to the one place that can fix it."""
+        self.write_config({"openai_api_key": "dpapi:1:bm90IG1pbmUgYXQgYWxs"})
+        self.assertEqual(cfg.Config()["openai_api_key"], "")
+
+    @linux_only
+    def test_on_linux_the_key_is_stored_as_it_was_typed(self):
+        conf = cfg.Config()
+        conf["openai_api_key"] = "sk-secret-key"
+        conf.save()
+        self.assertEqual(self.read_config_file()["openai_api_key"], "sk-secret-key")
 
     def test_nothing_is_left_behind_half_written(self):
         cfg.Config().save()
@@ -454,55 +524,6 @@ class Defaults(unittest.TestCase):
             for suffix in ("EN", "TR"):
                 with self.subTest(prompt=f"{name}_{suffix}"):
                     self.assertTrue(getattr(cfg, f"{name}_{suffix}").strip())
-
-    def test_the_paste_key_is_the_one_this_desktop_pastes_with(self):
-        """cmd+v on a Mac, and it must be one paste.py can actually press."""
-        self.assertEqual(cfg.DEFAULTS["paste_shortcut"],
-                         paste.desktop().shortcuts[0])
-
-
-class Directories(unittest.TestCase):
-    """Where the settings and the recordings are kept, per system."""
-
-    def test_linux_keeps_them_apart_and_follows_xdg(self):
-        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/c",
-                                          "XDG_DATA_HOME": "/d"}):
-            config_dir, data_dir = cfg._directories("linux")
-        self.assertEqual(str(config_dir), "/c/dikte")
-        self.assertEqual(str(data_dir), "/d/dikte")
-
-    def test_linux_without_the_variables_set(self):
-        with mock.patch.dict(os.environ, {}, clear=True):
-            config_dir, data_dir = cfg._directories("linux")
-        self.assertTrue(str(config_dir).endswith("/.config/dikte"))
-        self.assertTrue(str(data_dir).endswith("/.local/share/dikte"))
-
-    def test_a_mac_keeps_both_in_application_support(self):
-        config_dir, data_dir = cfg._directories("darwin")
-        self.assertEqual(config_dir, data_dir)
-        self.assertTrue(str(config_dir).endswith("/Library/Application Support/Dikte"))
-
-    def test_a_mac_does_not_read_the_xdg_variables(self):
-        """A Mac with them set from some other tool still stores in one place."""
-        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/c"}):
-            config_dir, _ = cfg._directories("darwin")
-        self.assertNotIn("/c", str(config_dir))
-
-    def test_windows_uses_roaming_settings_and_local_data(self):
-        with mock.patch.dict(os.environ, {"APPDATA": "C:/Roaming",
-                                          "LOCALAPPDATA": "C:/Local"},
-                             clear=True):
-            config_dir, data_dir = cfg._directories("win32")
-        self.assertEqual(config_dir, pathlib.Path("C:/Roaming/Dikte"))
-        self.assertEqual(data_dir, pathlib.Path("C:/Local/Dikte"))
-
-    def test_windows_does_not_read_xdg_variables(self):
-        with mock.patch.dict(os.environ, {"APPDATA": "C:/Roaming",
-                                          "LOCALAPPDATA": "C:/Local",
-                                          "XDG_CONFIG_HOME": "C:/Wrong"},
-                             clear=True):
-            config_dir, _ = cfg._directories("win32")
-        self.assertNotIn("Wrong", str(config_dir))
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -563,6 +563,7 @@ class LocalCleanup(DikteTest):
 class ReadyToRun(DikteTest):
     def setUp(self):
         super().setUp()
+        self.patch_attr(ggml, "BIN_DIR", self.path("bin"))
         self.patch_attr(ggml, "MODELS_DIR", self.path("models"))
 
     def install(self, name):

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -366,6 +366,8 @@ class WindowsAssets(Local):
         self.patch_attr(ggml, "IS_WINDOWS", True)
         self.patch_attr(ggml, "EXE", ".exe")
         self.patch_attr(ggml, "_arch", lambda: "x64")
+        self.patch_attr(ggml.runtime, "cuda_driver_version", lambda: None)
+        self.patch_attr(ggml, "_has_vulkan", lambda: False)
         self.archive = zipball({
             "Release/whisper-server.exe": b"MZ not really",
             "Release/whisper.dll": b"nor this",
@@ -395,11 +397,24 @@ class WindowsAssets(Local):
     ]
 
     def test_the_cpu_build_is_what_nobody_asking_gets(self):
-        """It runs on every machine, and its failures are not about drivers."""
+        """Auto falls back to the build that runs without a graphics driver."""
         self.assertEqual(self.matched(ggml.WHISPER, self.WHISPER_RELEASE),
                          ["whisper-bin-x64.zip"])
         self.assertEqual(self.matched(ggml.LLAMA, self.LLAMA_RELEASE),
                          ["llama-b1-bin-win-cpu-x64.zip"])
+
+    def test_auto_prefers_cuda_when_an_nvidia_driver_is_available(self):
+        with mock.patch.object(ggml.runtime, "cuda_driver_version",
+                               return_value=(12, 4)):
+            patterns = ggml._wanted_assets(ggml.WHISPER, "auto")
+        self.assertIn("cublas", patterns[0])
+        self.assertEqual(patterns[-1], r"^whisper-bin-x64\.zip$")
+
+    def test_auto_prefers_vulkan_for_llama_without_nvidia(self):
+        with mock.patch.object(ggml, "_has_vulkan", return_value=True):
+            patterns = ggml._wanted_assets(ggml.LLAMA, "auto")
+        self.assertIn("vulkan", patterns[0])
+        self.assertIn("cpu", patterns[-1])
 
     def test_the_blas_and_cublas_builds_are_not_mistaken_for_the_plain_one(self):
         """All three end in bin-x64.zip and are three different downloads."""

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -186,6 +186,7 @@ class InstallProgram(Local):
     def setUp(self):
         super().setUp()
         self.patch_attr(ggml, "IS_WINDOWS", False)
+        self.patch_attr(ggml, "IS_MACOS", False)
         self.patch_attr(ggml, "EXE", "")
         # Built once, because the release listing has to publish its checksum
         # and a tarball is not the same bytes twice.
@@ -330,6 +331,17 @@ class InstallProgram(Local):
         """Asked for one, Linux is told so rather than handed the CPU build."""
         self.patch_attr(ggml, "_arch", lambda: "x64")
         self.assertEqual(ggml._wanted_assets(ggml.LLAMA, "cuda"), ())
+
+    def test_a_mac_does_not_take_an_ubuntu_whisper_archive(self):
+        self.patch_attr(ggml, "IS_MACOS", True)
+        self.patch_attr(ggml, "_arch", lambda: "arm64")
+        self.assertEqual(ggml._wanted_assets(ggml.WHISPER), ())
+
+    def test_a_mac_uses_the_native_llama_archive(self):
+        self.patch_attr(ggml, "IS_MACOS", True)
+        self.patch_attr(ggml, "_arch", lambda: "arm64")
+        self.assertEqual(ggml._wanted_assets(ggml.LLAMA),
+                         (r"bin-macos-arm64\.tar\.gz$",))
 
 
 def zipball(entries):

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -9,18 +9,20 @@ import contextlib
 import hashlib
 import io
 import os
+import re
 import signal
 import sys
 import tarfile
 import textwrap
 import threading
 import time
+import zipfile
 from unittest import mock
 
 import ggml
 import hub
 from tests.support import (DikteTest, fake_urlopen, http_error, json_body,
-                           linux_only, url_error)
+                           linux_only, url_error, windows_only)
 
 
 def body(data, length=None):
@@ -174,11 +176,17 @@ class Download(Local):
 
 
 class InstallProgram(Local):
+    """The Linux half of picking a release apart.
+
+    Pinned to the Linux tables rather than skipped off it: which asset a
+    machine is owed is a decision worth testing on whichever machine the tests
+    are run, and the code that makes it is the same code there.
+    """
+
     def setUp(self):
         super().setUp()
-        # These fixtures are Ubuntu release archives.  Keep checking that path
-        # on every host, including the Mac that checks the macOS backend.
-        self.patch_attr(sys, "platform", "linux")
+        self.patch_attr(ggml, "IS_WINDOWS", False)
+        self.patch_attr(ggml, "EXE", "")
         # Built once, because the release listing has to publish its checksum
         # and a tarball is not the same bytes twice.
         self.archive = tarball({
@@ -218,23 +226,6 @@ class InstallProgram(Local):
             with self.assertRaises(ggml.LocalError) as caught:
                 ggml.install_program(ggml.WHISPER)
         self.assertIn("this machine", str(caught.exception))
-
-    def test_a_mac_does_not_install_an_ubuntu_archive_for_the_same_architecture(self):
-        self.patch_attr(sys, "platform", "darwin")
-        self.patch_attr(ggml, "_arch", lambda: "arm64")
-        listing = self.release("whisper-bin-ubuntu-arm64.tar.gz")
-        with fake_urlopen(listing):
-            with self.assertRaises(ggml.LocalError) as caught:
-                ggml.install_program(ggml.WHISPER)
-        self.assertIn("brew install whisper-cpp", str(caught.exception))
-
-    def test_a_mac_uses_the_native_llama_archive_instead_of_ubuntu(self):
-        self.patch_attr(sys, "platform", "darwin")
-        self.patch_attr(ggml, "_arch", lambda: "arm64")
-        self.assertEqual(
-            ggml._wanted_assets(ggml.LLAMA),
-            ("bin-macos-arm64.tar.gz",),
-        )
 
     def test_what_was_installed_is_remembered(self):
         path, _ = self.install("whisper-bin-ubuntu-x64.tar.gz")
@@ -314,16 +305,169 @@ class InstallProgram(Local):
             with self.subTest(url=url):
                 self.assertTrue(url.startswith("https://"))
 
+    def matched(self, program, names, backend="auto"):
+        """Which of `names` the asset patterns would take, best first."""
+        return [name for pattern in ggml._wanted_assets(program, backend)
+                for name in names if re.search(pattern, name)]
+
     def test_llama_takes_the_vulkan_build_when_there_is_a_loader(self):
         self.patch_attr(ggml, "_arch", lambda: "x64")
         self.patch_attr(ggml, "_has_vulkan", lambda: True)
-        self.assertEqual(ggml._wanted_assets(ggml.LLAMA)[0],
-                         "bin-ubuntu-vulkan-x64.tar.gz")
+        self.assertEqual(
+            self.matched(ggml.LLAMA, ["llama-b1-bin-ubuntu-x64.tar.gz",
+                                      "llama-b1-bin-ubuntu-vulkan-x64.tar.gz"])[0],
+            "llama-b1-bin-ubuntu-vulkan-x64.tar.gz")
 
     def test_llama_falls_back_to_the_plain_build_without_one(self):
         self.patch_attr(ggml, "_arch", lambda: "x64")
         self.patch_attr(ggml, "_has_vulkan", lambda: False)
-        self.assertEqual(ggml._wanted_assets(ggml.LLAMA), ("bin-ubuntu-x64.tar.gz",))
+        self.assertEqual(
+            self.matched(ggml.LLAMA, ["llama-b1-bin-ubuntu-x64.tar.gz",
+                                      "llama-b1-bin-ubuntu-vulkan-x64.tar.gz"]),
+            ["llama-b1-bin-ubuntu-x64.tar.gz"])
+
+    def test_no_cuda_build_is_published_for_linux(self):
+        """Asked for one, Linux is told so rather than handed the CPU build."""
+        self.patch_attr(ggml, "_arch", lambda: "x64")
+        self.assertEqual(ggml._wanted_assets(ggml.LLAMA, "cuda"), ())
+
+
+def zipball(entries):
+    """A .zip laid out the way the Windows releases are: one directory of files."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+class WindowsAssets(Local):
+    """Which of a release's files a Windows machine is owed, and what unpacking
+    one does.
+
+    Pinned to the Windows tables the same way the Linux class above is pinned
+    to its own, so a change to either is caught wherever the tests are run.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.patch_attr(ggml, "IS_WINDOWS", True)
+        self.patch_attr(ggml, "EXE", ".exe")
+        self.patch_attr(ggml, "_arch", lambda: "x64")
+        self.archive = zipball({
+            "Release/whisper-server.exe": b"MZ not really",
+            "Release/whisper.dll": b"nor this",
+        })
+
+    # ---- picking the asset ----------------------------------------------
+
+    def matched(self, program, names, backend="auto"):
+        return [name for pattern in ggml._wanted_assets(program, backend)
+                for name in names if re.search(pattern, name)]
+
+    WHISPER_RELEASE = [
+        "whisper-bin-ubuntu-x64.tar.gz",
+        "whisper-bin-Win32.zip",
+        "whisper-bin-x64.zip",
+        "whisper-blas-bin-x64.zip",
+        "whisper-cublas-11.8.0-bin-x64.zip",
+        "whisper-cublas-12.4.0-bin-x64.zip",
+    ]
+
+    LLAMA_RELEASE = [
+        "cudart-llama-bin-win-cuda-12.4-x64.zip",
+        "llama-b1-bin-ubuntu-x64.tar.gz",
+        "llama-b1-bin-win-cpu-x64.zip",
+        "llama-b1-bin-win-cuda-12.4-x64.zip",
+        "llama-b1-bin-win-vulkan-x64.zip",
+    ]
+
+    def test_the_cpu_build_is_what_nobody_asking_gets(self):
+        """It runs on every machine, and its failures are not about drivers."""
+        self.assertEqual(self.matched(ggml.WHISPER, self.WHISPER_RELEASE),
+                         ["whisper-bin-x64.zip"])
+        self.assertEqual(self.matched(ggml.LLAMA, self.LLAMA_RELEASE),
+                         ["llama-b1-bin-win-cpu-x64.zip"])
+
+    def test_the_blas_and_cublas_builds_are_not_mistaken_for_the_plain_one(self):
+        """All three end in bin-x64.zip and are three different downloads."""
+        taken = self.matched(ggml.WHISPER, self.WHISPER_RELEASE)
+        self.assertNotIn("whisper-blas-bin-x64.zip", taken)
+        self.assertNotIn("whisper-cublas-12.4.0-bin-x64.zip", taken)
+
+    def test_asking_for_cuda_gets_the_cuda_build(self):
+        self.assertIn("whisper-cublas",
+                      self.matched(ggml.WHISPER, self.WHISPER_RELEASE, "cuda")[0])
+        self.assertEqual(self.matched(ggml.LLAMA, self.LLAMA_RELEASE, "cuda"),
+                         ["llama-b1-bin-win-cuda-12.4-x64.zip"])
+
+    def test_asking_for_vulkan_where_there_is_none_is_refused(self):
+        """whisper.cpp publishes no Vulkan build for Windows, and a CPU one
+        handed over quietly would look like a graphics card that is just slow."""
+        self.assertEqual(ggml._wanted_assets(ggml.WHISPER, "vulkan"), ())
+        self.assertEqual(self.matched(ggml.LLAMA, self.LLAMA_RELEASE, "vulkan"),
+                         ["llama-b1-bin-win-vulkan-x64.zip"])
+
+    def test_the_cuda_runtime_comes_along_with_the_cuda_build(self):
+        """llama.cpp ships the DLLs in a second archive, and the server exits
+        without them on a machine with no CUDA toolkit installed."""
+        assets = [hub.Item(name, f"https://example.invalid/{name}", 10, "a" * 64)
+                  for name in self.LLAMA_RELEASE]
+        chosen = next(a for a in assets if a.name.endswith("win-cuda-12.4-x64.zip"))
+        self.assertEqual([a.name for a in ggml._companions(ggml.LLAMA, chosen, assets)],
+                         ["cudart-llama-bin-win-cuda-12.4-x64.zip"])
+
+    def test_the_cpu_build_needs_nothing_beside_it(self):
+        assets = [hub.Item(name, f"https://example.invalid/{name}", 10, "a" * 64)
+                  for name in self.LLAMA_RELEASE]
+        chosen = next(a for a in assets if a.name.endswith("win-cpu-x64.zip"))
+        self.assertEqual(ggml._companions(ggml.LLAMA, chosen, assets), [])
+
+    # ---- unpacking it ----------------------------------------------------
+
+    def release(self, *names, archive=None):
+        digest = hashlib.sha256(self.archive if archive is None else archive)
+        return {"tag_name": "v1.9.1", "assets": [
+            {"name": name, "browser_download_url": f"https://example.invalid/{name}",
+             "size": 10, "digest": "sha256:" + digest.hexdigest()}
+            for name in names]}
+
+    def install(self, *names, archive=None):
+        blob = self.archive if archive is None else archive
+        with serving(self.release(*names, archive=blob), blob) as calls:
+            path = ggml.install_program(ggml.WHISPER)
+        return path, [call.args[0].full_url for call in calls.call_args_list]
+
+    def test_the_exe_and_its_dlls_land_together(self):
+        """The loader looks beside the .exe, so the directory is what survives."""
+        path, _ = self.install("whisper-bin-x64.zip")
+        self.assertTrue(path.endswith("whisper-server.exe"))
+        self.assertTrue(os.path.isfile(path))
+        self.assertTrue(os.path.isfile(
+            os.path.join(os.path.dirname(path), "whisper.dll")))
+
+    def test_the_windows_build_is_taken_over_the_linux_one(self):
+        _, urls = self.install("whisper-bin-ubuntu-x64.tar.gz", "whisper-bin-x64.zip")
+        self.assertTrue(urls[1].endswith("whisper-bin-x64.zip"))
+
+    def test_a_zip_cannot_write_outside_the_directory_it_is_opened_in(self):
+        """A zip entry is a string the archive chose, and it may name ..\\..\\."""
+        escape = zipball({"../../../escaped.txt": b"should not land"})
+        with self.assertRaises(ggml.LocalError) as caught:
+            self.install("whisper-bin-x64.zip", archive=escape)
+        self.assertIn("outside", str(caught.exception))
+        self.assertFalse(self.path("escaped.txt").exists())
+        self.assertFalse(self.path("data", "escaped.txt").exists())
+
+    def test_an_archive_without_the_exe_is_refused(self):
+        empty = zipball({"Release/README.txt": b"nothing here"})
+        with self.assertRaises(ggml.LocalError) as caught:
+            self.install("whisper-bin-x64.zip", archive=empty)
+        self.assertIn("whisper-server.exe", str(caught.exception))
+
+    def test_the_archive_is_not_kept(self):
+        self.install("whisper-bin-x64.zip")
+        self.assertEqual(list(self.path("data", "bin", "whisper").glob("*.zip")), [])
 
 
 class WhichCopyRuns(Local):
@@ -681,3 +825,4 @@ class Sizes(DikteTest):
         self.assertEqual(ggml.human_size(512), "512 B")
         self.assertEqual(ggml.human_size(574041195), "547.4 MB")
         self.assertEqual(ggml.human_size(3_095_033_483), "2.9 GB")
+

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -837,4 +837,3 @@ class Sizes(DikteTest):
         self.assertEqual(ggml.human_size(512), "512 B")
         self.assertEqual(ggml.human_size(574041195), "547.4 MB")
         self.assertEqual(ggml.human_size(3_095_033_483), "2.9 GB")
-

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -185,6 +185,10 @@ class InstallProgram(Local):
 
     def setUp(self):
         super().setUp()
+        # These tests describe the Linux release table even when the suite is
+        # running on a Mac.  _wanted_assets also honours sys.platform so the
+        # native macOS tests can exercise that path explicitly below.
+        self.patch_attr(sys, "platform", "linux")
         self.patch_attr(ggml, "IS_WINDOWS", False)
         self.patch_attr(ggml, "IS_MACOS", False)
         self.patch_attr(ggml, "EXE", "")

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -200,21 +200,21 @@ class Chooser(DikteTest):
 
     def test_installing_goes_to_whichever_it_is(self):
         with self.under("GNOME"), \
-                mock.patch.object(hotkey, "install_gnome_shortcut",
+                mock.patch.object(linux_hotkeys, "install_gnome_shortcut",
                                   return_value=(True, "ok")) as gnome:
             linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         gnome.assert_called_once()
 
         with self.under("KDE"), \
-                mock.patch.object(hotkey, "install_kde_shortcut",
+                mock.patch.object(linux_hotkeys, "install_kde_shortcut",
                                   return_value=(True, "ok")) as kde:
             linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         kde.assert_called_once()
 
     def test_removing_and_reading_back_go_to_the_same_one(self):
         with self.under("GNOME"), \
-                mock.patch.object(hotkey, "remove_gnome_shortcut") as remove, \
-                mock.patch.object(hotkey, "gnome_shortcut_status",
+                mock.patch.object(linux_hotkeys, "remove_gnome_shortcut") as remove, \
+                mock.patch.object(linux_hotkeys, "gnome_shortcut_status",
                                   return_value="Ctrl+Space") as status:
             linux_hotkeys.remove_shortcut()
             self.assertEqual(linux_hotkeys.shortcut_status(), "Ctrl+Space")

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -361,8 +361,8 @@ class KdeShortcut(DikteTest):
         self.apps = self.path("applications")
         self.apps.mkdir(parents=True)
         self.rc = self.path("kglobalshortcutsrc")
-        self.patch_attr(hotkey, "APPLICATIONS_DIR", self.apps)
-        self.patch_attr(hotkey, "SHORTCUTS_FILE", self.rc)
+        self.patch_attr(linux_hotkeys, "APPLICATIONS_DIR", self.apps)
+        self.patch_attr(linux_hotkeys, "SHORTCUTS_FILE", self.rc)
 
     def test_installing_writes_a_desktop_file_kwin_will_launch(self):
         with mock.patch.object(subprocess, "run", return_value=FakeCompleted()):

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import config as cfg
 import hotkey
+import platforms.linux.hotkeys as linux_hotkeys
 from tests.support import DikteTest, FakeCompleted, linux_only
 
 SHORTCUTS_RC = """[services][dikte-toggle.desktop]
@@ -24,37 +25,37 @@ Switch Window Down=Meta+Alt+Down,Meta+Alt+Down,Switch to Window Below
 
 class ParseShortcut(unittest.TestCase):
     def test_the_default(self):
-        self.assertEqual(hotkey.parse_shortcut("Ctrl+Space"), ({"ctrl"}, 57))
+        self.assertEqual(linux_hotkeys.parse_shortcut("Ctrl+Space"), ({"ctrl"}, 57))
 
     def test_case_and_spacing_do_not_matter(self):
-        self.assertEqual(hotkey.parse_shortcut(" ctrl + SPACE "), ({"ctrl"}, 57))
+        self.assertEqual(linux_hotkeys.parse_shortcut(" ctrl + SPACE "), ({"ctrl"}, 57))
 
     def test_several_modifiers(self):
-        mods, key = hotkey.parse_shortcut("Ctrl+Alt+Shift+D")
+        mods, key = linux_hotkeys.parse_shortcut("Ctrl+Alt+Shift+D")
         self.assertEqual(mods, {"ctrl", "alt", "shift"})
         self.assertEqual(key, 32)
 
     def test_the_synonyms_land_on_one_name(self):
-        self.assertEqual(hotkey.parse_shortcut("Control+Space"),
-                         hotkey.parse_shortcut("Ctrl+Space"))
-        self.assertEqual(hotkey.parse_shortcut("Meta+Space"),
-                         hotkey.parse_shortcut("Super+Space"))
+        self.assertEqual(linux_hotkeys.parse_shortcut("Control+Space"),
+                         linux_hotkeys.parse_shortcut("Ctrl+Space"))
+        self.assertEqual(linux_hotkeys.parse_shortcut("Meta+Space"),
+                         linux_hotkeys.parse_shortcut("Super+Space"))
 
     def test_a_key_on_its_own(self):
-        self.assertEqual(hotkey.parse_shortcut("F9"), (set(), 67))
+        self.assertEqual(linux_hotkeys.parse_shortcut("F9"), (set(), 67))
 
     def test_modifiers_with_no_key(self):
-        self.assertEqual(hotkey.parse_shortcut("Ctrl+Alt"), (None, None))
+        self.assertEqual(linux_hotkeys.parse_shortcut("Ctrl+Alt"), (None, None))
 
     def test_a_key_nobody_mapped(self):
-        self.assertEqual(hotkey.parse_shortcut("Ctrl+F13"), (None, None))
+        self.assertEqual(linux_hotkeys.parse_shortcut("Ctrl+F13"), (None, None))
 
     def test_nothing(self):
-        self.assertEqual(hotkey.parse_shortcut(""), (None, None))
-        self.assertEqual(hotkey.parse_shortcut("+++"), (None, None))
+        self.assertEqual(linux_hotkeys.parse_shortcut(""), (None, None))
+        self.assertEqual(linux_hotkeys.parse_shortcut("+++"), (None, None))
 
     def test_something_that_is_not_even_a_string(self):
-        self.assertEqual(hotkey.parse_shortcut(None), (None, None))
+        self.assertEqual(linux_hotkeys.parse_shortcut(None), (None, None))
 
 
 class Table(unittest.TestCase):
@@ -83,7 +84,7 @@ class ModsMatch(unittest.TestCase):
     """The combination has to be exact, or Ctrl+Space fires on Ctrl+Shift+Space."""
 
     def match(self, held, wanted):
-        return hotkey.EvdevHotkey._mods_match(set(held), set(wanted))
+        return linux_hotkeys.EvdevHotkey._mods_match(set(held), set(wanted))
 
     def test_the_wanted_modifier_is_down(self):
         self.assertTrue(self.match({29}, {"ctrl"}))
@@ -109,17 +110,17 @@ class Bindings(DikteTest):
     """start() before it reaches /dev/input, which a test may not read."""
 
     def test_a_binding_with_no_shortcut_is_skipped(self):
-        listener = hotkey.EvdevHotkey()
+        listener = linux_hotkeys.EvdevHotkey()
         with mock.patch.object(listener, "_open_devices", return_value=[]):
             self.assertFalse(listener.start({"toggle": "", "ask": ""}))
 
     def test_an_unparsable_shortcut_is_reported_and_the_rest_go_on(self):
-        listener = hotkey.EvdevHotkey()
+        listener = linux_hotkeys.EvdevHotkey()
         self.addCleanup(listener.stop)
         failures = []
         listener.failed.connect(failures.append)
         with mock.patch.object(listener, "_open_devices", return_value=[99]), \
-                mock.patch.object(hotkey.threading, "Thread"):
+                mock.patch.object(linux_hotkeys.threading, "Thread"):
             self.assertTrue(listener.start({"toggle": "Ctrl+F13",
                                             "ask": "Ctrl+Space"}))
         self.assertEqual(len(failures), 1)
@@ -127,7 +128,7 @@ class Bindings(DikteTest):
         self.assertEqual(list(listener._bindings), [57])
 
     def test_no_readable_devices_says_what_to_do_about_it(self):
-        listener = hotkey.EvdevHotkey()
+        listener = linux_hotkeys.EvdevHotkey()
         failures = []
         listener.failed.connect(failures.append)
         with mock.patch.object(listener, "_open_devices", return_value=[]):
@@ -135,10 +136,10 @@ class Bindings(DikteTest):
         self.assertIn("input", failures[0])
 
     def test_two_shortcuts_on_one_key_are_both_kept(self):
-        listener = hotkey.EvdevHotkey()
+        listener = linux_hotkeys.EvdevHotkey()
         self.addCleanup(listener.stop)
         with mock.patch.object(listener, "_open_devices", return_value=[]), \
-                mock.patch.object(hotkey.threading, "Thread") as thread:
+                mock.patch.object(linux_hotkeys.threading, "Thread") as thread:
             listener._open_devices.return_value = [99]
             self.assertTrue(listener.start({"toggle": "Ctrl+Space",
                                             "ask": "Ctrl+Alt+Space"}))
@@ -148,15 +149,15 @@ class Bindings(DikteTest):
     def test_starting_and_discarding_do_not_fire_on_each_other(self):
         """The two defaults are one modifier apart on the same key code, so the
         modifier set is the only thing keeping them apart."""
-        listener = hotkey.EvdevHotkey()
+        listener = linux_hotkeys.EvdevHotkey()
         self.addCleanup(listener.stop)
         with mock.patch.object(listener, "_open_devices", return_value=[99]), \
-                mock.patch.object(hotkey.threading, "Thread"):
+                mock.patch.object(linux_hotkeys.threading, "Thread"):
             listener.start({"toggle": "Ctrl+Space", "cancel": "Ctrl+Alt+Space"})
 
         def fired(held):
             return [name for mods, name in listener._bindings[57]
-                    if hotkey.EvdevHotkey._mods_match(held, mods)]
+                    if linux_hotkeys.EvdevHotkey._mods_match(held, mods)]
 
         self.assertEqual(fired({29}), ["toggle"])          # ctrl
         self.assertEqual(fired({29, 56}), ["cancel"])      # ctrl + alt
@@ -174,40 +175,40 @@ class Chooser(DikteTest):
     def under(self, desktop, has_gsettings=True):
         """A session that says it is this desktop, with or without gsettings."""
         with mock.patch.dict(os.environ, {"XDG_CURRENT_DESKTOP": desktop}), \
-                mock.patch.object(hotkey.shutil, "which",
+                mock.patch.object(linux_hotkeys.shutil, "which",
                                   return_value="/usr/bin/gsettings"
                                   if has_gsettings else None):
             yield
 
     def test_gnome_when_the_session_says_so_and_gsettings_is_there(self):
         with self.under("GNOME"):
-            self.assertEqual(hotkey.desktop_name(), "GNOME")
+            self.assertEqual(linux_hotkeys.desktop_name(), "GNOME")
 
     def test_kde_otherwise(self):
         with self.under("KDE"):
-            self.assertEqual(hotkey.desktop_name(), "KDE")
+            self.assertEqual(linux_hotkeys.desktop_name(), "KDE")
 
     def test_a_gnome_session_with_no_gsettings_falls_back(self):
         """Nothing to write the binding with, so KDE's file is the only try."""
         with self.under("GNOME", has_gsettings=False):
-            self.assertEqual(hotkey.desktop_name(), "KDE")
+            self.assertEqual(linux_hotkeys.desktop_name(), "KDE")
 
     def test_the_desktop_is_matched_loosely(self):
         for desktop in ("GNOME", "ubuntu:GNOME", "gnome"):
             with self.subTest(desktop=desktop), self.under(desktop):
-                self.assertEqual(hotkey.desktop_name(), "GNOME")
+                self.assertEqual(linux_hotkeys.desktop_name(), "GNOME")
 
     def test_installing_goes_to_whichever_it_is(self):
         with self.under("GNOME"), \
                 mock.patch.object(hotkey, "install_gnome_shortcut",
                                   return_value=(True, "ok")) as gnome:
-            hotkey.install_shortcut("Ctrl+Space", "dikte toggle")
+            linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         gnome.assert_called_once()
 
         with self.under("KDE"), \
                 mock.patch.object(hotkey, "install_kde_shortcut",
                                   return_value=(True, "ok")) as kde:
-            hotkey.install_shortcut("Ctrl+Space", "dikte toggle")
+            linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         kde.assert_called_once()
 
     def test_removing_and_reading_back_go_to_the_same_one(self):
@@ -215,8 +216,8 @@ class Chooser(DikteTest):
                 mock.patch.object(hotkey, "remove_gnome_shortcut") as remove, \
                 mock.patch.object(hotkey, "gnome_shortcut_status",
                                   return_value="Ctrl+Space") as status:
-            hotkey.remove_shortcut()
-            self.assertEqual(hotkey.shortcut_status(), "Ctrl+Space")
+            linux_hotkeys.remove_shortcut()
+            self.assertEqual(linux_hotkeys.shortcut_status(), "Ctrl+Space")
         remove.assert_called_once()
         status.assert_called_once()
 
@@ -226,53 +227,53 @@ class GnomeAccelerator(DikteTest):
     """Qt spells a combination one way, GNOME another."""
 
     def test_the_default_shortcut(self):
-        self.assertEqual(hotkey.gnome_accelerator("Ctrl+Space"), "<Primary>Space")
+        self.assertEqual(linux_hotkeys.gnome_accelerator("Ctrl+Space"), "<Primary>Space")
 
     def test_several_modifiers_keep_their_order(self):
-        self.assertEqual(hotkey.gnome_accelerator("Ctrl+Alt+A"), "<Primary><Alt>a")
+        self.assertEqual(linux_hotkeys.gnome_accelerator("Ctrl+Alt+A"), "<Primary><Alt>a")
 
     def test_the_synonyms(self):
-        self.assertEqual(hotkey.gnome_accelerator("Meta+A"),
-                         hotkey.gnome_accelerator("Super+A"))
-        self.assertEqual(hotkey.gnome_accelerator("Control+A"),
-                         hotkey.gnome_accelerator("Ctrl+A"))
+        self.assertEqual(linux_hotkeys.gnome_accelerator("Meta+A"),
+                         linux_hotkeys.gnome_accelerator("Super+A"))
+        self.assertEqual(linux_hotkeys.gnome_accelerator("Control+A"),
+                         linux_hotkeys.gnome_accelerator("Ctrl+A"))
 
     def test_a_modifier_repeated_is_written_once(self):
-        self.assertEqual(hotkey.gnome_accelerator("Ctrl+Control+A"), "<Primary>a")
+        self.assertEqual(linux_hotkeys.gnome_accelerator("Ctrl+Control+A"), "<Primary>a")
 
     def test_modifiers_with_no_key_are_not_a_shortcut(self):
-        self.assertEqual(hotkey.gnome_accelerator("Ctrl+Alt"), "")
-        self.assertEqual(hotkey.gnome_accelerator(""), "")
+        self.assertEqual(linux_hotkeys.gnome_accelerator("Ctrl+Alt"), "")
+        self.assertEqual(linux_hotkeys.gnome_accelerator(""), "")
 
     def test_what_goes_out_comes_back_the_way_dikte_writes_it(self):
         for shortcut in ("Ctrl+Space", "Ctrl+Alt+A", "Shift+F9", "Super+M"):
             with self.subTest(shortcut=shortcut):
-                accelerator = hotkey.gnome_accelerator(shortcut)
-                self.assertEqual(hotkey.display_accelerator(accelerator), shortcut)
+                accelerator = linux_hotkeys.gnome_accelerator(shortcut)
+                self.assertEqual(linux_hotkeys.display_accelerator(accelerator), shortcut)
 
     def test_the_control_spelling_gnome_also_uses(self):
-        self.assertEqual(hotkey.display_accelerator("<Control>a"), "Ctrl+A")
+        self.assertEqual(linux_hotkeys.display_accelerator("<Control>a"), "Ctrl+A")
 
     def test_an_empty_binding(self):
-        self.assertEqual(hotkey.display_accelerator(""), "")
+        self.assertEqual(linux_hotkeys.display_accelerator(""), "")
 
 
 @linux_only
 class GsettingsArray(DikteTest):
     def test_a_list_of_paths(self):
         self.assertEqual(
-            hotkey._gsettings_array("['/org/gnome/one/', '/org/gnome/two/']"),
+            linux_hotkeys._gsettings_array("['/org/gnome/one/', '/org/gnome/two/']"),
             ["/org/gnome/one/", "/org/gnome/two/"])
 
     def test_the_empty_form_gsettings_prints(self):
-        self.assertEqual(hotkey._gsettings_array("@as []"), [])
+        self.assertEqual(linux_hotkeys._gsettings_array("@as []"), [])
 
     def test_nothing_at_all(self):
-        self.assertEqual(hotkey._gsettings_array(""), [])
+        self.assertEqual(linux_hotkeys._gsettings_array(""), [])
 
     def test_something_that_is_not_an_array(self):
         with self.assertRaises(ValueError):
-            hotkey._gsettings_array("'just a string'")
+            linux_hotkeys._gsettings_array("'just a string'")
 
 
 @linux_only
@@ -283,7 +284,7 @@ class GnomeShortcut(DikteTest):
         super().setUp()
         self.enterContext(mock.patch.dict(os.environ,
                                           {"XDG_CURRENT_DESKTOP": "GNOME"}))
-        self.enterContext(mock.patch.object(hotkey.shutil, "which",
+        self.enterContext(mock.patch.object(linux_hotkeys.shutil, "which",
                                             return_value="/usr/bin/gsettings"))
 
     def gsettings(self, listed="@as []", binding="'<Primary>Space'"):
@@ -303,54 +304,54 @@ class GnomeShortcut(DikteTest):
 
     def test_installing_registers_the_path_the_name_and_the_binding(self):
         with self.gsettings() as run:
-            ok, message = hotkey.install_shortcut("Ctrl+Space", "dikte toggle")
+            ok, message = linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         self.assertTrue(ok)
         self.assertIn("Ctrl+Space", message)
-        self.assertIn(hotkey.DESKTOP_ID.removesuffix(".desktop"),
+        self.assertIn(linux_hotkeys.DESKTOP_ID.removesuffix(".desktop"),
                       self.written(run, "custom-keybindings"))
         self.assertEqual(self.written(run, "command"), repr("dikte toggle"))
         self.assertEqual(self.written(run, "binding"), repr("<Primary>Space"))
 
     def test_installing_twice_does_not_list_the_path_twice(self):
-        path = hotkey._gnome_path(hotkey.DESKTOP_ID)
+        path = linux_hotkeys._gnome_path(linux_hotkeys.DESKTOP_ID)
         with self.gsettings(listed=repr([path])) as run:
-            hotkey.install_shortcut("Ctrl+Space", "dikte toggle")
+            linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         self.assertIsNone(self.written(run, "custom-keybindings"))
 
     def test_each_verb_gets_its_own_path(self):
-        self.assertNotEqual(hotkey._gnome_path(hotkey.DESKTOP_ID),
-                            hotkey._gnome_path(hotkey.ASK_DESKTOP_ID))
+        self.assertNotEqual(linux_hotkeys._gnome_path(linux_hotkeys.DESKTOP_ID),
+                            linux_hotkeys._gnome_path(linux_hotkeys.ASK_DESKTOP_ID))
 
     def test_a_shortcut_gnome_cannot_express(self):
         with self.gsettings():
-            ok, message = hotkey.install_shortcut("Ctrl+Alt", "dikte toggle")
+            ok, message = linux_hotkeys.install_shortcut("Ctrl+Alt", "dikte toggle")
         self.assertFalse(ok)
         self.assertIn("Ctrl+Alt", message)
 
     def test_no_session_bus_to_talk_to(self):
         with mock.patch.object(subprocess, "run", side_effect=OSError("no bus")):
-            ok, _ = hotkey.install_shortcut("Ctrl+Space", "dikte toggle")
+            ok, _ = linux_hotkeys.install_shortcut("Ctrl+Space", "dikte toggle")
         self.assertFalse(ok)
 
     def test_reading_back_a_shortcut_that_is_registered(self):
-        path = hotkey._gnome_path(hotkey.DESKTOP_ID)
+        path = linux_hotkeys._gnome_path(linux_hotkeys.DESKTOP_ID)
         with self.gsettings(listed=repr([path])):
-            self.assertEqual(hotkey.shortcut_status(), "Ctrl+Space")
+            self.assertEqual(linux_hotkeys.shortcut_status(), "Ctrl+Space")
 
     def test_reading_back_one_that_is_not(self):
         with self.gsettings(listed="@as []"):
-            self.assertIsNone(hotkey.shortcut_status())
+            self.assertIsNone(linux_hotkeys.shortcut_status())
 
     def test_removing_takes_the_path_off_the_list(self):
-        path = hotkey._gnome_path(hotkey.DESKTOP_ID)
+        path = linux_hotkeys._gnome_path(linux_hotkeys.DESKTOP_ID)
         with self.gsettings(listed=repr([path, "/org/gnome/other/"])) as run:
-            hotkey.remove_shortcut()
+            linux_hotkeys.remove_shortcut()
         self.assertEqual(self.written(run, "custom-keybindings"),
                          repr(["/org/gnome/other/"]))
 
     def test_removing_one_that_was_never_installed(self):
         with self.gsettings(listed="@as []"):
-            hotkey.remove_shortcut()   # must not raise
+            linux_hotkeys.remove_shortcut()   # must not raise
 
 
 @linux_only
@@ -365,9 +366,9 @@ class KdeShortcut(DikteTest):
 
     def test_installing_writes_a_desktop_file_kwin_will_launch(self):
         with mock.patch.object(subprocess, "run", return_value=FakeCompleted()):
-            ok, message = hotkey.install_kde_shortcut("Ctrl+Space", "dikte toggle")
+            ok, message = linux_hotkeys.install_kde_shortcut("Ctrl+Space", "dikte toggle")
         self.assertTrue(ok)
-        text = (self.apps / hotkey.DESKTOP_ID).read_text(encoding="utf-8")
+        text = (self.apps / linux_hotkeys.DESKTOP_ID).read_text(encoding="utf-8")
         self.assertIn("Exec=dikte toggle", text)
         self.assertIn("X-KDE-GlobalAccel-CommandShortcut=true", text)
         self.assertIn("log out", message)
@@ -375,79 +376,79 @@ class KdeShortcut(DikteTest):
     def test_the_shortcut_is_registered_under_the_desktop_id(self):
         with mock.patch.object(subprocess, "run",
                                return_value=FakeCompleted()) as run:
-            hotkey.install_kde_shortcut("Meta+D", "dikte ask",
-                                        desktop_id=hotkey.ASK_DESKTOP_ID)
+            linux_hotkeys.install_kde_shortcut("Meta+D", "dikte ask",
+                                        desktop_id=linux_hotkeys.ASK_DESKTOP_ID)
         cmd = run.call_args.args[0]
         self.assertEqual(cmd[0], "kwriteconfig6")
-        self.assertIn(hotkey.ASK_DESKTOP_ID, cmd)
+        self.assertIn(linux_hotkeys.ASK_DESKTOP_ID, cmd)
         self.assertEqual(cmd[-1], "Meta+D")
 
     def test_each_verb_gets_its_own_entry(self):
         with mock.patch.object(subprocess, "run", return_value=FakeCompleted()):
-            hotkey.install_kde_shortcut("Ctrl+Space", "dikte toggle")
-            hotkey.install_kde_shortcut("Meta+M", "dikte meeting",
-                                        desktop_id=hotkey.MEETING_DESKTOP_ID)
-        self.assertTrue((self.apps / hotkey.DESKTOP_ID).exists())
-        self.assertTrue((self.apps / hotkey.MEETING_DESKTOP_ID).exists())
+            linux_hotkeys.install_kde_shortcut("Ctrl+Space", "dikte toggle")
+            linux_hotkeys.install_kde_shortcut("Meta+M", "dikte meeting",
+                                        desktop_id=linux_hotkeys.MEETING_DESKTOP_ID)
+        self.assertTrue((self.apps / linux_hotkeys.DESKTOP_ID).exists())
+        self.assertTrue((self.apps / linux_hotkeys.MEETING_DESKTOP_ID).exists())
 
     def test_no_kwriteconfig_installed(self):
         with mock.patch.object(subprocess, "run", side_effect=OSError("nope")):
-            ok, message = hotkey.install_kde_shortcut("Ctrl+Space", "dikte toggle")
+            ok, message = linux_hotkeys.install_kde_shortcut("Ctrl+Space", "dikte toggle")
         self.assertFalse(ok)
         self.assertIn("kglobalshortcutsrc", message)
 
     def test_removing_takes_the_desktop_file_with_it(self):
-        (self.apps / hotkey.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
+        (self.apps / linux_hotkeys.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
         with mock.patch.object(subprocess, "run", return_value=FakeCompleted()) as run:
-            hotkey.remove_kde_shortcut()
-        self.assertFalse((self.apps / hotkey.DESKTOP_ID).exists())
+            linux_hotkeys.remove_kde_shortcut()
+        self.assertFalse((self.apps / linux_hotkeys.DESKTOP_ID).exists())
         self.assertIn("--delete", run.call_args.args[0])
 
     def test_removing_one_that_was_never_installed(self):
         with mock.patch.object(subprocess, "run", side_effect=OSError("nope")):
-            hotkey.remove_kde_shortcut()   # must not raise
+            linux_hotkeys.remove_kde_shortcut()   # must not raise
 
     def test_the_registered_shortcut_is_read_back(self):
-        (self.apps / hotkey.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
+        (self.apps / linux_hotkeys.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
         self.rc.write_text(SHORTCUTS_RC, encoding="utf-8")
-        self.assertEqual(hotkey.kde_shortcut_status(), "Ctrl+Space")
+        self.assertEqual(linux_hotkeys.kde_shortcut_status(), "Ctrl+Space")
 
     def test_no_desktop_file_means_nothing_is_installed(self):
         self.rc.write_text(SHORTCUTS_RC, encoding="utf-8")
-        self.assertIsNone(hotkey.kde_shortcut_status())
+        self.assertIsNone(linux_hotkeys.kde_shortcut_status())
 
     def test_a_desktop_file_with_no_entry_beside_it(self):
-        (self.apps / hotkey.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
+        (self.apps / linux_hotkeys.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
         self.rc.write_text("[kwin]\nOverview=Meta+W\n", encoding="utf-8")
-        self.assertIsNone(hotkey.kde_shortcut_status())
+        self.assertIsNone(linux_hotkeys.kde_shortcut_status())
 
     def test_no_shortcuts_file_at_all(self):
-        (self.apps / hotkey.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
-        self.assertIsNone(hotkey.kde_shortcut_status())
+        (self.apps / linux_hotkeys.DESKTOP_ID).write_text("[Desktop Entry]", encoding="utf-8")
+        self.assertIsNone(linux_hotkeys.kde_shortcut_status())
 
     def test_a_combination_somebody_else_already_took(self):
         self.rc.write_text(SHORTCUTS_RC, encoding="utf-8")
-        hits = hotkey.conflicting_shortcuts("Meta+W")
+        hits = linux_hotkeys.conflicting_shortcuts("Meta+W")
         self.assertEqual(len(hits), 1)
         self.assertIn("kwin", hits[0])
         self.assertIn("Overview", hits[0])
 
     def test_our_own_entry_is_not_a_conflict(self):
         self.rc.write_text(SHORTCUTS_RC, encoding="utf-8")
-        self.assertEqual(hotkey.conflicting_shortcuts("Ctrl+Space"), [])
+        self.assertEqual(linux_hotkeys.conflicting_shortcuts("Ctrl+Space"), [])
 
     def test_a_free_combination(self):
         self.rc.write_text(SHORTCUTS_RC, encoding="utf-8")
-        self.assertEqual(hotkey.conflicting_shortcuts("Ctrl+Alt+J"), [])
+        self.assertEqual(linux_hotkeys.conflicting_shortcuts("Ctrl+Alt+J"), [])
 
     def test_a_tab_separated_entry_is_read_too(self):
         self.rc.write_text(SHORTCUTS_RC, encoding="utf-8")
-        hits = hotkey.conflicting_shortcuts("Meta+Shift+Print")
+        hits = linux_hotkeys.conflicting_shortcuts("Meta+Shift+Print")
         self.assertEqual(len(hits), 1)
         self.assertIn("spectacle", hits[0])
 
     def test_no_shortcuts_file_means_no_conflicts(self):
-        self.assertEqual(hotkey.conflicting_shortcuts("Ctrl+Space"), [])
+        self.assertEqual(linux_hotkeys.conflicting_shortcuts("Ctrl+Space"), [])
 
 
 # --- macOS ----------------------------------------------------------------

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -65,11 +65,21 @@ class Paths(unittest.TestCase):
         self.assertTrue(command.startswith(sys.executable))
         self.assertTrue(command.endswith(" toggle"))
 
-    @unittest.skipUnless(hasattr(os, "getuid"),
-                         "the socket is named after a user id, which Windows "
-                         "has no equivalent of")
     def test_the_socket_is_per_user(self):
-        self.assertEqual(ipc.SERVER_NAME, f"dikte-{os.getuid()}")
+        self.assertEqual(ipc.SERVER_NAME, f"dikte-{ipc.user_id()}")
+
+    def test_unix_uses_the_numeric_user_id(self):
+        if not hasattr(os, "getuid"):
+            self.skipTest("Windows has no numeric uid")
+        self.assertEqual(ipc.user_id("linux"), str(os.getuid()))
+
+    def test_windows_uses_a_short_hash_of_the_sid(self):
+        with mock.patch.object(ipc, "_windows_sid", return_value="S-1-5-21-42"):
+            first = ipc.user_id("win32")
+            second = ipc.user_id("win32")
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 16)
+        self.assertNotIn("S-1-5", first)
 
 
 class Send(unittest.TestCase):

--- a/tests/test_keycapture.py
+++ b/tests/test_keycapture.py
@@ -1,0 +1,163 @@
+"""Choosing a global shortcut by pressing it in the settings window."""
+
+import unittest
+from unittest import mock
+
+from PyQt6.QtCore import QEvent, Qt
+from PyQt6.QtGui import QKeyEvent
+from PyQt6.QtWidgets import QApplication
+
+import dikte
+import keycapture
+
+
+_app = QApplication.instance() or QApplication([])
+
+
+class Catcher(keycapture.ShortcutCatcher):
+    """The real keyboard grab is replaced; events are handed in directly."""
+
+    def __init__(self):
+        self.grabs = 0
+        self.releases = 0
+        super().__init__()
+
+    def grabKeyboard(self):
+        self.grabs += 1
+
+    def releaseKeyboard(self):
+        self.releases += 1
+
+
+def press(key, modifiers=Qt.KeyboardModifier.NoModifier):
+    return QKeyEvent(QEvent.Type.KeyPress, key, modifiers)
+
+
+class Naming(unittest.TestCase):
+    def test_modifiers_are_written_in_the_stored_order(self):
+        held = (Qt.KeyboardModifier.ShiftModifier
+                | Qt.KeyboardModifier.AltModifier
+                | Qt.KeyboardModifier.ControlModifier)
+        self.assertEqual(
+            keycapture.combination(held, Qt.Key.Key_M),
+            "Ctrl+Alt+Shift+M",
+        )
+
+    def test_space_and_function_keys_get_their_normal_names(self):
+        ctrl = Qt.KeyboardModifier.ControlModifier
+        self.assertEqual(
+            keycapture.combination(ctrl, Qt.Key.Key_Space), "Ctrl+Space")
+        self.assertEqual(
+            keycapture.combination(ctrl, Qt.Key.Key_F9), "Ctrl+F9")
+
+    def test_a_modifier_on_its_own_is_not_a_shortcut(self):
+        self.assertEqual(keycapture.combination(
+            Qt.KeyboardModifier.ControlModifier, Qt.Key.Key_Control), "")
+
+    def test_an_unsupported_key_is_not_invented(self):
+        self.assertEqual(keycapture.combination(
+            Qt.KeyboardModifier.ControlModifier, Qt.Key.Key_Plus), "")
+
+
+class Capturing(unittest.TestCase):
+    def setUp(self):
+        self.catcher = Catcher()
+        self.addCleanup(self.catcher.deleteLater)
+        self.addCleanup(self.catcher.cancel)
+
+    def test_clicking_starts_listening_and_a_combination_finishes_it(self):
+        states, found = [], []
+        self.catcher.listening.connect(states.append)
+        self.catcher.captured.connect(found.append)
+
+        self.catcher.click()
+        self.assertTrue(self.catcher.waiting)
+        self.assertEqual(self.catcher.grabs, 1)
+        self.catcher.keyPressEvent(press(
+            Qt.Key.Key_Space,
+            Qt.KeyboardModifier.ControlModifier
+            | Qt.KeyboardModifier.AltModifier,
+        ))
+
+        self.assertEqual(found, ["Ctrl+Alt+Space"])
+        self.assertEqual(states, [True, False])
+        self.assertFalse(self.catcher.waiting)
+        self.assertEqual(self.catcher.releases, 1)
+
+    def test_bare_modifiers_are_waited_through(self):
+        found = []
+        self.catcher.captured.connect(found.append)
+        self.catcher.click()
+        self.catcher.keyPressEvent(press(
+            Qt.Key.Key_Control, Qt.KeyboardModifier.ControlModifier))
+        self.assertTrue(self.catcher.waiting)
+        self.assertEqual(found, [])
+
+    def test_escape_alone_cancels(self):
+        found = []
+        self.catcher.captured.connect(found.append)
+        self.catcher.click()
+        self.catcher.keyPressEvent(press(Qt.Key.Key_Escape))
+        self.assertFalse(self.catcher.waiting)
+        self.assertEqual(found, [])
+
+    def test_escape_with_a_modifier_can_be_a_shortcut(self):
+        found = []
+        self.catcher.captured.connect(found.append)
+        self.catcher.click()
+        self.catcher.keyPressEvent(press(
+            Qt.Key.Key_Escape, Qt.KeyboardModifier.ControlModifier))
+        self.assertEqual(found, ["Ctrl+Esc"])
+
+    def test_an_unsupported_key_says_why_and_stops(self):
+        refused = []
+        self.catcher.refused.connect(refused.append)
+        self.catcher.click()
+        self.catcher.keyPressEvent(press(
+            Qt.Key.Key_Plus, Qt.KeyboardModifier.ControlModifier))
+        self.assertFalse(self.catcher.waiting)
+        self.assertEqual(len(refused), 1)
+
+    def test_the_timeout_gives_the_keyboard_back(self):
+        refused = []
+        self.catcher.refused.connect(refused.append)
+        self.catcher.click()
+        self.catcher._timed_out()
+        self.assertFalse(self.catcher.waiting)
+        self.assertEqual(len(refused), 1)
+        self.assertEqual(self.catcher.releases, 1)
+
+
+class ApplicationCoordination(unittest.TestCase):
+    def app(self):
+        made = object.__new__(dikte.Dikte)
+        made._capturing_shortcut = False
+        made._quitting = False
+        made.evdev = mock.Mock()
+        made._apply_shortcuts = mock.Mock()
+        return made
+
+    def test_the_global_listener_stands_down_while_a_key_is_read(self):
+        app = self.app()
+        app._capture_shortcut(True)
+        app._capture_shortcut(True)
+        app.evdev.stop.assert_called_once_with()
+        self.assertTrue(app._capturing_shortcut)
+
+    def test_the_listener_returns_when_capture_ends(self):
+        app = self.app()
+        app._capture_shortcut(True)
+        app._capture_shortcut(False)
+        app._apply_shortcuts.assert_called_once_with()
+        self.assertFalse(app._capturing_shortcut)
+
+    def test_the_listener_does_not_return_during_shutdown(self):
+        app = self.app()
+        app._capture_shortcut(True)
+        app._quitting = True
+        app._capture_shortcut(False)
+        app._apply_shortcuts.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_keycapture.py
+++ b/tests/test_keycapture.py
@@ -14,6 +14,16 @@ import keycapture
 _app = QApplication.instance() or QApplication([])
 
 
+class Launching(unittest.TestCase):
+    def test_opening_the_icon_again_brings_settings_back(self):
+        with mock.patch.object(dikte, "QApplication"), \
+                mock.patch.object(dikte.runtime, "single_instance",
+                                  return_value=None), \
+                mock.patch.object(dikte.ipc, "send") as send:
+            self.assertEqual(dikte.run_app([]), 0)
+        send.assert_called_once_with("settings")
+
+
 class Catcher(keycapture.ShortcutCatcher):
     """The real keyboard grab is replaced; events are handed in directly."""
 

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,185 @@
+"""The contract every platform adapter owes, and the other platform's answers.
+
+Two jobs. The first is to say what an adapter is: four modules, each offering a
+fixed set of names, so that a port is a directory rather than a branch inside
+every function, and so that a name added to one platform and forgotten on the
+other is caught here rather than by whoever runs the other one.
+
+The second is the one worth having. Most of this port was written on Windows,
+where nothing checks that Linux still gets its XDG directories, its evdev key
+codes, its Ubuntu tarballs and a socket named after its user id. Those are
+pinned below, loaded through `platforms.adapter(part, name="linux")`, which
+imports the Linux half on any machine: it is plain Python and PyQt6, and none
+of it calls anything Linux-only until something asks it to.
+
+The reverse does not work. The Windows adapters open user32 and kernel32 at
+import, so a Linux machine cannot load them at all, and Windows is where this
+half of the guarding has to happen.
+"""
+
+import os
+import unittest
+from unittest import mock
+
+import platforms
+from tests.support import windows_only
+
+# What each part of an adapter has to offer, whatever the platform. A name
+# missing from one of them is an application that works on one desktop.
+CONTRACT = {
+    "audio": ("Recorder", "MeetingRecorder",
+              "list_sources", "list_monitors", "default_monitor"),
+    "clipboard": ("PasteError", "read_clipboard", "copy", "copy_bytes",
+                  "paste_ready", "press"),
+    "hotkeys": ("Listener", "parse_shortcut", "install_shortcut",
+                "remove_shortcut", "shortcut_status", "conflicting_shortcuts",
+                "desktop_name"),
+    "runtime": ("APP_DIR", "RECORDINGS_NAME", "MEETINGS_NAME", "PROGRAMS",
+                "NO_WINDOW",
+                "config_dir", "data_dir", "cache_dir",
+                "user_id", "single_instance",
+                "protect", "unprotect", "secure_file",
+                "adopt", "is_our_process", "terminate",
+                "signals", "wakeup_socketpair", "abort_socket",
+                "prepare_console", "relaunch", "open_folder"),
+}
+
+
+class Contract(unittest.TestCase):
+    """This platform's adapters, whichever platform is running the tests."""
+
+    def test_every_part_is_here(self):
+        for part in CONTRACT:
+            with self.subTest(part=part):
+                self.assertIsNotNone(platforms.adapter(part))
+
+    def test_every_part_offers_what_the_contract_says(self):
+        for part, names in CONTRACT.items():
+            module = platforms.adapter(part)
+            for attribute in names:
+                with self.subTest(part=part, name=attribute):
+                    self.assertTrue(hasattr(module, attribute),
+                                    f"{module.__name__} has no {attribute}")
+
+    def test_the_platform_is_one_of_the_two(self):
+        self.assertIn(platforms.NAME, (platforms.LINUX, platforms.WINDOWS))
+        self.assertEqual(platforms.IS_WINDOWS, platforms.NAME == platforms.WINDOWS)
+
+    def test_an_adapter_is_imported_once_and_remembered(self):
+        self.assertIs(platforms.adapter("runtime"), platforms.adapter("runtime"))
+
+    def test_take_answers_none_for_what_a_platform_does_not_have(self):
+        found, missing = platforms.take("runtime", "user_id", "no_such_name")
+        self.assertTrue(callable(found))
+        self.assertIsNone(missing)
+
+
+@windows_only
+class TheLinuxHalf(unittest.TestCase):
+    """What Linux is owed, checked from the machine the port was written on.
+
+    Loaded rather than assumed: these are the answers the Linux application has
+    always given, and every one of them is something a careless change on this
+    side could quietly move.
+    """
+
+    def part(self, name):
+        return platforms.adapter(name, name="linux")
+
+    # ---- the shape -------------------------------------------------------
+
+    def test_it_offers_the_same_contract(self):
+        for part, names in CONTRACT.items():
+            module = self.part(part)
+            for attribute in names:
+                with self.subTest(part=part, name=attribute):
+                    self.assertTrue(hasattr(module, attribute),
+                                    f"{module.__name__} has no {attribute}")
+
+    # ---- where things live -----------------------------------------------
+
+    def test_the_directories_are_the_xdg_ones(self):
+        runtime = self.part("runtime")
+        with mock.patch.dict(os.environ, {"XDG_CONFIG_HOME": "/home/x/.config",
+                                          "XDG_DATA_HOME": "/home/x/.local/share",
+                                          "XDG_CACHE_HOME": "/home/x/.cache"}):
+            self.assertEqual(runtime.config_dir().as_posix(), "/home/x/.config/dikte")
+            self.assertEqual(runtime.data_dir().as_posix(),
+                             "/home/x/.local/share/dikte")
+            self.assertEqual(runtime.cache_dir().as_posix(), "/home/x/.cache/dikte")
+
+    def test_the_directory_names_stay_lowercase(self):
+        runtime = self.part("runtime")
+        self.assertEqual(runtime.APP_DIR, "dikte")
+        self.assertEqual(runtime.RECORDINGS_NAME, "recordings")
+        self.assertEqual(runtime.MEETINGS_NAME, "meetings")
+
+    def test_the_socket_is_named_after_the_numeric_user_id(self):
+        runtime = self.part("runtime")
+        with mock.patch.object(os, "getuid", lambda: 1000, create=True):
+            self.assertEqual(runtime.user_id(), "1000")
+
+    # ---- secrets ---------------------------------------------------------
+
+    def test_a_key_is_stored_as_it_was_typed(self):
+        """The mode on the file is the protection there, not the bytes in it."""
+        runtime = self.part("runtime")
+        self.assertEqual(runtime.protect("sk-secret"), "sk-secret")
+        self.assertEqual(runtime.unprotect("sk-secret"), "sk-secret")
+
+    # ---- processes -------------------------------------------------------
+
+    def test_nothing_is_asked_of_a_subprocess_that_linux_does_not_have(self):
+        self.assertEqual(self.part("runtime").NO_WINDOW, {})
+
+    def test_the_programs_it_expects_are_the_ones_it_shells_out_to(self):
+        self.assertEqual(
+            self.part("runtime").PROGRAMS,
+            ("pw-record", "wl-copy", "ydotool", "ffmpeg", "pactl", "kwriteconfig6"))
+
+    # ---- the desktop -----------------------------------------------------
+
+    def test_the_listener_is_the_evdev_one(self):
+        hotkeys = self.part("hotkeys")
+        self.assertIs(hotkeys.Listener, hotkeys.EvdevHotkey)
+
+    def test_the_key_codes_are_evdev_codes(self):
+        hotkeys = self.part("hotkeys")
+        self.assertEqual(hotkeys.parse_shortcut("Ctrl+Space"), ({"ctrl"}, 57))
+        self.assertEqual(hotkeys.parse_shortcut("F9"), (set(), 67))
+
+    def test_the_clipboard_still_goes_through_two_programs(self):
+        clipboard = self.part("clipboard")
+        self.assertEqual(clipboard.WAYLAND.clipboard, "wl-copy")
+        self.assertEqual(clipboard.WAYLAND.keyboard, "ydotool")
+        self.assertEqual(clipboard.X11.clipboard, "xclip")
+        self.assertEqual(clipboard.X11.keyboard, "xdotool")
+
+    def test_the_recorder_still_asks_the_sound_server(self):
+        audio = self.part("audio")
+        with mock.patch("shutil.which", side_effect=lambda tool:
+                        "/usr/bin/parec" if tool == "parec" else None):
+            command = audio.recording_command("alsa_input.usb")
+        self.assertEqual(command[0], "parec")
+        self.assertIn("--device=alsa_input.usb", command)
+
+    def test_the_release_it_wants_is_still_an_ubuntu_tarball(self):
+        import ggml
+
+        with mock.patch.object(ggml, "IS_WINDOWS", False), \
+                mock.patch.object(ggml, "_arch", lambda: "x64"), \
+                mock.patch.object(ggml, "_has_vulkan", lambda: False):
+            self.assertEqual(ggml._wanted_assets(ggml.WHISPER),
+                             (r"bin-ubuntu-x64\.tar\.gz$",))
+            self.assertEqual(ggml.backend_choices(ggml.LLAMA),
+                             ("auto", "cpu", "vulkan"))
+
+    def test_the_binary_has_no_extension_there(self):
+        import ggml
+
+        with mock.patch.object(ggml, "EXE", ""):
+            self.assertEqual(ggml.binary_name(ggml.WHISPER), "whisper-server")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -61,9 +61,11 @@ class Contract(unittest.TestCase):
                     self.assertTrue(hasattr(module, attribute),
                                     f"{module.__name__} has no {attribute}")
 
-    def test_the_platform_is_one_of_the_two(self):
-        self.assertIn(platforms.NAME, (platforms.LINUX, platforms.WINDOWS))
+    def test_the_platform_is_supported(self):
+        self.assertIn(platforms.NAME,
+                      (platforms.LINUX, platforms.WINDOWS, platforms.MACOS))
         self.assertEqual(platforms.IS_WINDOWS, platforms.NAME == platforms.WINDOWS)
+        self.assertEqual(platforms.IS_MACOS, platforms.NAME == platforms.MACOS)
 
     def test_an_adapter_is_imported_once_and_remembered(self):
         self.assertIs(platforms.adapter("runtime"), platforms.adapter("runtime"))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -6,9 +6,7 @@ save, so a setting added to one half and not the other is silently reset the
 next time anybody presses Save. That is the failure this catches.
 """
 
-import sys
 import unittest
-from typing import ClassVar
 from unittest import mock
 
 from PyQt6.QtWidgets import QApplication, QMessageBox
@@ -17,9 +15,8 @@ import cleanup
 import config as cfg
 import hotkey
 import overlay as overlay_module
-import paste
 import settings_ui
-from tests.support import DikteTest, only_these_tools
+from tests.support import DikteTest, only_these_tools, sandbox_shortcuts
 
 # One application for the whole run; Qt allows no second one.
 _app = QApplication.instance() or QApplication([])
@@ -100,26 +97,22 @@ CHANGED = {
 
 
 class Settings(DikteTest):
-    # What a Mac shows instead, where the combination on offer is a different
-    # one. Everything else about the window is the same on both.
-    changed = CHANGED
-    platform = "linux"
-
     def setUp(self):
         super().setUp()
         # No pactl, no model lists over the network, and no modal dialogue
         # waiting for somebody to press OK.
-        self.enterContext(mock.patch.object(sys, "platform", self.platform))
         self.enterContext(only_these_tools())
         self.enterContext(mock.patch.object(QMessageBox, "information"))
+        # A shortcut somebody else already holds asks before it is installed,
+        # and a modal question in a test is a run that never ends. Windows
+        # reserves a good many combinations, so this is not hypothetical.
+        self.enterContext(mock.patch.object(
+            QMessageBox, "question", return_value=QMessageBox.StandardButton.Yes))
         self.enterContext(mock.patch.object(settings_ui.SettingsWindow,
                                             "_load_models"))
         self.enterContext(mock.patch.object(settings_ui.SettingsWindow,
                                             "_load_transcribe_models"))
-        self.enterContext(mock.patch.object(settings_ui.hotkey, "APPLICATIONS_DIR",
-                                            self.path("applications")))
-        self.enterContext(mock.patch.object(settings_ui.hotkey, "SHORTCUTS_FILE",
-                                            self.path("kglobalshortcutsrc")))
+        sandbox_shortcuts(self)
 
     def window(self, conf):
         window = settings_ui.SettingsWindow(conf)
@@ -142,13 +135,16 @@ class Settings(DikteTest):
         self.assertEqual(conf.data, before)
 
     def test_a_setting_of_your_own_survives_the_round_trip(self):
-        self.write_config(self.changed)
+        self.write_config(CHANGED)
         conf = cfg.Config()
         self.window(conf)._save()
-        stored = self.read_config_file()
-        for key, value in self.changed.items():
+        # Read back through Config rather than out of the file: an API key is
+        # not stored as it was typed on every platform, and what matters here
+        # is that the window did not drop it on the way through.
+        reloaded = cfg.Config()
+        for key, value in CHANGED.items():
             with self.subTest(key=key):
-                self.assertEqual(stored[key], value)
+                self.assertEqual(reloaded[key], value)
 
     def test_the_model_box_on_screen_belongs_to_whoever_cleans_up(self):
         """An OpenRouter id and a Claude alias are not the same field."""
@@ -184,7 +180,7 @@ class Settings(DikteTest):
         conf = cfg.Config()
         window = self.window(conf)
         for box, _status, _missing in window._shortcut_rows.values():
-            box.setCurrentText("")
+            box.setText("")
         window._save()
         self.assertEqual(conf["shortcut"], "Ctrl+Space")
         self.assertEqual(conf["cancel_shortcut"], "")
@@ -194,7 +190,7 @@ class Settings(DikteTest):
     def test_installing_the_discard_key_writes_its_own_entry(self):
         conf = cfg.Config()
         window = self.window(conf)
-        window._shortcut_rows["cancel"][0].setCurrentText("Meta+Shift+Space")
+        window._shortcut_rows["cancel"][0].setText("Meta+Shift+Space")
         with mock.patch.object(settings_ui.hotkey, "install_shortcut",
                                return_value=(True, "saved")) as install:
             window._install_shortcut("cancel")
@@ -204,6 +200,37 @@ class Settings(DikteTest):
         self.assertEqual(install.call_args.kwargs["desktop_id"],
                          hotkey.CANCEL_DESKTOP_ID)
         self.assertEqual(conf["cancel_shortcut"], "Meta+Shift+Space")
+
+    def test_each_shortcut_has_a_capture_button_instead_of_a_preset_list(self):
+        window = self.window(cfg.Config())
+        self.assertEqual(set(window._shortcut_catchers), set(hotkey.SHORTCUTS))
+        for box, _status, _missing in window._shortcut_rows.values():
+            with self.subTest(box=box):
+                self.assertIsInstance(box, settings_ui.QLineEdit)
+
+    def test_a_captured_shortcut_is_selected_in_its_own_field(self):
+        window = self.window(cfg.Config())
+        window._shortcut_captured("meeting", "Ctrl+Shift+M")
+        box, status, _missing = window._shortcut_rows["meeting"]
+        self.assertEqual(box.text(), "Ctrl+Shift+M")
+        self.assertIn("Ctrl+Shift+M", status.text())
+
+    def test_one_combination_cannot_be_captured_for_two_actions(self):
+        window = self.window(cfg.Config())
+        window._shortcut_rows["toggle"][0].setText("Ctrl+Space")
+        window._shortcut_rows["cancel"][0].setText("Ctrl+Alt+Space")
+        window._shortcut_captured("cancel", "Ctrl+Space")
+        box, status, _missing = window._shortcut_rows["cancel"]
+        self.assertEqual(box.text(), "Ctrl+Alt+Space")
+        self.assertIn("Ctrl+Space", status.text())
+
+    def test_closing_while_capturing_gives_the_keyboard_back(self):
+        window = self.window(cfg.Config())
+        catchers = list(window._shortcut_catchers.values())
+        for catcher in catchers:
+            catcher.cancel = mock.Mock()
+        window.close()
+        self.assertTrue(all(catcher.cancel.called for catcher in catchers))
 
     def test_a_prompt_left_at_its_default_is_stored_as_empty(self):
         """So that switching the interface language switches the prompt too."""
@@ -313,34 +340,6 @@ class Settings(DikteTest):
         self.assertFalse(window.file_stop.isEnabled())
 
 
-class MacSettings(Settings):
-    """The same window and the same round trip, standing on a Mac.
-
-    Nothing here is about macOS: it is the rest of the window, checked on the
-    platform where three of its widgets are gone and one offers other keys.
-    """
-
-    platform = "darwin"
-    changed: ClassVar[dict] = {**CHANGED, "paste_shortcut": "cmd+shift+v"}
-
-    def test_there_is_no_install_button_where_nothing_is_installed(self):
-        window = self.window(cfg.Config())
-        labels = [button.text() for button in
-                  window.findChildren(settings_ui.QPushButton)]
-        self.assertFalse([text for text in labels if "shortcut" in text.lower()])
-
-    def test_the_listener_is_not_offered_as_a_choice(self):
-        """It is the whole mechanism there; turning it off would leave nothing."""
-        window = self.window(cfg.Config())
-        self.assertFalse(window.evdev_enabled.isVisible())
-
-    def test_the_paste_keys_on_offer_are_the_ones_a_mac_uses(self):
-        window = self.window(cfg.Config())
-        offered = [window.paste_shortcut.itemText(index)
-                   for index in range(window.paste_shortcut.count())]
-        self.assertEqual(offered, paste.MACOS.shortcuts)
-
-
 class Overlay(DikteTest):
     def overlay(self, **kwargs):
         widget = overlay_module.Overlay(**kwargs)
@@ -354,25 +353,6 @@ class Overlay(DikteTest):
         flags = self.overlay().windowFlags()
         self.assertTrue(flags & Qt.WindowType.WindowDoesNotAcceptFocus)
         self.assertTrue(flags & Qt.WindowType.WindowStaysOnTopHint)
-
-    def test_it_lets_a_click_through_to_whatever_is_under_it(self):
-        """It stays mapped while idle, so without this its corner of the screen
-        would stop taking clicks for good. The widget attribute is not enough:
-        on a top-level window it only makes Qt drop the event it already took."""
-        from PyQt6.QtCore import Qt
-        flags = self.overlay().windowFlags()
-        self.assertTrue(flags & Qt.WindowType.WindowTransparentForInput)
-
-    def test_the_one_that_takes_clicks_shrinks_out_of_the_way(self):
-        """It has to stay clickable, so it cannot be transparent to input; it
-        gets out of the way by leaving nothing there to click instead."""
-        widget = self.overlay(dismissable=True)
-        widget.show_busy("Asking Claude…")
-        self.assertGreater(widget.width(), 1)
-        widget.dismiss()
-        self.assertEqual((widget.width(), widget.height()), (1, 1))
-        widget.show_busy("Asking Claude…")
-        self.assertGreater(widget.width(), 1)
 
     def test_recording_then_working_then_done(self):
         widget = self.overlay()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -9,7 +9,7 @@ next time anybody presses Save. That is the failure this catches.
 import unittest
 from unittest import mock
 
-from PyQt6.QtWidgets import QApplication, QMessageBox
+from PyQt6.QtWidgets import QApplication, QMessageBox, QScrollArea
 
 import cleanup
 import config as cfg
@@ -449,8 +449,14 @@ class LocalModels(DikteTest):
     def test_it_opens_where_the_missing_model_is_fixed(self):
         # Nothing can transcribe on a fresh install, which is why this window
         # was opened at all.
-        window = self.window(cfg.Config())
+        conf = cfg.Config()
+        with mock.patch.object(conf, "transcribe_ready", return_value=False):
+            window = self.window(conf)
         self.assertEqual(window.tabs.currentIndex(), window.api_tab_index)
+
+    def test_the_model_page_scrolls_without_pushing_save_off_screen(self):
+        window = self.window(cfg.Config())
+        self.assertIsInstance(window.tabs.widget(window.api_tab_index), QScrollArea)
 
     def test_it_opens_where_it_was_left_when_everything_works(self):
         conf = self.config(transcribe_provider="openai", openai_api_key="sk-test")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -354,6 +354,17 @@ class Overlay(DikteTest):
         self.assertTrue(flags & Qt.WindowType.WindowDoesNotAcceptFocus)
         self.assertTrue(flags & Qt.WindowType.WindowStaysOnTopHint)
 
+    def test_a_regular_indicator_is_transparent_to_native_input(self):
+        from PyQt6.QtCore import Qt
+        flags = self.overlay().windowFlags()
+        self.assertTrue(flags & Qt.WindowType.WindowTransparentForInput)
+
+    def test_a_dismissable_indicator_shrinks_when_concealed(self):
+        widget = self.overlay(dismissable=True)
+        widget.show_busy("Working")
+        widget._conceal()
+        self.assertEqual((widget.width(), widget.height()), (1, 1))
+
     def test_recording_then_working_then_done(self):
         widget = self.overlay()
         widget.show_recording()

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -633,8 +633,20 @@ class Directories(unittest.TestCase):
         self.assertEqual(win_runtime.RECORDINGS_NAME, "Recordings")
         self.assertEqual(win_runtime.MEETINGS_NAME, "Meetings")
 
+    def test_a_packaged_app_can_find_programs_shipped_beside_it(self):
+        executable = str(win_runtime.data_dir() / "Dikte" / "dikte.exe")
+        with mock.patch.object(sys, "frozen", True, create=True), \
+                mock.patch.object(sys, "executable", executable), \
+                mock.patch.dict(os.environ, {"PATH": r"C:\Windows"}):
+            win_runtime._expose_bundled_programs()
+            first = os.environ["PATH"].split(os.pathsep)[0]
+        self.assertEqual(os.path.normcase(first),
+                         os.path.normcase(os.path.dirname(executable)))
+
 
 @windows_only
+@unittest.skipUnless(win_runtime and win_runtime.dpapi_available(),
+                     "this Windows login has no loaded DPAPI profile")
 class Secrets(unittest.TestCase):
     """DPAPI, which is what keeps an API key on a filesystem with no modes."""
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,764 @@
+"""The Windows half: WASAPI arithmetic, the Win32 clipboard, hotkeys, DPAPI.
+
+Two kinds of test in here. The arithmetic runs anywhere, because it is plain
+Python and the whole point of it is that it does not drift or lose anything:
+turning a sound card's blocks into the 16 kHz mono whisper wants, packing a
+clipboard snapshot, working out which keys a combination is. The rest talks to
+Windows itself and is marked accordingly.
+
+The drift tests are the ones worth reading. A meeting is two devices with two
+clocks, and a converter that rounded a fraction of a sample away per block
+would slide the two channels apart over an hour, which is exactly the thing
+that makes a channel-split transcript useless.
+"""
+
+import array
+import ctypes
+import os
+import sys
+import threading
+import time
+import unittest
+import wave
+from unittest import mock
+
+from tests.support import DikteTest, windows_only
+
+if sys.platform.startswith("win"):
+    from PyQt6.QtWidgets import QApplication
+
+    from platforms.windows import clipboard as win_clipboard
+    from platforms.windows import hotkeys as win_hotkeys
+    from platforms.windows import resample as win_resample
+    from platforms.windows import runtime as win_runtime
+
+    # A signal emitted on a capture thread is queued for the thread its
+    # receiver belongs to, and a queued signal needs an event loop to be
+    # delivered. There is no window here, only the loop the levels arrive over.
+    _app = QApplication.instance() or QApplication([])
+else:      # imported so the module loads; nothing below it runs
+    _app = None
+    win_clipboard = win_hotkeys = win_resample = win_runtime = None
+
+RATE = 16000
+
+
+# --- turning a device's blocks into whisper's format ------------------------
+
+
+@windows_only
+class Resampling(unittest.TestCase):
+    """The rate conversion, which is where a meeting would drift apart."""
+
+    def feed_in_blocks(self, resampler, total, block, value=1000):
+        out = 0
+        left = total
+        while left > 0:
+            count = min(block, left)
+            out += len(resampler.feed(array.array("h", [value] * count)))
+            left -= count
+        return out
+
+    def test_forty_eight_to_sixteen_is_exactly_a_third(self):
+        resampler = win_resample.Resampler(48000, RATE)
+        self.assertEqual(self.feed_in_blocks(resampler, 48000, 1024), RATE)
+
+    def test_a_rate_that_does_not_divide_still_lands_on_the_right_count(self):
+        """44100 is 2.75625 source samples per output one, and the fraction is
+        what a converter that started each block from zero would throw away."""
+        resampler = win_resample.Resampler(44100, RATE)
+        self.assertEqual(self.feed_in_blocks(resampler, 44100, 441), RATE)
+
+    def test_ten_seconds_of_it_is_still_exact(self):
+        """A tenth of a sample lost per block is 36 seconds lost per hour.
+
+        The accumulator carries its remainder between blocks, so the error does
+        not accumulate at all: the count after ten seconds is the count, not
+        the count give or take.
+        """
+        resampler = win_resample.Resampler(44100, RATE)
+        self.assertEqual(self.feed_in_blocks(resampler, 44100 * 10, 480),
+                         RATE * 10)
+
+    def test_the_block_size_does_not_change_the_answer(self):
+        counts = set()
+        for block in (64, 441, 1024, 4096):
+            resampler = win_resample.Resampler(44100, RATE)
+            counts.add(self.feed_in_blocks(resampler, 44100 * 3, block))
+        self.assertEqual(counts, {RATE * 3})
+
+    def test_a_device_already_at_sixteen_is_left_alone(self):
+        resampler = win_resample.Resampler(RATE, RATE)
+        self.assertTrue(resampler.passthrough)
+        samples = array.array("h", [1, -2, 3])
+        self.assertEqual(list(resampler.feed(samples)), [1, -2, 3])
+
+    def test_downsampling_averages_rather_than_picking_one(self):
+        """Point-sampling folds everything above 8 kHz back into the speech
+        band, which a transcription model hears as noise."""
+        resampler = win_resample.Resampler(48000, RATE)
+        out = resampler.feed(array.array("h", [3000, 0, 0] * 4))
+        self.assertEqual(list(out), [1000, 1000, 1000, 1000])
+
+    def test_a_device_below_sixteen_is_stretched_rather_than_refused(self):
+        resampler = win_resample.Resampler(8000, RATE)
+        self.assertEqual(len(resampler.feed(array.array("h", [5] * 800))), 1600)
+
+
+@windows_only
+class Downmixing(unittest.TestCase):
+    def test_a_stereo_microphone_becomes_one_channel(self):
+        raw = array.array("h", [1000, 2000, -1000, -2000]).tobytes()
+        self.assertEqual(list(win_resample.to_mono(raw, 2)), [1500, -1500])
+
+    def test_a_mono_one_is_passed_through(self):
+        raw = array.array("h", [7, -7]).tobytes()
+        self.assertEqual(list(win_resample.to_mono(raw, 1)), [7, -7])
+
+    def test_a_partial_frame_is_ignored_rather_than_fatal(self):
+        raw = array.array("h", [100, 200]).tobytes() + b"\x01"
+        self.assertEqual(list(win_resample.to_mono(raw, 2)), [150])
+
+    def test_a_surround_device_is_averaged_across_all_of_it(self):
+        raw = array.array("h", [400, 800, 1200, 1600]).tobytes()
+        self.assertEqual(list(win_resample.to_mono(raw, 4)), [1000])
+
+    def test_the_converter_does_both_and_hands_back_bytes(self):
+        converter = win_resample.Converter(48000, 2, RATE)
+        raw = array.array("h", [1000, 2000] * 3).tobytes()   # 3 stereo frames
+        out = array.array("h")
+        out.frombytes(converter.feed(raw))
+        self.assertEqual(list(out), [1500])
+
+
+# --- the meeting mixer ------------------------------------------------------
+
+
+class FakeStream:
+    """A WASAPI stream handing over blocks, and ending the way a real one does.
+
+    `blocks` bounds how many it gives; after that it either keeps quiet, which
+    is what a loopback does while the speakers are idle, or raises, which is
+    what a device being unplugged looks like from inside a read.
+    """
+
+    def __init__(self, value, block=160, gap=0.005, blocks=None, unplugged=False):
+        self.value = value
+        self.block = block
+        self.gap = gap
+        self.left = blocks
+        self.unplugged = unplugged
+        self.latency = 0.0
+        self.closed = False
+
+    def read(self):
+        time.sleep(self.gap)
+        if self.left is not None:
+            if self.left <= 0:
+                if self.unplugged:
+                    raise OSError("the device went away")
+                return b""
+            self.left -= 1
+        return array.array("h", [self.value] * self.block).tobytes()
+
+    def close(self):
+        self.closed = True
+
+
+def settle(seconds=0.15):
+    """Let the queued signals from the capture threads arrive."""
+    deadline = time.perf_counter() + seconds
+    while time.perf_counter() < deadline:
+        _app.processEvents()
+        time.sleep(0.01)
+    _app.processEvents()
+
+
+@windows_only
+class MeetingMixing(DikteTest):
+    """Two devices, one timeline, and which voice ends up on which channel."""
+
+    def record(self, mic, system, seconds=0.6):
+        from platforms.windows import audio as win_audio
+
+        path = str(self.path("meeting.wav"))
+        streams = iter([mic, system])
+        with mock.patch.object(win_audio, "_microphone",
+                               return_value={"name": "mic", "index": 0}), \
+                mock.patch.object(win_audio, "_loopbacks",
+                                  return_value=[{"name": "out", "index": 1}]), \
+                mock.patch.object(win_audio, "_Stream",
+                                  side_effect=lambda device: next(streams)):
+            recorder = win_audio.MeetingRecorder()
+            done, failed = [], []
+            recorder.stopped.connect(lambda *args: done.append(args))
+            recorder.failed.connect(failed.append)
+            recorder.start(path, max_seconds=60)
+            time.sleep(seconds)
+            recorder.stop()
+        settle()
+        return path, done, failed
+
+    def channels(self, path):
+        with wave.open(path, "rb") as wav:
+            self.assertEqual(wav.getnchannels(), 2)
+            self.assertEqual(wav.getframerate(), RATE)
+            samples = array.array("h")
+            samples.frombytes(wav.readframes(wav.getnframes()))
+        return samples[0::2], samples[1::2]
+
+    def test_the_microphone_is_the_left_channel_and_nothing_of_it_leaks_right(self):
+        path, done, failed = self.record(FakeStream(1000), FakeStream(-2000))
+        self.assertEqual(failed, [])
+        self.assertTrue(done)
+        left, right = self.channels(path)
+        self.assertEqual(set(left) - {0}, {1000})
+        self.assertEqual(set(right) - {0}, {-2000})
+
+    def test_both_channels_hold_the_same_stretch_of_time(self):
+        """They are written together or not at all, so neither can slide."""
+        path, _, _ = self.record(FakeStream(1000), FakeStream(-2000))
+        left, right = self.channels(path)
+        self.assertEqual(len(left), len(right))
+        self.assertGreater(len(left), RATE // 10)
+
+    def test_a_silent_loopback_does_not_hold_up_the_microphone(self):
+        """WASAPI hands over nothing at all while the speakers are idle on some
+        machines, and an hour of meeting must not wait on it."""
+        path, done, failed = self.record(FakeStream(1000),
+                                         FakeStream(0, blocks=0))
+        self.assertEqual(failed, [])
+        self.assertTrue(done)
+        left, right = self.channels(path)
+        self.assertEqual(set(left) - {0}, {1000})
+        self.assertEqual(set(right), {0})
+
+    def test_the_duration_written_is_the_time_that_passed(self):
+        path, done, _ = self.record(FakeStream(1000), FakeStream(-2000),
+                                    seconds=0.8)
+        _path, seconds = done[0]
+        left, _right = self.channels(path)
+        self.assertAlmostEqual(len(left) / RATE, seconds, places=3)
+        # Written against the wall clock, so what is on disk is how long the
+        # meeting ran rather than how many samples a card felt like giving.
+        self.assertGreater(seconds, 0.4)
+        self.assertLess(seconds, 1.2)
+
+    def test_a_cancelled_meeting_leaves_no_file(self):
+        from platforms.windows import audio as win_audio
+
+        path = str(self.path("meeting.wav"))
+        streams = iter([FakeStream(1000), FakeStream(-2000)])
+        with mock.patch.object(win_audio, "_microphone",
+                               return_value={"name": "mic", "index": 0}), \
+                mock.patch.object(win_audio, "_loopbacks",
+                                  return_value=[{"name": "out", "index": 1}]), \
+                mock.patch.object(win_audio, "_Stream",
+                                  side_effect=lambda device: next(streams)):
+            recorder = win_audio.MeetingRecorder()
+            recorder.start(path, max_seconds=60)
+            time.sleep(0.2)
+            recorder.cancel()
+        self.assertFalse(os.path.exists(path))
+
+
+@windows_only
+class Dictation(DikteTest):
+    """The microphone on its own, which is what a dictation is."""
+
+    def record(self, stream, seconds=0.5):
+        from platforms.windows import audio as win_audio
+
+        with mock.patch.object(win_audio, "_microphone",
+                               return_value={"name": "mic", "index": 0}), \
+                mock.patch.object(win_audio, "_Stream", return_value=stream):
+            recorder = win_audio.Recorder()
+            done, failed, levels = [], [], []
+            recorder.stopped.connect(lambda *args: done.append(args))
+            recorder.failed.connect(failed.append)
+            recorder.level.connect(levels.append)
+            recorder.start(max_seconds=60)
+            time.sleep(seconds)
+            recorder.stop()
+        settle()
+        return done, failed, levels
+
+    def test_a_recording_ends_as_a_wav_at_the_rate_whisper_wants(self):
+        done, failed, levels = self.record(FakeStream(8000))
+        self.assertEqual(failed, [])
+        path, seconds, rms = done[0]
+        self.addCleanup(os.unlink, path)
+        with wave.open(path, "rb") as wav:
+            self.assertEqual(wav.getnchannels(), 1)
+            self.assertEqual(wav.getframerate(), RATE)
+            self.assertEqual(wav.getsampwidth(), 2)
+        self.assertGreater(seconds, 0.2)
+        self.assertTrue(rms)
+        self.assertGreater(max(levels), 0.0)
+
+    def test_a_stray_keypress_is_not_a_recording(self):
+        done, failed, _ = self.record(FakeStream(8000, blocks=1), seconds=0.2)
+        self.assertEqual(done, [])
+        self.assertIn("0.3", failed[0])
+
+    def test_a_microphone_that_gave_nothing_says_so_rather_than_looking_short(self):
+        """Reported as the device going away, not as a recording too short:
+        the second one sends the user looking in the wrong place."""
+        done, failed, _ = self.record(
+            FakeStream(0, blocks=0, unplugged=True), seconds=0.3)
+        self.assertEqual(done, [])
+        self.assertTrue(any("microphone stopped" in line for line in failed),
+                        failed)
+
+    def test_a_cancelled_recording_produces_nothing(self):
+        from platforms.windows import audio as win_audio
+
+        with mock.patch.object(win_audio, "_microphone",
+                               return_value={"name": "mic", "index": 0}), \
+                mock.patch.object(win_audio, "_Stream",
+                                  return_value=FakeStream(8000)):
+            recorder = win_audio.Recorder()
+            done = []
+            recorder.stopped.connect(lambda *args: done.append(args))
+            recorder.start()
+            time.sleep(0.2)
+            recorder.cancel()
+            recorder.stop()
+        self.assertEqual(done, [])
+
+    def test_no_microphone_at_all_names_where_to_pick_one(self):
+        from platforms.windows import audio as win_audio
+
+        with mock.patch.object(win_audio, "_microphone", return_value=None):
+            recorder = win_audio.Recorder()
+            failed = []
+            recorder.failed.connect(failed.append)
+            recorder.start()
+        settle()
+        self.assertIn("Settings", failed[0])
+
+    def test_a_device_windows_refuses_points_at_the_privacy_setting(self):
+        """A microphone switched off under Privacy fails to open with an access
+        error, and the number PortAudio reports for it means nothing to anybody."""
+        from platforms.windows import audio as win_audio
+
+        with mock.patch.object(win_audio, "_microphone",
+                               return_value={"name": "Mic", "index": 0}), \
+                mock.patch.object(win_audio, "_Stream",
+                                  side_effect=OSError("[Errno -9996] access denied")):
+            recorder = win_audio.Recorder()
+            failed = []
+            recorder.failed.connect(failed.append)
+            recorder.start()
+        settle()
+        self.assertIn("Privacy", failed[0])
+
+
+# --- the clipboard ----------------------------------------------------------
+
+
+@windows_only
+class KeyPresses(unittest.TestCase):
+    def codes(self, shortcut):
+        return win_clipboard.key_events(shortcut)
+
+    def test_down_in_order_then_up_in_reverse(self):
+        """Releasing Ctrl before V leaves the application with a plain V."""
+        self.assertEqual(self.codes("ctrl+v"),
+                         [(0x11, False), (0x56, False),
+                          (0x56, True), (0x11, True)])
+
+    def test_three_keys(self):
+        self.assertEqual(self.codes("ctrl+shift+v"),
+                         [(0x11, False), (0x10, False), (0x56, False),
+                          (0x56, True), (0x10, True), (0x11, True)])
+
+    def test_case_and_spacing_do_not_matter(self):
+        self.assertEqual(self.codes(" Ctrl + V "), self.codes("ctrl+v"))
+
+    def test_the_synonyms_land_on_the_same_codes(self):
+        self.assertEqual(self.codes("control+insert"), self.codes("ctrl+insert"))
+        self.assertEqual(self.codes("super+enter"), self.codes("meta+return"))
+
+    def test_a_key_nobody_mapped_is_refused_before_anything_is_sent(self):
+        with self.assertRaises(win_clipboard.PasteError) as caught:
+            self.codes("ctrl+f13")
+        self.assertIn("f13", str(caught.exception))
+
+    def test_insert_is_sent_as_the_extended_key_it_is(self):
+        """Without the flag it arrives as the numeric keypad's 0."""
+        self.assertIn(0x2D, win_clipboard.EXTENDED)
+        self.assertIn(0x5B, win_clipboard.EXTENDED)
+
+
+@windows_only
+class ClipboardSnapshot(unittest.TestCase):
+    """Putting back what was on the clipboard before a dictation replaced it."""
+
+    def test_plain_text_goes_out_and_comes_back_as_itself(self):
+        self.assertIsNone(win_clipboard._unpack("günaydın".encode("utf-8")))
+
+    def test_the_formats_survive_the_round_trip(self):
+        parts = [("text", "günaydın".encode("utf-8")),
+                 ("HTML Format", b"<b>g\xc3\xbcnayd\xc4\xb1n</b>")]
+        self.assertEqual(win_clipboard._unpack(win_clipboard._pack(parts)), parts)
+
+    def test_something_that_is_not_a_snapshot_is_treated_as_text(self):
+        self.assertIsNone(win_clipboard._unpack(b"\x89PNG\r\n"))
+
+    def test_a_snapshot_that_was_cut_short_is_refused_whole(self):
+        """Half a clipboard put back is an invented clipboard."""
+        packed = win_clipboard._pack([("text", b"hello")])
+        self.assertIsNone(win_clipboard._unpack(packed[:-3]))
+
+
+@windows_only
+class RealClipboard(unittest.TestCase):
+    """Against the clipboard this machine actually has."""
+
+    def setUp(self):
+        self.before = win_clipboard.read_clipboard()
+        self.addCleanup(win_clipboard.copy_bytes, self.before)
+
+    def test_turkish_survives_the_trip_through_utf16(self):
+        # A dotted capital I and a dash the Turkish console codepage has never
+        # heard of. Both go through UTF-16 on the way in and UTF-8 on the way
+        # out, and either conversion is where a dictation would be lost.
+        text = "g\u00fcnayd\u0131n, \u0130stanbul \u2014 a\u011f\u0131r"
+        win_clipboard.copy(text)
+        self.assertEqual(win_clipboard.read_clipboard().decode("utf-8"), text)
+
+    def test_an_empty_string_is_empty_text_rather_than_no_text(self):
+        """The two are not the same thing to copy_bytes: nothing to put back
+        leaves the clipboard alone, and empty text clears it."""
+        win_clipboard.copy("")
+        self.assertEqual(win_clipboard.read_clipboard(), b"")
+
+    def test_a_snapshot_restores_the_text_that_was_there(self):
+        win_clipboard.copy("what was there before")
+        snapshot = win_clipboard.read_clipboard()
+        win_clipboard.copy("a dictation")
+        win_clipboard.copy_bytes(snapshot)
+        self.assertEqual(win_clipboard.read_clipboard().decode("utf-8"),
+                         "what was there before")
+
+    def test_a_clipboard_nobody_will_hand_over_is_a_sentence_not_a_hang(self):
+        with mock.patch.object(win_clipboard, "_open", return_value=False):
+            with self.assertRaises(win_clipboard.PasteError) as caught:
+                win_clipboard.copy("hello")
+        self.assertIn("clipboard", str(caught.exception))
+
+    def test_restoring_never_raises(self):
+        """It runs after the paste went in; failing here must not undo that."""
+        with mock.patch.object(win_clipboard, "_open", return_value=False):
+            win_clipboard.copy_bytes(b"whatever was there before")
+
+
+# --- the shortcuts ----------------------------------------------------------
+
+
+@windows_only
+class ParseShortcut(unittest.TestCase):
+    def test_the_default(self):
+        self.assertEqual(win_hotkeys.parse_shortcut("Ctrl+Space"), ({"ctrl"}, 0x20))
+
+    def test_case_and_spacing_do_not_matter(self):
+        self.assertEqual(win_hotkeys.parse_shortcut(" ctrl + SPACE "),
+                         ({"ctrl"}, 0x20))
+
+    def test_several_modifiers(self):
+        mods, key = win_hotkeys.parse_shortcut("Ctrl+Alt+Shift+D")
+        self.assertEqual(mods, {"ctrl", "alt", "shift"})
+        self.assertEqual(key, 0x44)
+
+    def test_the_synonyms_land_on_one_name(self):
+        self.assertEqual(win_hotkeys.parse_shortcut("Control+Space"),
+                         win_hotkeys.parse_shortcut("Ctrl+Space"))
+        self.assertEqual(win_hotkeys.parse_shortcut("Meta+Space"),
+                         win_hotkeys.parse_shortcut("Super+Space"))
+
+    def test_modifiers_with_no_key(self):
+        self.assertEqual(win_hotkeys.parse_shortcut("Ctrl+Alt"), (None, None))
+
+    def test_a_key_nobody_mapped(self):
+        self.assertEqual(win_hotkeys.parse_shortcut("Ctrl+F13"), (None, None))
+
+    def test_nothing(self):
+        self.assertEqual(win_hotkeys.parse_shortcut(""), (None, None))
+        self.assertEqual(win_hotkeys.parse_shortcut(None), (None, None))
+
+    def test_the_flags_are_the_ones_registerhotkey_takes(self):
+        mods, _key = win_hotkeys.parse_shortcut("Ctrl+Shift+Space")
+        self.assertEqual(win_hotkeys._modifier_flags(mods),
+                         win_hotkeys.MOD_CONTROL | win_hotkeys.MOD_SHIFT)
+
+    def test_every_shortcut_the_settings_can_store_is_understood_here(self):
+        """A combination typed on Linux has to mean the same key on Windows."""
+        import platforms.linux.hotkeys as linux_hotkeys
+
+        for name in linux_hotkeys.KEYS:
+            with self.subTest(key=name):
+                self.assertIn(name, win_hotkeys.KEYS)
+
+
+@windows_only
+class Registering(DikteTest):
+    """What was installed, remembered for the process that did not install it."""
+
+    def setUp(self):
+        super().setUp()
+        registry = self.path("shortcuts.json")
+        self.patch_attr(win_hotkeys, "_registry_path", lambda: registry)
+
+    def test_nothing_is_installed_to_begin_with(self):
+        self.assertIsNone(win_hotkeys.shortcut_status(win_hotkeys.DESKTOP_ID))
+
+    def test_installing_one_is_remembered_and_removing_it_forgets_it(self):
+        with mock.patch.object(win_hotkeys, "_free", return_value=True):
+            ok, _message = win_hotkeys.install_shortcut(
+                "Ctrl+Alt+F9", desktop_id=win_hotkeys.CANCEL_DESKTOP_ID)
+        self.assertTrue(ok)
+        self.assertEqual(
+            win_hotkeys.shortcut_status(win_hotkeys.CANCEL_DESKTOP_ID),
+            "Ctrl+Alt+F9")
+        win_hotkeys.remove_shortcut(win_hotkeys.CANCEL_DESKTOP_ID)
+        self.assertIsNone(
+            win_hotkeys.shortcut_status(win_hotkeys.CANCEL_DESKTOP_ID))
+
+    def test_each_verb_keeps_its_own(self):
+        with mock.patch.object(win_hotkeys, "_free", return_value=True):
+            win_hotkeys.install_shortcut("Ctrl+Space",
+                                         desktop_id=win_hotkeys.DESKTOP_ID)
+            win_hotkeys.install_shortcut("Ctrl+Alt+Space",
+                                         desktop_id=win_hotkeys.CANCEL_DESKTOP_ID)
+        self.assertEqual(win_hotkeys.shortcut_status(win_hotkeys.DESKTOP_ID),
+                         "Ctrl+Space")
+        self.assertEqual(
+            win_hotkeys.shortcut_status(win_hotkeys.CANCEL_DESKTOP_ID),
+            "Ctrl+Alt+Space")
+
+    def test_a_combination_nobody_can_parse_is_refused(self):
+        ok, message = win_hotkeys.install_shortcut("Ctrl+F13")
+        self.assertFalse(ok)
+        self.assertIn("F13", message)
+
+    def test_one_somebody_else_holds_is_refused_and_says_what_to_do(self):
+        with mock.patch.object(win_hotkeys, "_free", return_value=False):
+            ok, message = win_hotkeys.install_shortcut("Ctrl+Alt+F9")
+        self.assertFalse(ok)
+        self.assertIn("another application", message)
+        self.assertIsNone(win_hotkeys.shortcut_status(win_hotkeys.DESKTOP_ID))
+
+    def test_dikte_s_own_registration_is_not_mistaken_for_a_conflict(self):
+        with mock.patch.object(win_hotkeys, "_free", return_value=True):
+            win_hotkeys.install_shortcut("Ctrl+Space",
+                                         desktop_id=win_hotkeys.DESKTOP_ID)
+        with mock.patch.object(win_hotkeys, "_free", return_value=False):
+            self.assertEqual(
+                win_hotkeys.conflicting_shortcuts("Ctrl+Space",
+                                                  win_hotkeys.DESKTOP_ID), [])
+
+    def test_a_conflict_says_windows_will_not_name_the_other_program(self):
+        with mock.patch.object(win_hotkeys, "_free", return_value=False):
+            clashes = win_hotkeys.conflicting_shortcuts("Ctrl+Alt+F9")
+        self.assertEqual(len(clashes), 1)
+        self.assertIn("Windows", clashes[0])
+
+    def test_the_desktop_is_called_windows(self):
+        self.assertEqual(win_hotkeys.desktop_name(), "Windows")
+
+
+@windows_only
+class LiveHotkey(unittest.TestCase):
+    """Against RegisterHotKey itself, on a combination nothing else wants."""
+
+    def test_a_combination_is_taken_and_given_back(self):
+        listener = win_hotkeys.WindowsHotkeys()
+        self.addCleanup(listener.stop)
+        self.assertTrue(listener.start({"toggle": "Ctrl+Alt+Shift+F9"}))
+        self.assertEqual(listener.registered(), {"toggle": "Ctrl+Alt+Shift+F9"})
+        listener.stop()
+        self.assertFalse(listener.running)
+        # Given back rather than held: taking it again has to work.
+        again = win_hotkeys.WindowsHotkeys()
+        self.addCleanup(again.stop)
+        self.assertTrue(again.start({"toggle": "Ctrl+Alt+Shift+F9"}))
+
+    def test_an_unparsable_one_is_reported_and_the_rest_go_on(self):
+        listener = win_hotkeys.WindowsHotkeys()
+        self.addCleanup(listener.stop)
+        failures = []
+        listener.failed.connect(failures.append)
+        self.assertTrue(listener.start({"toggle": "Ctrl+F13",
+                                        "ask": "Ctrl+Alt+Shift+F10"}))
+        settle()
+        self.assertEqual(len(failures), 1)
+        self.assertIn("Ctrl+F13", failures[0])
+        self.assertEqual(list(listener.registered()), ["ask"])
+
+    def test_nothing_to_register_is_not_a_listener(self):
+        listener = win_hotkeys.WindowsHotkeys()
+        self.addCleanup(listener.stop)
+        self.assertFalse(listener.start({"toggle": "", "ask": ""}))
+
+    def test_a_second_listener_cannot_take_what_the_first_one_holds(self):
+        """Which is the whole conflict report Windows offers."""
+        first = win_hotkeys.WindowsHotkeys()
+        self.addCleanup(first.stop)
+        self.assertTrue(first.start({"toggle": "Ctrl+Alt+Shift+F8"}))
+        second = win_hotkeys.WindowsHotkeys()
+        self.addCleanup(second.stop)
+        failures = []
+        second.failed.connect(failures.append)
+        self.assertFalse(second.start({"toggle": "Ctrl+Alt+Shift+F8"}))
+        settle()
+        self.assertTrue(failures)
+        self.assertIn("already taken", failures[0])
+
+
+# --- directories, secrets, processes ----------------------------------------
+
+
+@windows_only
+class Directories(unittest.TestCase):
+    def test_settings_roam_and_everything_large_does_not(self):
+        self.assertEqual(win_runtime.config_dir().name, "Dikte")
+        self.assertEqual(win_runtime.data_dir().name, "Dikte")
+        self.assertNotEqual(win_runtime.config_home(), win_runtime.data_home())
+
+    def test_the_cache_sits_under_the_data_directory(self):
+        self.assertEqual(win_runtime.cache_dir().parent, win_runtime.data_dir())
+
+    def test_the_directories_are_named_the_way_explorer_shows_them(self):
+        self.assertEqual(win_runtime.RECORDINGS_NAME, "Recordings")
+        self.assertEqual(win_runtime.MEETINGS_NAME, "Meetings")
+
+
+@windows_only
+class Secrets(unittest.TestCase):
+    """DPAPI, which is what keeps an API key on a filesystem with no modes."""
+
+    def test_a_key_comes_back_out_of_what_was_stored(self):
+        stored = win_runtime.protect("sk-secret-key")
+        self.assertEqual(win_runtime.unprotect(stored), "sk-secret-key")
+
+    def test_what_is_stored_is_not_the_key(self):
+        stored = win_runtime.protect("sk-secret-key")
+        self.assertNotIn("sk-secret-key", stored)
+        self.assertTrue(stored.startswith(win_runtime.SECRET_PREFIX))
+
+    def test_turkish_and_the_long_ones_survive(self):
+        for secret in ("ağırbaşlı-anahtar", "sk-" + "x" * 400, "a"):
+            with self.subTest(secret=secret[:12]):
+                self.assertEqual(
+                    win_runtime.unprotect(win_runtime.protect(secret)), secret)
+
+    def test_an_empty_key_stays_empty_rather_than_becoming_ciphertext(self):
+        self.assertEqual(win_runtime.protect(""), "")
+        self.assertEqual(win_runtime.unprotect(""), "")
+
+    def test_a_key_written_in_plain_text_is_read_as_it_stands(self):
+        self.assertEqual(win_runtime.unprotect("sk-written-by-hand"),
+                         "sk-written-by-hand")
+
+    def test_ciphertext_from_another_account_reads_as_missing(self):
+        self.assertEqual(win_runtime.unprotect("dpapi:1:bm90IG1pbmU="), "")
+
+    def test_and_so_does_something_that_is_not_even_base64(self):
+        self.assertEqual(win_runtime.unprotect("dpapi:1:not base64 at all"), "")
+
+    def test_two_encryptions_of_one_key_are_not_the_same_bytes(self):
+        """Or the file would tell anyone reading it when a key was reused."""
+        self.assertNotEqual(win_runtime.protect("sk-secret-key"),
+                            win_runtime.protect("sk-secret-key"))
+
+
+@windows_only
+class Identity(unittest.TestCase):
+    def test_the_user_is_the_same_user_every_time(self):
+        self.assertEqual(win_runtime.user_id(), win_runtime.user_id())
+
+    def test_it_is_a_name_a_pipe_can_carry(self):
+        found = win_runtime.user_id()
+        self.assertTrue(found)
+        self.assertTrue(all(char.isalnum() for char in found))
+
+    def test_a_second_instance_finds_the_first_one_holding_the_mutex(self):
+        """Two servers can bind one pipe name on Windows, so the pipe cannot
+        answer this and the mutex has to."""
+        name = "dikte-test-" + win_runtime.user_id()
+        first = win_runtime.single_instance(name)
+        self.assertIsNotNone(first)
+        try:
+            self.assertIsNone(win_runtime.single_instance(name))
+        finally:
+            first.release()
+        # Released, so the next one gets it: this is the restart path.
+        second = win_runtime.single_instance(name)
+        self.assertIsNotNone(second)
+        second.release()
+
+
+@windows_only
+class Processes(unittest.TestCase):
+    def test_this_process_is_found_by_what_is_on_its_command_line(self):
+        self.assertTrue(win_runtime.is_our_process(os.getpid(), ["python"])
+                        or win_runtime.is_our_process(os.getpid(), ["Python"]))
+
+    def test_something_that_is_not_there_is_not_ours(self):
+        self.assertFalse(win_runtime.is_our_process(os.getpid(), ["not-a-server"]))
+
+    def test_a_pid_nothing_is_using_is_not_ours_either(self):
+        self.assertFalse(win_runtime.is_our_process(0x7FFFFFF0, ["python"]))
+
+    def test_subprocesses_are_asked_for_without_a_console_window(self):
+        self.assertIn("creationflags", win_runtime.NO_WINDOW)
+
+    def test_a_child_can_be_tied_to_this_process(self):
+        import subprocess
+
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"],
+                                **win_runtime.NO_WINDOW)
+        try:
+            self.assertTrue(win_runtime.adopt(proc))
+            self.assertTrue(win_runtime.terminate(proc.pid))
+            self.assertIsNotNone(proc.wait(timeout=10))
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+
+@windows_only
+class Sockets(unittest.TestCase):
+    def test_a_blocked_read_is_ended_rather_than_left_waiting(self):
+        """Winsock does not promise a shutdown reaches a recv already in flight,
+        so the handle underneath it is closed."""
+        import socket
+
+        server = socket.socket()
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        self.addCleanup(server.close)
+        client = socket.create_connection(server.getsockname())
+        accepted, _ = server.accept()
+        self.addCleanup(accepted.close)
+
+        result = []
+
+        def read():
+            try:
+                result.append(client.recv(16))
+            except OSError as exc:
+                result.append(exc)
+
+        thread = threading.Thread(target=read, daemon=True)
+        thread.start()
+        time.sleep(0.2)
+        win_runtime.abort_socket(client)
+        thread.join(timeout=5)
+        self.assertFalse(thread.is_alive())
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds native Windows 10/11 support while preserving the current macOS and Linux behavior.

It introduces platform adapters for audio capture, clipboard/paste, global hotkeys, runtime paths, IPC, process lifecycle, and local model execution. It also adds a PyInstaller portable build, an Inno Setup installer, bundled FFmpeg support, Windows CI coverage, documentation, and platform-specific tests.

This work builds on the earlier Windows implementation by @melih3774 and reconciles it with the current upstream desktop architecture and recent macOS/Linux changes.

## User impact

- Run Dikte as a native Windows tray application.
- Capture microphone audio and WASAPI loopback audio for meetings.
- Use system-wide configurable shortcuts and Unicode clipboard paste.
- Run one per-user Dikte instance with local IPC and Windows process cleanup.
- Download and run whisper.cpp/llama.cpp builds with CPU, CUDA, or Vulkan selection.
- Install through a per-user Windows installer or use the portable distribution.

## Packaging and CI

- Adds reproducible PowerShell/PyInstaller/Inno Setup build tooling.
- Downloads a pinned FFmpeg archive with SHA-256 verification.
- Adds Windows test jobs across supported Python versions.
- Produces `DikteApp.exe`, `dikte.exe`, and a Windows setup executable.
- Preserves user settings and history by default during uninstall; silent uninstall remains unattended.

## Validation

- `python -m unittest discover -s tests`
  - 1,068 tests passed
  - 56 platform-specific/environment-specific tests skipped
- Portable application smoke test passed.
- Tray startup, status IPC, single-instance behavior, and clean shutdown passed.
- Packaged `doctor --json` detected bundled FFmpeg and Windows audio devices.
- Silent installer install/diagnostic/uninstall flow passed without dialogs.
- `git diff --check upstream/master...HEAD` passed.

## Notes

Live microphone capture could not be completed from the automation login because Windows denied that session access to the physical input device. Device enumeration and the permission guidance path were verified; an interactive hardware check is still recommended during review.
