### PR TITLE
Stop the macOS test job waiting on a name nobody has

### DIFF
--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -439,7 +439,7 @@ class Catalogue(Local):
 
 
 STAND_IN = textwrap.dedent("""
-    import http.server, sys, threading, time
+    import http.server, socketserver, sys, threading, time
 
     args = sys.argv[1:]
 
@@ -465,7 +465,17 @@ STAND_IN = textwrap.dedent("""
         def log_message(self, *a):
             pass
 
-    server = http.server.HTTPServer((opt("--host"), int(opt("--port"))), Handler)
+    # The same server, without the reverse lookup of the address it bound.
+    # http.server asks the resolver for the name behind 127.0.0.1 in between
+    # binding and listening; on a Mac nothing answers and the call sits in a
+    # timeout for half a minute, all of it with the port still closed and a
+    # start waiting on it.
+    class Bound(http.server.HTTPServer):
+        def server_bind(self):
+            socketserver.TCPServer.server_bind(self)
+            self.server_name, self.server_port = self.server_address[:2]
+
+    server = Bound((opt("--host"), int(opt("--port"))), Handler)
     print("listening on " + opt("--port"), flush=True)
     server.serve_forever()
 """)


### PR DESCRIPTION
`tests/test_ggml.py` starts a stand-in whisper server, and it is an `http.server`. `HTTPServer.server_bind` calls `socket.getfqdn()` on the address it just bound, in between the bind and the listen. On Linux and Windows that returns immediately. On the macOS runner the reverse lookup for 127.0.0.1 goes out to the resolver, nothing answers, and the call blocks for thirty-five seconds with the port still closed while `Server._wait_ready` polls it.

Seven tests start a server, one of them twice. Measured on run 31935875745:

| job | suite |
|---|---|
| linux (3.13) | 15 s |
| macos (3.13) | 334 s |

and 330 of those 334 seconds are the eight starts. Every test that does not bind a port finishes in milliseconds on macOS too, including the one that runs the same script with `--die`, which rules out interpreter startup.

The fix is in the stand-in only: bind through `socketserver.TCPServer` and take the server name from the address already in hand. Nothing in `ggml.py` changes, and the real `whisper-server` is a binary that never went near this code.