### PR TITLE
Carry the two paths the RHEL family uses as well

### DIFF
--- a/dikte/integrate.py
+++ b/dikte/integrate.py
@@ -95,13 +95,19 @@ def restore_library_path():
     return moved
 
 
-# Where the distributions keep the trust store. One list rather than a guess
-# per distribution, in the order curl and Go try them.
+# Where the trust store is, which is not one place but is a short list of them:
+# every distribution takes its layout from one of four packages rather than
+# inventing one, and this is the list Go's crypto/x509 and curl both carry. The
+# first line alone answers Debian, Ubuntu, Arch, Gentoo, Fedora and Alpine,
+# which was checked rather than assumed; the rest are the ones that do it their
+# own way.
 CA_FILES = (
-    "/etc/ssl/certs/ca-certificates.crt",   # Debian, Ubuntu, Arch, Gentoo
-    "/etc/pki/tls/certs/ca-bundle.crt",     # Fedora, RHEL
-    "/etc/ssl/ca-bundle.pem",               # openSUSE
-    "/etc/ssl/cert.pem",                    # Alpine, and macOS
+    "/etc/ssl/certs/ca-certificates.crt",                 # Debian and everything after it
+    "/etc/pki/tls/certs/ca-bundle.crt",                   # Fedora, RHEL
+    "/etc/ssl/ca-bundle.pem",                             # openSUSE
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  # RHEL 7 and CentOS
+    "/etc/pki/tls/cacert.pem",                            # OpenELEC
+    "/etc/ssl/cert.pem",                                  # Alpine, and macOS
 )
 CA_DIRECTORIES = ("/etc/ssl/certs", "/etc/pki/tls/certs")
 


### PR DESCRIPTION
A follow-on to #41, which shipped four of the six certificate paths that Go's `crypto/x509` and curl both carry. The two left out are `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`, where RHEL 7 and CentOS keep the bundle, and OpenELEC's `/etc/pki/tls/cacert.pem`.

Small, and honestly closer to completeness than to a fix: I checked the common distributions in containers rather than guessing, and the first entry already answers them.

| distribution | what it has |
|---|---|
| Debian, Ubuntu, Arch, Gentoo | `/etc/ssl/certs/ca-certificates.crt` |
| Fedora | the same, plus `/etc/ssl/cert.pem` and the ca-trust bundle |
| Alpine | the same, plus `/etc/ssl/cert.pem` |
| openSUSE | `/etc/ssl/ca-bundle.pem`, and nothing else on the list |
| macOS | `/etc/ssl/cert.pem` |

So openSUSE is the only common one that needs anything past the first line. The two added here are for the RHEL family, where a machine old enough not to have the first entry is the case this covers.

The comment above the list now says which line answers what, and that it was checked.