### PR TITLE
Remove macOS command wrapper during integration cleanup

### DIFF
--- a/dikte/integrate.py
+++ b/dikte/integrate.py
@@ -34,6 +34,7 @@ import sys
 AGENT_ID = "io.github.yusufipk.dikte"
 ICON_NAME = "dikte"
 DESKTOP_FILE = "dikte.desktop"
+MACOS_COMMAND_MARKER = "# Written by Dikte itself. Delete it to be rid of it.\n"
 
 
 def packaged():
@@ -398,6 +399,20 @@ def _agent_path():
     return pathlib.Path.home() / "Library" / "LaunchAgents" / f"{AGENT_ID}.plist"
 
 
+def _macos_command_path():
+    return pathlib.Path.home() / ".local" / "bin" / "dikte"
+
+
+def _macos_command_is_ours(command):
+    """Whether this is the wrapper a downloaded Mac build wrote itself."""
+    try:
+        return command.is_file() and MACOS_COMMAND_MARKER in command.read_text(
+            encoding="utf-8"
+        )
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
 def _agent_plist(app):
     """Through `open` rather than the executable inside the bundle, so that the
     process is one LaunchServices started: that is what gives it the bundle's
@@ -449,13 +464,13 @@ def _macos_install(app, force=False):
     # The command, as a wrapper rather than a symlink: the executable has to be
     # run from inside the bundle for macOS to file its permissions under Dikte,
     # and a symlink somewhere else is a different process to macOS.
-    command = pathlib.Path.home() / ".local" / "bin" / "dikte"
+    command = _macos_command_path()
     binary = app / "Contents" / "MacOS" / "Dikte"
-    marker = "# Written by Dikte itself. Delete it to be rid of it.\n"
-    script = f'#!/bin/sh\n{marker}exec {shlex.quote(str(binary))} "$@"\n'
+    script = (f'#!/bin/sh\n{MACOS_COMMAND_MARKER}'
+              f'exec {shlex.quote(str(binary))} "$@"\n')
     # install-mac.sh writes its own wrapper here, naming the checkout's Python.
     # Ours only replaces a wrapper it wrote before, or nothing at all.
-    ours = command.exists() and marker in command.read_text(encoding="utf-8")
+    ours = _macos_command_is_ours(command)
     if (not command.exists() or ours or force) and _write(command, script):
         command.chmod(0o755)
         written.append(command)
@@ -470,6 +485,10 @@ def _macos_remove():
                        capture_output=True, check=False)
         agent.unlink()
         gone.append(agent)
+    command = _macos_command_path()
+    if _macos_command_is_ours(command):
+        command.unlink()
+        gone.append(command)
     return gone
 
 

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -358,6 +358,12 @@ class MacOS(Home):
              mock.patch.object(integrate, "_launchctl_reload"):
             return integrate.install(force=force)
 
+    def remove(self):
+        with Frozen("/Applications/Dikte.app/Contents/MacOS/Dikte",
+                    home=self.home, platform="darwin"), \
+             mock.patch("subprocess.run"):
+            return integrate.remove()
+
     def test_it_writes_a_login_item_and_the_command(self):
         app = self.home / "Applications" / "Dikte.app"
         (app / "Contents/MacOS").mkdir(parents=True)
@@ -417,6 +423,25 @@ class MacOS(Home):
         app = self.home / "Applications" / "Dikte.app"
         (app / "Contents/MacOS").mkdir(parents=True)
         self.install(app)
+        self.assertIn("install-mac.sh", command.read_text())
+
+    def test_removing_takes_back_the_login_item_and_command_it_wrote(self):
+        app = self.home / "Applications" / "Dikte.app"
+        (app / "Contents/MacOS").mkdir(parents=True)
+        self.install(app)
+        command = self.home / ".local/bin/dikte"
+
+        self.assertEqual(self.remove(), [self.agent(), command])
+        self.assertFalse(self.agent().exists())
+        self.assertFalse(command.exists())
+
+    def test_removing_leaves_another_installers_command_alone(self):
+        command = self.home / ".local/bin/dikte"
+        command.parent.mkdir(parents=True)
+        command.write_text("#!/bin/sh\n# Written by install-mac.sh.\n"
+                           "exec /usr/local/bin/python3 /src/__main__.py \"$@\"\n")
+
+        self.assertEqual(self.remove(), [])
         self.assertIn("install-mac.sh", command.read_text())
 
 


### PR DESCRIPTION
## What changed

- remove the downloaded macOS build's generated `~/.local/bin/dikte` wrapper when `dikte integrate --remove` runs
- identify the wrapper through the ownership marker already written by Dikte
- leave checkout-installed and unrelated commands untouched
- add regression coverage for both removal and preservation paths

## Why

The real Intel DMG test in #40 found that integration cleanup removed the LaunchAgent and launchctl service but left the generated command wrapper behind.

## Validation

- `python3 -m unittest tests.test_integrate.MacOS --verbose` — 7 passed
- `.venv/bin/python -m unittest tests.test_integrate --verbose` — 36 passed
- non-UI/tray unit modules — 970 passed, 43 skipped
- `python3 -m compileall -q dikte tests`
- `git diff --check`

Follow-up to #40.