### PR TITLE
Leave both halves of libxkbcommon to the system

### DIFF
--- a/packaging/dikte.spec
+++ b/packaging/dikte.spec
@@ -56,6 +56,18 @@ analysis = Analysis(                            # noqa: F821
     noarchive=False,
 )
 
+# Qt's xcb platform plugin uses libxkbcommon in two halves: the core library
+# and libxkbcommon-x11, which allocates keymap objects and hands them to the
+# core half to use and free, so the two must come from the same build. The
+# build machine has only the core half installed, which had PyInstaller
+# bundling that one while the other kept coming from the user's system, and a
+# 22.04-era core freeing what a current x11 half allocated is the startup
+# crash of issue #57. Ship neither: any desktop that can show a window
+# carries both, from one build.
+if not (MACOS or WINDOWS):
+    analysis.binaries = [entry for entry in analysis.binaries
+                         if "libxkbcommon" not in entry[0]]
+
 archive = PYZ(analysis.pure)                    # noqa: F821
 
 executable = EXE(                               # noqa: F821


### PR DESCRIPTION
Fixes #57.

## What was actually crashing

The reproduction on CachyOS + KDE Wayland + Turkish layout confirmed the segfault inside the bundled `libxkbcommon.so.0`, but the mechanism is not the one the report guessed. The bundled library alone parses current xkeyboard-config 2.48 Turkish keymaps fine, both from RMLVO names and from a compositor-produced keymap string.

The real problem is a mixed pair. `libQt6XcbQpa` links both `libxkbcommon.so.0` and `libxkbcommon-x11.so.0`, and the x11 half allocates keymap objects that the core half later uses and frees, so both must come from one build. The CI builder installs only `libxkbcommon0`, so PyInstaller bundled the core half while the x11 half kept loading from the user's system. gdb on the core dump shows exactly that: the bundled 22.04-era core (`xkb_keymap_unref`, highest version symbol `V_1.0.0`) crashing on an object the system's 1.13.2 `libxkbcommon-x11.so.0` allocated, both mapped into the same process. The keyboard layout only decides where the corruption surfaces: startup in the report, `QXcbConnection` teardown here.

## The fix

Ship neither half. The spec now drops every `libxkbcommon*` entry from the Linux bundle, so both libraries come from the user's system, from one build. Any desktop that can show a window carries them; the release workflow itself already installs the core one just to run Qt.

Verified by building the spec in an Ubuntu 22.04 container: no `libxkbcommon` in `_internal`, the other 66 shared libraries untouched. The 1.0.2 AppImage with the bundled copy removed by hand (the reporter's workaround, same effect as this change) runs cleanly on the same machine that reproduced the crash.