### PR TITLE
Drop three explanatory texts from the settings window

### DIFF
--- a/dikte/i18n.py
+++ b/dikte/i18n.py
@@ -244,16 +244,6 @@ TR = {
     "Connection works. {count} models visible.":
         "Bağlantı tamam. {count} model görünüyor.",
     "Clean the transcript with a model": "Transkripti bir modelle temizle",
-    "OpenRouter, Google AI Studio and OpenCode Go are the quick ones that need "
-    "nothing installed. llama.cpp runs here, on a model downloaded below. "
-    "Claude Code, Codex and Antigravity clean up on a subscription you already "
-    "have, without a second key, and take a few seconds longer because each "
-    "opens a session to do it.":
-        "OpenRouter, Google AI Studio ve OpenCode Go kurulum istemeyen hızlı "
-        "seçeneklerdir. llama.cpp burada, aşağıdan indirilen bir modelle "
-        "çalışır. Claude Code, Codex ve Antigravity temizliği hâlihazırda sahip "
-        "olduğun bir abonelik üzerinden, ikinci anahtar olmadan yapar; her biri "
-        "bunun için bir oturum açtığından birkaç saniye daha uzun sürer.",
     "{binary} is not on your PATH, so cleanup would fail and the raw transcript "
     "would be pasted. Install it, or pick another one above.":
         "{binary} PATH'te değil; temizleme başarısız olur ve ham transkript "
@@ -523,18 +513,6 @@ TR = {
 
     # --- settings: the agent ------------------------------------------------
     "Agent": "Ajan",
-    "This shortcut records the same way dictation does, but the transcript is "
-    "not what gets pasted. It goes to an agent as a command, and what comes "
-    "back is pasted instead: the answer to a question, or a sentence saying "
-    "what was done. Claude Code, Codex and Antigravity run as the session you "
-    "would have opened yourself, with your skills, your connected services and "
-    "your account.":
-        "Bu kısayol dikte ile aynı şekilde kaydeder, ama yapıştırılan şey "
-        "transkript değildir. Transkript bir ajana komut olarak gider ve yerine "
-        "oradan döneni yapıştırılır: bir sorunun cevabı ya da ne yapıldığını "
-        "söyleyen bir cümle. Claude Code, Codex ve Antigravity kendi açacağın "
-        "oturumun aynısı olarak çalışır: skill'lerinle, bağlı servislerinle "
-        "ve kendi hesabınla.",
     "How it runs": "Nasıl çalışıyor",
     "Runs on": "Şunun üstünde çalışır",
     "More thinking is slower, and you are standing in front of the screen while "
@@ -707,12 +685,6 @@ TR = {
 
     # --- settings: meeting --------------------------------------------------
     "Minutes": "Tutanaklar",
-    "A meeting is recorded from two devices at once: your microphone and "
-    "whatever comes out of your speakers. Nothing has to guess who was "
-    "speaking, because the two never share a channel.":
-        "Toplantı iki aygıttan aynı anda kaydedilir: mikrofonun ve hoparlöründen "
-        "çıkan ses. Kimin konuştuğunun tahmin edilmesi gerekmez, çünkü ikisi hiç "
-        "aynı kanala girmez.",
     "Sound": "Ses",
     "Same as dictation": "Diktedekiyle aynı",
     "Current output": "Geçerli çıkış",

--- a/dikte/settings_ui.py
+++ b/dikte/settings_ui.py
@@ -915,13 +915,6 @@ class SettingsWindow(QDialog):
         self.cleanup_provider = QComboBox()
         for label, value in CLEANUP_PROVIDERS:
             self.cleanup_provider.addItem(t(label), value)
-        self.cleanup_provider.setToolTip(t(
-            "OpenRouter, Google AI Studio and OpenCode Go are the quick ones "
-            "that need nothing installed. llama.cpp runs here, on a model "
-            "downloaded below. Claude Code, Codex and Antigravity clean up on "
-            "a subscription you already have, without a second key, and take a "
-            "few seconds longer because each opens a session to do it."
-        ))
         self.cleanup_provider.currentIndexChanged.connect(self._cleanup_provider_changed)
         orr_form.addRow(t("Runs on"), self.cleanup_provider)
 
@@ -1051,17 +1044,6 @@ class SettingsWindow(QDialog):
     def _assistant_tab(self):
         page = QWidget()
         layout = QVBoxLayout(page)
-        intro = QLabel(t(
-            "This shortcut records the same way dictation does, but the "
-            "transcript is not what gets pasted. It goes to an agent as a "
-            "command, and what comes back is pasted instead: the answer to a "
-            "question, or a sentence saying what was done. Claude Code, Codex "
-            "and Antigravity run as the session you would have opened yourself, "
-            "with your skills, your connected services and your account."
-        ))
-        intro.setWordWrap(True)
-        layout.addWidget(intro)
-
         self.assistant_found = QLabel("")
         self.assistant_found.setWordWrap(True)
         layout.addWidget(self.assistant_found)
@@ -1259,14 +1241,6 @@ class SettingsWindow(QDialog):
     def _meeting_tab(self):
         page = QWidget()
         layout = QVBoxLayout(page)
-        intro = QLabel(t(
-            "A meeting is recorded from two devices at once: your microphone and "
-            "whatever comes out of your speakers. Nothing has to guess who was "
-            "speaking, because the two never share a channel."
-        ))
-        intro.setWordWrap(True)
-        layout.addWidget(intro)
-
         sources = QGroupBox(t("Sound"))
         sources_form = QFormLayout(sources)
         self.meeting_mic = QComboBox()


### PR DESCRIPTION
## What changed

- The Agent tab no longer opens with the long intro paragraph explaining how the shortcut differs from dictation; the tab now starts at the "How it runs" box.
- The Meeting tab no longer opens with the "recorded from two devices at once" intro label; the tab now starts at the "Sound" box.
- The provider box under Transcript cleanup (the "Runs on" row in API and models) lost its hover tooltip comparing the providers.
- The orphaned Turkish translations for all three strings are removed from i18n.py.

## Why

The intro texts were long and not particularly clear, and the tooltip restated what the provider list itself already conveys. Pure removal, 54 deleted lines, no behavior change.

## Notes for review

Full test suite passes (1431 tests).