### PR TITLE
Let a concealed indicator pass clicks through to what is underneath

### DIFF
--- a/overlay.py
+++ b/overlay.py
@@ -66,10 +66,21 @@ class Overlay(QWidget):
         # One that can be clicked away has to receive the click, which means it
         # also swallows one aimed at whatever is underneath it. The rest stay
         # transparent to the mouse, as an indicator should be.
+        #
+        # WA_TransparentForMouseEvents alone is not enough for that: it only
+        # tells Qt not to deliver the click to this widget. The native window
+        # still owns the pixels as far as X11/Wayland is concerned, so a click
+        # there reaches nothing at all - and since a concealed indicator stays
+        # mapped (see _conceal), that made an invisible 460x56 dead zone in the
+        # corner that swallowed clicks meant for the app underneath. The window
+        # flag is what makes the compositor pass the click through.
         if dismissable:
             self.setCursor(Qt.CursorShape.PointingHandCursor)
         else:
             self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        # Both start out letting the mouse through; the dismissable one takes
+        # it only while it has something to dismiss (_sync_click_through).
+        self.setWindowFlag(Qt.WindowType.WindowTransparentForInput, True)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.resize(MIN_WIDTH, HEIGHT)
 
@@ -172,6 +183,7 @@ class Overlay(QWidget):
         if self._concealed:
             self.raise_()
             self._concealed = False
+        self._sync_click_through()
         if not self._anim.isActive():
             self._anim.start()
 
@@ -189,7 +201,25 @@ class Overlay(QWidget):
         self._anim.stop()
         self.state = "hidden"
         self._concealed = True
+        self._sync_click_through()
         self.repaint()
+
+    def _sync_click_through(self):
+        """A dismissable indicator takes the mouse only while there is
+        something to dismiss. The rest of the time - concealed, recording, or
+        showing an outcome - it must let clicks fall through to whatever is
+        underneath, exactly like the plain one. The flag is flipped on the
+        native window rather than the widget: QWidget.setWindowFlag would tear
+        the window down and build a new one, which is the very repaint flinch
+        _conceal keeps the window mapped to avoid."""
+        if not self.dismissable:
+            return
+        through = not self._can_dismiss
+        handle = self.windowHandle()
+        if handle is None:
+            self.setWindowFlag(Qt.WindowType.WindowTransparentForInput, through)
+        elif bool(handle.flags() & Qt.WindowType.WindowTransparentForInput) != through:
+            handle.setFlag(Qt.WindowType.WindowTransparentForInput, through)
 
     def _resize_to_content(self):
         if self.state in LIVE:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -385,6 +385,38 @@ class Overlay(DikteTest):
         self.assertTrue(widget.showing)
         self.assertFalse(widget.muted)
 
+    @staticmethod
+    def takes_the_mouse(widget):
+        # What the windowing system was told, not what the widget remembers:
+        # the flag is flipped on the native window once there is one.
+        from PyQt6.QtCore import Qt
+        handle = widget.windowHandle()
+        flags = handle.flags() if handle is not None else widget.windowFlags()
+        return not (flags & Qt.WindowType.WindowTransparentForInput)
+
+    def test_it_lets_a_click_through_to_what_is_underneath(self):
+        """A concealed indicator stays mapped in its corner. Without telling
+        the compositor to pass the mouse through, that is an invisible box
+        that eats every click aimed at the application below it."""
+        widget = self.overlay()
+        widget.show_done("Pasted")
+        self.assertFalse(self.takes_the_mouse(widget))
+        widget._conceal()
+        self.assertFalse(self.takes_the_mouse(widget))
+
+    def test_a_dismissable_one_takes_the_mouse_only_while_it_can_be_dismissed(self):
+        widget = self.overlay(dismissable=True)
+        widget.show_recording()
+        self.assertFalse(self.takes_the_mouse(widget))
+        widget.show_busy("Asking Claude…")
+        self.assertTrue(self.takes_the_mouse(widget))
+        widget.show_done("Pasted")
+        self.assertFalse(self.takes_the_mouse(widget))
+        widget.show_busy("Reading a web page…")
+        self.assertTrue(self.takes_the_mouse(widget))
+        widget.dismiss()
+        self.assertFalse(self.takes_the_mouse(widget))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What was wrong

On KDE Plasma 6 (Wayland, Dikte on xcb), clicks in the bottom-left corner of the screen sometimes reached nothing at all. It looked like the compositor dropping input, but it was the recording indicator.

`Overlay._conceal()` keeps the window mapped on purpose (so the app behind does not flinch on the next dictation), and relies on `WA_TransparentForMouseEvents` to stay out of the way. That attribute only stops Qt from delivering the click to the widget; the native window still owns its pixels as far as X11/Wayland is concerned. So after the first dictation there is an invisible box (up to 460x56) in the corner that swallows every click aimed at the application below it. The dismissable indicator had no mouse transparency at all.

Verified on the live window with python-xlib: `map_state=IsViewable`, input shape `(0,0,460,56)`, nothing painted.

## The fix

- Set `Qt.WindowType.WindowTransparentForInput` on both indicators. That is the flag Qt turns into an empty XShape input region on xcb and an empty `wl_surface` input region on Wayland, so the click goes to whatever is underneath.
- For the dismissable one, flip the flag on the native `QWindow` in `_sync_click_through()`: it takes the mouse only while `_can_dismiss` (a busy job), and lets clicks through while recording, showing an outcome, or concealed. Flipping it on the `QWindow` rather than via `QWidget.setWindowFlag` avoids tearing the window down and rebuilding it, which is the repaint `_conceal` exists to avoid.

Checked the resulting X input shapes in each state on a real display: empty everywhere except the dismissable indicator while busy.

## Tests

Two tests added to `tests/test_ui.py::Overlay` that read the flag off the native window across the state transitions. Full suite: 840 tests, OK.
