### PR TITLE
Say the download started before the first byte arrives

### DIFF
--- a/dikte/i18n.py
+++ b/dikte/i18n.py
@@ -793,6 +793,7 @@ TR = {
         "İndirildi, sürüm {version}. Vulkan sürümü yoktu, bu sürüm işlemcide çalışıyor.",
     "Fetching the model list…": "Model listesi çekiliyor…",
     "Downloading…": "İndiriliyor…",
+    "Starting the download…": "İndirme başlatılıyor…",
     "Downloading: {done} of {total}{share}": "İndiriliyor: {done} / {total}{share}",
     "Download stopped.": "İndirme durduruldu.",
     "Ready: {name}.": "Hazır: {name}.",

--- a/dikte/settings_ui.py
+++ b/dikte/settings_ui.py
@@ -701,12 +701,21 @@ class LocalModelBox(QGroupBox):
     def _download(self):
         if self._downloading:
             self._stop = True
+            # The flag is only read between blocks, and the wait for the server
+            # to answer is not between blocks: a click during it changes
+            # nothing on screen for as long as the connection takes.
+            self.status.setText(t("Stopping…"))
             return
         item = self._current_item()
         if item is None:
             return
         self._downloading, self._stop = True, False
         self._refresh_buttons()
+        # Opening the connection can take ten or twenty seconds, and the first
+        # byte counts are what the line below would otherwise wait for. Left
+        # saying "not downloaded yet" beside a button that now reads Stop, a
+        # download that started looks like a click that did not register.
+        self.status.setText(t("Starting the download…"))
 
         def work():
             try:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1336,6 +1336,28 @@ class LocalModels(DikteTest):
         self.assertIn("10", box.program_label.text())
         self.assertIn("20", box.status.text())
 
+    def test_a_download_says_something_before_the_first_byte(self):
+        # Opening the connection takes ten or twenty seconds, and the byte
+        # counts only start after it. The line underneath still read "has not
+        # been downloaded yet" beside a button that now said Stop, so a
+        # download that had started looked like a click that had not landed.
+        box = self.window(cfg.Config()).local_llm
+        box.load("", "ggml-org/SmolLM3-3B-GGUF")
+        box.repo.blockSignals(True)
+        box.repo.setCurrentText("ggml-org/SmolLM3-3B-GGUF")
+        box.repo.blockSignals(False)
+        box._on_listed([("models", [self._item("SmolLM3-Q4_K_M.gguf")],
+                         "ggml-org/SmolLM3-3B-GGUF")], "")
+        with mock.patch.object(settings_ui.threading, "Thread"):
+            box._download()
+        self.assertIn("Starting", box.status.text())
+        # And the same again for the stop, which is read between blocks and so
+        # not read at all while the connection is still being opened.
+        with mock.patch.object(settings_ui.threading, "Thread"):
+            box._download()
+        self.assertTrue(box._stop)
+        self.assertIn("Stopping", box.status.text())
+
     def test_a_long_model_name_is_not_cut_in_half(self):
         # The list under a combo box takes the box's width and elides what does
         # not fit, in the middle: "ggml-org/Qwen....7B-Base-GGUF".


### PR DESCRIPTION
Pressing Download on a model left the line under the box reading "X has not been downloaded yet" while the button beside it turned into Stop. The byte counts only start once `urlopen` has the connection, which can take ten or twenty seconds, and `_refresh_buttons` returns early while a download is running, so nothing on screen moved. A download that had started looked like a click that had not registered, and people pressed Stop over it.

Stop had the same gap the other way round. `should_stop` is read between blocks, and the wait for the server to answer is not between blocks, so a press during the connection changed nothing visible either.

`LocalModelBox._download` now writes "Starting the download…" as soon as the thread goes out, and "Stopping…" when the stop is asked for. The program download above already said "Downloading…" on the click, so it is untouched.

`tests/test_ui.py` covers both halves with the worker thread mocked out. Full UI suite passes (201 passed).