### PR TITLE
Measure a wrapped label against a width it actually has

### DIFF
--- a/dikte/settings_ui.py
+++ b/dikte/settings_ui.py
@@ -181,18 +181,34 @@ class WrappedLabel(QLabel):
         super().setText(text)
         self._fit()
 
+    def showEvent(self, event):
+        # Text set while the window was still being built was measured against
+        # nothing; this is the first moment the width means anything.
+        super().showEvent(event)
+        self._fit()
+
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._fit()
 
     def _fit(self):
+        # A label the layout has not placed yet is a handful of pixels wide,
+        # and wrapping a sentence against that width invents a hundred lines.
+        # The minimum set from it does not stay a minimum either: QLabel folds
+        # it into its own cached size hints and clears that cache only when the
+        # text changes, so the row stands thousands of pixels tall and carries
+        # the model box and everything under it off the bottom of the window
+        # until another publisher is picked. Nothing to measure against yet
+        # means nothing to claim yet, and the show and resize above come back
+        # for it.
+        if not self.isVisible() or self.width() <= 0:
+            return
         # Measured off the font rather than asked of the label, whose own answer
         # is floored by the minimum set here a moment ago and so only ever grows.
-        if self.width() > 0:
-            wrap = Qt.TextFlag.TextWordWrap | Qt.TextFlag.TextWrapAnywhere
-            box = QRect(0, 0, self.width(), 0)
-            self.setMinimumHeight(
-                self.fontMetrics().boundingRect(box, wrap, self.text()).height())
+        wrap = Qt.TextFlag.TextWordWrap | Qt.TextFlag.TextWrapAnywhere
+        box = QRect(0, 0, self.width(), 0)
+        self.setMinimumHeight(
+            self.fontMetrics().boundingRect(box, wrap, self.text()).height())
 
 
 class WheelGuard(QObject):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -14,7 +14,7 @@ import unittest
 from typing import ClassVar
 from unittest import mock
 
-from PyQt6.QtCore import QPoint, QPointF, Qt
+from PyQt6.QtCore import QPoint, QPointF, QRect, Qt
 from PyQt6.QtGui import QWheelEvent
 from PyQt6.QtWidgets import QApplication, QMessageBox
 
@@ -263,12 +263,19 @@ class Settings(DikteTest):
         self.assertEqual(label.minimumHeight(), 0)
         # Placed and shown, which is the first width worth measuring against.
         # The room the wrapping needs is claimed then, and it is the lines the
-        # sentence actually takes at this width rather than at the last one.
+        # sentence takes at this width rather than at the last one. Counted
+        # off the font rather than written down here, because how many lines
+        # 400 pixels hold is a different answer on every machine.
         label.resize(400, line)
         label.show()
-        self.assertGreater(label.minimumHeight(), line)
-        self.assertLessEqual(label.minimumHeight(), 4 * line)
-        self.assertLessEqual(label.sizeHint().height(), 4 * line)
+        wrap = Qt.TextFlag.TextWordWrap | Qt.TextFlag.TextWrapAnywhere
+        needed = label.fontMetrics().boundingRect(
+            QRect(0, 0, 400, 0), wrap, label.text()).height()
+        self.assertGreater(needed, line)      # or the sentence never wrapped
+        self.assertEqual(label.minimumHeight(), needed)
+        # And the label's own hints are the wrapping at this width too, not
+        # the hundred lines the eight pixel one asked for.
+        self.assertLessEqual(label.sizeHint().height(), 3 * needed)
 
     def test_saving_without_touching_anything_changes_nothing(self):
         """Every widget has to load what is stored, or Save writes its default

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -244,6 +244,32 @@ class Settings(DikteTest):
         label.resize(2000, line)
         self.assertLessEqual(label.minimumHeight(), line)
 
+    def test_a_label_written_before_the_layout_places_it_claims_nothing(self):
+        # The publisher note is written while the settings window is still
+        # being built, when the label is a handful of pixels wide. Wrapped
+        # against that width the sentence became a hundred lines, and the
+        # minimum taken from it did not stay a minimum: QLabel folds it into
+        # its own cached size hints and clears that cache only when the text
+        # changes. The group box stood thousands of pixels tall, with the
+        # model box and everything under it off the bottom of the window,
+        # until another publisher was picked.
+        label = settings_ui.WrappedLabel()
+        self.addCleanup(label.deleteLater)
+        line = label.fontMetrics().height()
+        label.resize(8, line)
+        label.setText("Google Gemma 4, the small one. The default: nothing "
+                      "else this size follows an instruction as closely, and "
+                      "cleanup is all instruction.")
+        self.assertEqual(label.minimumHeight(), 0)
+        # Placed and shown, which is the first width worth measuring against.
+        # The room the wrapping needs is claimed then, and it is the lines the
+        # sentence actually takes at this width rather than at the last one.
+        label.resize(400, line)
+        label.show()
+        self.assertGreater(label.minimumHeight(), line)
+        self.assertLessEqual(label.minimumHeight(), 4 * line)
+        self.assertLessEqual(label.sizeHint().height(), 4 * line)
+
     def test_saving_without_touching_anything_changes_nothing(self):
         """Every widget has to load what is stored, or Save writes its default
         over it. This says so for the whole table at once."""


### PR DESCRIPTION
Opening the settings window and picking a publisher on the API tab sometimes left everything below the publisher row blank: no model box, no status line, no local options. Picking another publisher brought them back.

## What was happening

The publisher note is written while the window is still being built, when its label is eight pixels wide. `WrappedLabel` wraps the text against its own width and claims the resulting height back as a minimum, and at eight pixels that sentence is 124 lines: `setMinimumHeight(2232)`.

That minimum does not stay a minimum. QLabel runs `sizeForWidth(...).expandedTo(minimumSize())` and caches the answer as its own `sizeHint` and `minimumSizeHint`, and it clears that cache only when the text changes. So the later resize dropped `minimumHeight` back to 54 while the cached hints stayed at 2232: the group box stood 2458 pixels tall and carried the model box off the bottom of the window. Changing the publisher rewrites the note, which clears the cache, which is why a second change fixed it.

Measured on a real session, before and after the fix:

```
before: note h=2232  minH=54  sizeHint=2232  group box=2458
after:  note h=72    minH=54  sizeHint=72    group box=298
```

## The change

`_fit` claims nothing while there is no width worth measuring against; the show and the resize come back for it once the layout has placed the label. Everything else about the class is unchanged.

## Note for a reviewer

This does not reproduce on Qt's offscreen platform, which hands the label a sensible width from the start, so the regression test drives the label to eight pixels itself rather than going through the settings window. Deleting the `showEvent` override fails it; deleting the guard in `_fit` fails it too.

`tests/test_ui.py` passes in full (203 tests). Four tests elsewhere fail in this checkout with and without this change (`test_hub.CacheLocation` and three `test_saving_without_touching_anything_changes_nothing`), which looks like leftover home-directory files in the worktree root rather than anything here.