### PR TITLE
Describe the binary the settings point at, not the one Dikte found

### DIFF
--- a/dikte/i18n.py
+++ b/dikte/i18n.py
@@ -806,6 +806,7 @@ TR = {
     "Local model": "Yerel model",
     "Not installed.": "Kurulu değil.",
     "Installed on the system: {path}": "Sistemde kurulu: {path}",
+    "Using custom build: {path}": "Özel derleme kullanılıyor: {path}",
     "Download again": "Yeniden indir",
     "Downloaded, version {version}.": "İndirildi, sürüm {version}.",
     "Downloaded, version {version}. There was no Vulkan build, "

--- a/dikte/settings_ui.py
+++ b/dikte/settings_ui.py
@@ -253,9 +253,11 @@ class LocalModelBox(QGroupBox):
 
     changed = pyqtSignal()
 
-    def __init__(self, program, title, models, model_path, repos=None, parent=None):
+    def __init__(self, program, title, models, model_path, binary=None,
+                 repos=None, parent=None):
         super().__init__(title, parent)
         self.program = program
+        self._binary = binary          # () -> a path set by hand, or ""
         self._models = models          # () -> [hub.Item], or (repo) -> [hub.Item]
         self._model_path = model_path  # (name) -> Path
         self._repos = repos            # None, or () -> [repo id]
@@ -417,12 +419,22 @@ class LocalModelBox(QGroupBox):
                 self._fill_repos(self.repository())
             self._fetch_models(self.repository())
 
+    def _program_path(self):
+        return ggml.program_path(self.program,
+                                 self._binary() if self._binary else "")
+
     def _show_program(self):
-        path = ggml.program_path(self.program)
+        path = self._program_path()
         if not path:
             self.program_label.setText(t("Not installed."))
             self.install_button.setText(t("Download"))
             self.install_button.setVisible(True)
+            return
+        if self._binary and self._binary():
+            # Neither a system copy nor one Dikte fetched, and "Downloaded"
+            # over a build someone made themselves is not true.
+            self.program_label.setText(t("Using custom build: {path}", path=path))
+            self.install_button.setVisible(False)
             return
         # A copy that is here is not a copy that is right. whisper.cpp releases
         # every few weeks, and a graphics card installed after Dikte was
@@ -835,7 +847,7 @@ class LocalModelBox(QGroupBox):
                   repo=self.repository(), cap=ggml.human_size(ggml.GGUF_MAX_BYTES)))
         elif not name:
             self.status.setText(t("Nothing downloaded yet."))
-        elif here and not ggml.program_path(self.program):
+        elif here and not self._program_path():
             # The model alone runs nothing, and "Ready" over a missing program
             # reads as though it does.
             self.status.setText(t("{name} is here, but the program above is "
@@ -1191,7 +1203,8 @@ class SettingsWindow(QDialog):
 
         self.local_whisper = LocalModelBox(
             ggml.WHISPER, t("On this machine"),
-            ggml.whisper_models, ggml.whisper_model_path)
+            ggml.whisper_models, ggml.whisper_model_path,
+            binary=lambda: self.conf["local_binary"])
         stt_form.addRow(self.local_whisper)
 
         self.local_gpu = QCheckBox(t("Use the graphics card"))
@@ -1300,7 +1313,9 @@ class SettingsWindow(QDialog):
 
         self.local_llm = LocalModelBox(
             ggml.LLAMA, t("On this machine"),
-            ggml.llm_quants, ggml.llm_model_path, repos=ggml.llm_repos)
+            ggml.llm_quants, ggml.llm_model_path,
+            binary=lambda: self.conf["local_llm_binary"],
+            repos=ggml.llm_repos)
         orr_form.addRow(self.local_llm)
 
         self.local_llm_gpu = QCheckBox(t("Use the graphics card"))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1461,6 +1461,29 @@ class LocalModels(DikteTest):
         self.assertNotIn("Ready", box.status.text())
         self.assertIn("program", box.status.text())
 
+    def test_a_program_set_in_the_settings_is_not_called_downloaded(self):
+        mine = self.path("my-whisper-server")
+        mine.write_text("#!/bin/sh\n")
+        mine.chmod(0o755)
+        self.patch_attr(ggml.shutil, "which", lambda name: None)
+        box = self.window(self.config(local_binary=str(mine))).local_whisper
+        self.assertIn(str(mine), box.program_label.text())
+        self.assertFalse(box.install_button.isVisibleTo(box))
+
+    def test_a_model_over_a_program_set_by_hand_is_ready(self):
+        # The program is there, it is just named by the settings rather than
+        # downloaded, and the status line looked past it.
+        mine = self.path("my-whisper-server")
+        mine.write_text("#!/bin/sh\n")
+        mine.chmod(0o755)
+        self.patch_attr(ggml.shutil, "which", lambda name: None)
+        path = ggml.whisper_model_path("ggml-small.bin")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"not really a model")
+        box = self.window(self.config(local_binary=str(mine))).local_whisper
+        box.load("ggml-small.bin")
+        self.assertIn("Ready", box.status.text())
+
     def test_changing_the_publisher_changes_the_model(self):
         # The model chosen under the old publisher is not published by the new
         # one. Carried over, it was added back as "not downloaded" and selected


### PR DESCRIPTION
### What changed
Now the Settings -> API and models says the custom binary. 

I compiled with whisper.cpp and llama.cpp with CUDA by myself and Dikte was using those. The one i downloaded through Dikte was wrongly quoting Dikte's binary than my own compiled and the other that i didn't download from Dikte was saying "Not installed." and a download button.
Now both are correctly quoting the custom binary and no download button.

To see the difference the screenshot before and after:

Before:
<img width="677" height="645" alt="image" src="https://github.com/user-attachments/assets/bf86ceb2-58cf-45ea-9a12-0f7f8e094e07" />

After:
<img width="683" height="642" alt="image" src="https://github.com/user-attachments/assets/7d974449-6026-4f32-b6a0-aa899fd1ae20" />

### Testing
python -m unittest discover: 1558 tests, all green. + new 2 test that are checks this fix and both of them were checked against a reverted fix and fail without it.

---
Also related to #72, which notes that nothing in the settings window or the CLI writes local_binary. This is the other half: nothing read it either.