### PR TITLE
ci: upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
@@ -107,7 +107,7 @@ jobs:
         shell: pwsh
         run: ./packaging/build-${{ matrix.kind }}.ps1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dikte-${{ matrix.os }}
           path: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - timeout-minutes: 5
@@ -65,7 +65,7 @@ jobs:
       version: ${{ steps.decide.outputs.version }}
       prerelease: ${{ steps.decide.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -124,11 +124,11 @@ jobs:
     needs: [version, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.version.outputs.ref }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: downloads
           merge-multiple: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
         python: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -60,9 +60,9 @@ jobs:
         python: ["3.11", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -101,9 +101,9 @@ jobs:
         python: ["3.11", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/whisper-vulkan.yml
+++ b/.github/workflows/whisper-vulkan.yml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Check out Dikte
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -66,7 +66,7 @@ jobs:
           [[ "$WHISPER_COMMIT" =~ ^[0-9a-f]{40}$ ]]
 
       - name: Check out pinned whisper.cpp source
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ggml-org/whisper.cpp
           ref: ${{ env.WHISPER_COMMIT }}
@@ -148,7 +148,7 @@ jobs:
         run: OUT_DIR=dist packaging/whisper-vulkan/smoke-runtime.sh vulkan
 
       - name: Upload reviewed outputs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: whisper-bin-ubuntu-vulkan-x64
           path: dist/*
@@ -169,7 +169,7 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Download the exact tested outputs
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: whisper-bin-ubuntu-vulkan-x64
           path: dist
@@ -178,12 +178,12 @@ jobs:
         run: (cd dist && sha256sum --check whisper-bin-ubuntu-vulkan-x64.tar.gz.sha256)
 
       - name: Attest build provenance
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: dist/whisper-bin-ubuntu-vulkan-x64.tar.gz
 
       - name: Attest SBOM to archive
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: dist/whisper-bin-ubuntu-vulkan-x64.tar.gz
           sbom-path: dist/whisper-bin-ubuntu-vulkan-x64.cdx.json


### PR DESCRIPTION
## Summary

- Upgrade official GitHub Actions from Node 20-based releases to current Node 24-based releases.
- Pin every external action to its reviewed immutable commit SHA.
- Preserve existing workflow triggers, permissions, inputs, and job behavior.

## Validation

- 1,556 existing tests passed locally.
- actionlint 1.7.12 and `git diff --check` passed.
- Fork-hosted Linux, macOS, Windows, packaging, and Vulkan CI passed (12 jobs).
- Workflow logs contain no Node 20 deprecation warnings, and GitHub reported zero annotations.

## Scope

This PR only updates GitHub Actions implementations. It does not change application code, runtime behavior, model UX, Python dependencies, or release logic.
