### PR TITLE
fix: expose AppImage version metadata

### DIFF
--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -55,6 +55,7 @@ cat > "$APPDIR/dikte.desktop" <<EOF
 [Desktop Entry]
 Type=Application
 Name=Dikte
+X-AppImage-Version=$VERSION
 Comment=Voice dictation: record, transcribe, clean up, paste
 Exec=dikte
 Icon=dikte

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -20,17 +20,6 @@ PACKAGING = ROOT / "packaging" / "whisper-vulkan"
 WORKFLOW = ROOT / ".github" / "workflows" / "whisper-vulkan.yml"
 
 
-class AppImagePackaging(unittest.TestCase):
-    def test_the_desktop_exposes_the_release_version_to_appimage_managers(self):
-        script = (ROOT / "packaging" / "build-appimage.sh").read_text(
-            encoding="utf-8")
-        marker = 'cat > "$APPDIR/dikte.desktop" <<EOF\n'
-        desktop = script.split(marker, 1)[1].split("\nEOF", 1)[0]
-        rendered = desktop.replace("$VERSION", "1.2.0")
-        self.assertEqual(
-            1, rendered.splitlines().count("X-AppImage-Version=1.2.0"))
-
-
 class WhisperVulkanPackaging(unittest.TestCase):
     @unittest.skipUnless(sys.platform != "win32" and shutil.which("bash"),
                          "bash syntax check is unavailable")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -20,6 +20,17 @@ PACKAGING = ROOT / "packaging" / "whisper-vulkan"
 WORKFLOW = ROOT / ".github" / "workflows" / "whisper-vulkan.yml"
 
 
+class AppImagePackaging(unittest.TestCase):
+    def test_the_desktop_exposes_the_release_version_to_appimage_managers(self):
+        script = (ROOT / "packaging" / "build-appimage.sh").read_text(
+            encoding="utf-8")
+        marker = 'cat > "$APPDIR/dikte.desktop" <<EOF\n'
+        desktop = script.split(marker, 1)[1].split("\nEOF", 1)[0]
+        rendered = desktop.replace("$VERSION", "1.2.0")
+        self.assertEqual(
+            1, rendered.splitlines().count("X-AppImage-Version=1.2.0"))
+
+
 class WhisperVulkanPackaging(unittest.TestCase):
     @unittest.skipUnless(sys.platform != "win32" and shutil.which("bash"),
                          "bash syntax check is unavailable")


### PR DESCRIPTION
## Summary
Add `X-AppImage-Version=$VERSION` to the embedded AppImage desktop entry so
AppImage managers such as Shelly can identify the installed version instead
of showing `Unknown` and offering the same release as an update.

## Verification
Extracted the built AppImage and confirmed that its embedded desktop entry
contains `X-AppImage-Version=1.2.0`, matching the application version.