### PR TITLE
Run platform UI screenshots only on demand

### DIFF
--- a/.github/workflows/ui-screenshots.yml
+++ b/.github/workflows/ui-screenshots.yml
@@ -1,8 +1,13 @@
 name: UI screenshots
+run-name: "UI screenshots (${{ inputs.pr && format('PR #{0}', inputs.pr) || github.ref_name }})"
 
 on:
-  pull_request:
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to capture (leave empty for the selected branch)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -26,6 +31,9 @@ jobs:
       QT_SCALE_FACTOR: "2"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || github.ref }}
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -55,4 +63,4 @@ jobs:
           name: ui-screenshots-${{ runner.os }}
           path: ui-screenshots/
           if-no-files-found: error
-          retention-days: 14
+          retention-days: 90


### PR DESCRIPTION
Platform screenshots currently run automatically on every pull request. Make the workflow manual-only, with an optional PR number that captures that PR's head across Linux, macOS and Windows; leaving it blank captures the selected branch. Checkout credentials are not persisted, and new screenshot artifacts are retained for 90 days. Existing runs are unchanged, including their original retention periods.

After merging, use Actions > UI screenshots > Run workflow and enter the PR number when needed. The run appears in Actions with the PR number in its title, rather than automatically becoming a check on that PR. The existing 132 reviewed images also remain in the local comparison archive.

Validation: YAML parsing, trigger/input/matrix/retention assertions and git diff --check passed. Independent correctness and security reviews found no issues. The new manual dispatch path has not been executed; the underlying three-platform capture job already passed in PR #87.
