### PR TITLE
Align history and meeting action rows

### DIFF
--- a/dikte/home_ui.py
+++ b/dikte/home_ui.py
@@ -311,7 +311,8 @@ class HomeWindow(QWidget):
         layout.addWidget(_button(t("Back to dictation"), lambda: self.show_mode("dictation")))
         layout.addWidget(self.settings.task_pages["history"], 1)
         self.settings.task_pages["history"].show()
-        layout.addWidget(_button(t("Open selected text"), self._open_selected))
+        actions = self.settings.history_actions
+        actions.insertWidget(actions.count() - 1, _button(t("Open selected text"), self._open_selected))
         self.settings.history.itemDoubleClicked.connect(self._open_selected)
         return page
 

--- a/dikte/settings_ui.py
+++ b/dikte/settings_ui.py
@@ -1985,6 +1985,7 @@ class SettingsWindow(QDialog):
         reload_ = QPushButton(t("Reload"))
         reload_.clicked.connect(self._load_minutes)
         row = QHBoxLayout()
+        row.addStretch()
         row.addWidget(copy)
         row.addWidget(self.minutes_retry)
         row.addWidget(folder)
@@ -2188,16 +2189,13 @@ class SettingsWindow(QDialog):
         clear.clicked.connect(self._clear_history)
         reload_ = QPushButton(t("Reload"))
         reload_.clicked.connect(self._load_history)
-        row = QHBoxLayout()
+        self.history_actions = row = QHBoxLayout()
         row.addWidget(copy)
         row.addWidget(delete)
+        row.addWidget(clear)
+        row.addWidget(reload_)
         row.addStretch()
         layout.addLayout(row)
-        more = QHBoxLayout()
-        more.addWidget(clear)
-        more.addWidget(reload_)
-        more.addStretch()
-        layout.addLayout(more)
         return page
 
     @staticmethod


### PR DESCRIPTION
History actions were split across three rows. Place Copy selected, Delete selected, Clear history, Reload and Open selected text in one compact row, and center the Meeting action row beneath the transcript. Existing callbacks and confirmation behavior are unchanged.

Validation: all 262 UI tests passed; isolated Linux offscreen captures at 620px and 1000px widths with 2x scale showed the expected layout without outer horizontal overflow. Independent correctness and security reviews found no issues. These new layouts have not been captured on macOS or Windows. Screenshot CI remains manual-only.
