### PR TITLE
Add DeepSeek cleanup provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ or runs it on the spot.
 
 Speech to text and cleanup each pick a provider in the settings window, and both
 run here by default, on models of your own. The cloud is the other option:
-speech to text on **OpenAI**, **Groq** or **OpenRouter** (`gpt-4o-transcribe`),
-cleanup on OpenRouter (`google/gemini-3.5-flash-lite`), on **Google AI Studio**
-(`gemini-3.5-flash-lite`), on **OpenCode Go** (`deepseek-v4-flash`) or, when one
-of them is installed, on Claude Code, Codex or Antigravity. The first three are
-a single HTTP request; the three CLIs each open a whole session to do it, which
-is where their few extra seconds go. The keys fall back to `OPENAI_API_KEY`,
-`GROQ_API_KEY`, `OPENROUTER_API_KEY`, `GEMINI_API_KEY` and `OPENCODE_API_KEY`,
-and are stored in
+speech to text on **OpenAI**, **Groq** or **OpenRouter** (`gpt-4o-transcribe`);
+cleanup on OpenRouter (`google/gemini-3.5-flash-lite`), **Google AI Studio**
+(`gemini-3.5-flash-lite`), **DeepSeek** (`deepseek-flash`), **OpenCode Go**
+(`deepseek-v4-flash`) or, when one of them is installed, Claude Code, Codex or
+Antigravity. The four hosted cleanup providers use one HTTP request; the three
+CLIs each open a whole session, which is where their few extra seconds go. The
+keys fall back to `OPENAI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`,
+`GEMINI_API_KEY`, `DEEPSEEK_API_KEY` and `OPENCODE_API_KEY`, and are stored in
 `~/.config/dikte/config.json`, mode 600, or in
 `~/Library/Application Support/Dikte` on a Mac. Cleanup can be switched off, in
 which case the raw transcript is pasted, and a thinking model's effort can be

--- a/README.tr.md
+++ b/README.tr.md
@@ -117,15 +117,16 @@ kurmaz, sayfayı açar. Genel sekmesi bu denetimi kapatır ya da anında çalı�
 Sesi yazıya çevirme ve temizleme, ayarlar penceresinde ayrı ayrı sağlayıcı
 seçer; ikisi de varsayılan olarak burada, kendi modellerinle çalışır. Bulutu
 seçersen sesi yazıya çevirme **OpenAI**, **Groq** ya da **OpenRouter**'da
-(varsayılan `gpt-4o-transcribe`), temizleme OpenRouter'da
+(varsayılan `gpt-4o-transcribe`); temizleme OpenRouter'da
 (`google/gemini-3.5-flash-lite`), **Google AI Studio**'da
-(`gemini-3.5-flash-lite`), **OpenCode Go**'da (`deepseek-v4-flash`) ya da
-kuruluysa Claude Code, Codex veya Antigravity'de çalışır. İlk üçü tek bir HTTP
-isteği; üç CLI ise bunun için birer oturum açar, fazladan giden birkaç saniye de
-oradan gelir. Anahtarları boş bırakırsan `OPENAI_API_KEY`, `GROQ_API_KEY`,
-`OPENROUTER_API_KEY`, `GEMINI_API_KEY` ve `OPENCODE_API_KEY` kullanılır;
-anahtarlar `~/.config/dikte/config.json` içinde, izinler 600, Mac'te ise
-`~/Library/Application Support/Dikte` altında.
+(`gemini-3.5-flash-lite`), **DeepSeek**'te (`deepseek-flash`), **OpenCode
+Go**'da (`deepseek-v4-flash`) ya da kuruluysa Claude Code, Codex veya
+Antigravity'de çalışır. Dört bulut temizleme sağlayıcısı tek bir HTTP isteği
+kullanır; üç CLI ise bunun için birer oturum açar, fazladan giden birkaç saniye
+de oradan gelir. Anahtarları boş bırakırsan `OPENAI_API_KEY`, `GROQ_API_KEY`,
+`OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY` ve `OPENCODE_API_KEY`
+kullanılır; anahtarlar `~/.config/dikte/config.json` içinde, izinler 600, Mac'te
+ise `~/Library/Application Support/Dikte` altında.
 Temizlemeyi tamamen kapatabilirsin, o zaman ham transkript yapıştırılır; modelin
 yanındaki kutudan düşünme seviyesini de seçebilirsin.
 

--- a/dikte/api.py
+++ b/dikte/api.py
@@ -653,11 +653,10 @@ def _thinking(payload, provider, reasoning):
     """Ask for as much thinking as this provider understands, or for none.
 
     An empty level means "whatever the model does on its own", so nothing is
-    sent. The three mean opposite things by that, which is why the setting is
-    kept per provider: OpenRouter's cleanup models answer straight away, while a
-    local model that was trained to think will think, and a Gemini Flash left to
-    itself thinks too. Cleanup is punctuation rather than a job worth thinking
-    about.
+    sent. Providers mean different things by that: OpenRouter's cleanup models
+    answer straight away, while a local model trained to think, Gemini Flash,
+    and DeepSeek think by default. Cleanup is punctuation rather than a job
+    worth thinking about.
     """
     if not reasoning:
         return
@@ -672,6 +671,14 @@ def _thinking(payload, provider, reasoning):
         # to decide for itself thinks, and thinking about a comma is the second
         # this provider was chosen to save.
         payload["reasoning_effort"] = GEMINI_EFFORT.get(reasoning, reasoning)
+    elif provider == "deepseek":
+        payload["thinking"] = {
+            "type": "disabled" if reasoning == "none" else "enabled"
+        }
+        if reasoning != "none":
+            payload["reasoning_effort"] = {
+                "minimal": "low", "medium": "high", "xhigh": "high",
+            }.get(reasoning, reasoning)
     elif reasoning != "none":
         # The thinking itself is never shown, so ask for it to be left out.
         payload["reasoning"] = {"effort": reasoning, "exclude": True}

--- a/dikte/cleanup.py
+++ b/dikte/cleanup.py
@@ -1,12 +1,12 @@
 """Who rewrites the transcript once it has been heard.
 
 Normally a small model over one HTTP request: a second, and a few tenths of a
-cent on OpenRouter or nothing at all on Google AI Studio's free tier. A machine
-with Claude Code, Codex or Antigravity on it is already paying for a model
-though, and the subscription that answers "put that in my calendar on Thursday"
-can just as well take the "eee"s out of a sentence. No second key, no second
-bill. It costs seconds rather than one, because a CLI opens a whole session to
-do it, which is the trade.
+cent on OpenRouter or DeepSeek, or nothing at all on Google AI Studio's free
+tier. A machine with Claude Code, Codex or Antigravity on it is already paying
+for a model though, and the subscription that answers "put that in my calendar
+on Thursday" can just as well take the "eee"s out of a sentence. No second key,
+no second bill. It costs seconds rather than one, because a CLI opens a whole
+session to do it, which is the trade.
 
 Whoever does it, the job is the same one: no tools, no files, no memory of the
 last dictation. There is nothing here to look up and nothing to carry over, and
@@ -29,7 +29,8 @@ from . import ggml
 from . import paths
 from .i18n import t
 
-PROVIDERS = ("openrouter", "gemini", "opencode", "local", "claude", "codex", "agy")
+PROVIDERS = ("openrouter", "gemini", "deepseek", "opencode", "local", "claude",
+             "codex", "agy")
 
 
 class CleanupError(api.ApiError):
@@ -67,6 +68,8 @@ def model(conf):
         return conf["cleanup_agy_model"].strip() or "agy"
     if name == "gemini":
         return conf["cleanup_gemini_model"]
+    if name == "deepseek":
+        return conf["cleanup_deepseek_model"]
     if name == "opencode":
         return conf["cleanup_opencode_model"]
     return conf["cleanup_model"]
@@ -92,6 +95,13 @@ def run(text, conf, system_prompt, timeout=180, aborter=None):
             reasoning=conf["cleanup_reasoning"],
             base_url=conf["gemini_base_url"], timeout=timeout,
             provider="gemini", service="Google AI Studio", aborter=aborter,
+        )
+    if name == "deepseek":
+        return api.cleanup(
+            text, conf.deepseek_key(), conf["cleanup_deepseek_model"], system_prompt,
+            reasoning=conf["cleanup_reasoning"],
+            base_url=conf["deepseek_base_url"], timeout=timeout,
+            provider="deepseek", service="DeepSeek", aborter=aborter,
         )
     if name == "opencode":
         return api.cleanup(

--- a/dikte/cli.py
+++ b/dikte/cli.py
@@ -513,7 +513,7 @@ def cmd_history_clear(opts):
 # --- settings ---------------------------------------------------------------
 
 SECRET_KEYS = ("openai_api_key", "groq_api_key", "openrouter_api_key",
-               "gemini_api_key", "opencode_api_key")
+               "gemini_api_key", "deepseek_api_key", "opencode_api_key")
 
 
 def _mask(key, value):
@@ -711,6 +711,16 @@ def cmd_test_key(opts):
             results["gemini"] = {"ok": True, "message": message}
         except api.ApiError as exc:
             results["gemini"] = {"ok": False, "message": str(exc)}
+    if opts.which in ("deepseek", "all"):
+        try:
+            count = len(api.openai_models(conf.deepseek_key(),
+                                          conf["deepseek_base_url"], "DeepSeek"))
+            results["deepseek"] = {
+                "ok": True,
+                "message": f"connection works, {count} models visible",
+            }
+        except api.ApiError as exc:
+            results["deepseek"] = {"ok": False, "message": str(exc)}
     if opts.which in ("opencode", "all"):
         try:
             count = len(api.openai_models(conf.opencode_key(),
@@ -961,6 +971,7 @@ def cmd_doctor(opts):
     cleanup_service, cleanup_key = {
         "openrouter": ("OpenRouter", conf.openrouter_key()),
         "gemini": ("Google AI Studio", conf.gemini_key()),
+        "deepseek": ("DeepSeek", conf.deepseek_key()),
         "opencode": ("OpenCode Go", conf.opencode_key()),
     }.get(cleaner, ("", ""))
     if cleanup_service:
@@ -1241,7 +1252,8 @@ def build_parser():
     models.set_defaults(func=cmd_models)
     test = leaf(subs, "test-key", "check the API keys")
     test.add_argument("which", nargs="?", default="all",
-                      choices=("all", *cfg.TRANSCRIBERS, "gemini", "opencode"))
+                      choices=("all", *cfg.TRANSCRIBERS, "gemini", "deepseek",
+                               "opencode"))
     test.set_defaults(func=cmd_test_key)
     leaf(subs, "doctor", "keys, programs, and what is missing").set_defaults(func=cmd_doctor)
 

--- a/dikte/config.py
+++ b/dikte/config.py
@@ -430,6 +430,8 @@ DEFAULTS = {
     # Google's OpenAI-compatible endpoint. Cleanup only: there is no
     # /audio/transcriptions behind it, so it is not one of the TRANSCRIBERS.
     "gemini_base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+    "deepseek_api_key": "",
+    "deepseek_base_url": "https://api.deepseek.com",
     "opencode_api_key": "",
     "opencode_base_url": "https://opencode.ai/zen/go/v1",
     "transcribe_provider": "local",  # "local", or a key of TRANSCRIBERS
@@ -463,6 +465,7 @@ DEFAULTS = {
     "cleanup_claude_model": "haiku",   # Claude Code: an alias, or a full model id
     "cleanup_codex_model": "",         # empty -> whatever Codex is set to
     "cleanup_gemini_model": "gemini-3.5-flash-lite",
+    "cleanup_deepseek_model": "deepseek-flash",
     "cleanup_agy_model": "",           # empty -> whatever Antigravity is set to
     "cleanup_opencode_model": "deepseek-v4-flash",
     "cleanup_reasoning": "",        # empty -> whatever the model does by default
@@ -704,6 +707,9 @@ class Config:
 
     def gemini_key(self):
         return self.api_key("gemini_api_key")
+
+    def deepseek_key(self):
+        return self.api_key("deepseek_api_key")
 
     def opencode_key(self):
         return self.api_key("opencode_api_key")

--- a/dikte/i18n.py
+++ b/dikte/i18n.py
@@ -42,13 +42,13 @@ def t(text, /, **kwargs):
 _TR_CASES = {
     "dative": {
         "Claude": "Claude'a", "Codex": "Codex'e", "OpenRouter": "OpenRouter'a",
-        "Google AI Studio": "Google AI Studio'ya", "Antigravity": "Antigravity'ye",
-        "OpenCode Go": "OpenCode Go'ya",
+        "Google AI Studio": "Google AI Studio'ya", "DeepSeek": "DeepSeek'e",
+        "Antigravity": "Antigravity'ye", "OpenCode Go": "OpenCode Go'ya",
     },
     "accusative": {
         "Claude": "Claude'u", "Codex": "Codex'i", "OpenRouter": "OpenRouter'ı",
-        "Google AI Studio": "Google AI Studio'yu", "Antigravity": "Antigravity'yi",
-        "OpenCode Go": "OpenCode Go'yu",
+        "Google AI Studio": "Google AI Studio'yu", "DeepSeek": "DeepSeek'i",
+        "Antigravity": "Antigravity'yi", "OpenCode Go": "OpenCode Go'yu",
     },
 }
 
@@ -309,11 +309,13 @@ TR = {
     "gsk_… (falls back to GROQ_API_KEY)": "gsk_… (boşsa GROQ_API_KEY kullanılır)",
     "sk-or-… (falls back to OPENROUTER_API_KEY)": "sk-or-… (boşsa OPENROUTER_API_KEY kullanılır)",
     "(falls back to GEMINI_API_KEY)": "(boşsa GEMINI_API_KEY kullanılır)",
+    "(falls back to DEEPSEEK_API_KEY)": "(boşsa DEEPSEEK_API_KEY kullanılır)",
     "(falls back to OPENCODE_API_KEY)": "(boşsa OPENCODE_API_KEY kullanılır)",
     "Test": "Test et",
     "Trying…": "Deneniyor…",
     "Runs on OpenRouter.": "OpenRouter üzerinde çalışır.",
     "Runs on Google AI Studio.": "Google AI Studio üzerinde çalışır.",
+    "Runs on DeepSeek.": "DeepSeek üzerinde çalışır.",
     "Runs on OpenCode Go.": "OpenCode Go üzerinde çalışır.",
     "Connection works. {count} audio models visible.":
         "Bağlantı tamam. {count} ses modeli görünüyor.",

--- a/dikte/settings_ui.py
+++ b/dikte/settings_ui.py
@@ -65,6 +65,7 @@ GEMINI_MODELS = [
     "gemini-3.5-flash-lite", "gemini-3.1-flash-lite",
     "gemini-2.5-flash-lite", "gemini-3.5-flash", "gemini-2.5-flash",
 ]
+DEEPSEEK_MODELS = ["deepseek-flash", "deepseek-v4-pro"]
 # agy's model ids carry the reasoning effort in their suffix, which is why one
 # model appears here at more than one level. The same list seeds two boxes:
 # cleanup, which wants the bottom rung, and the agent, which sometimes does not.
@@ -77,8 +78,9 @@ AGY_MODELS = [
 # agent can run on open a whole session to do the smaller job.
 CLEANUP_PROVIDERS = [
     ("OpenRouter", "openrouter"), ("Google AI Studio", "gemini"),
-    ("OpenCode Go", "opencode"), ("This machine (llama.cpp)", "local"),
-    ("Claude Code", "claude"), ("Codex", "codex"), ("Antigravity", "agy"),
+    ("DeepSeek", "deepseek"), ("OpenCode Go", "opencode"),
+    ("This machine (llama.cpp)", "local"), ("Claude Code", "claude"),
+    ("Codex", "codex"), ("Antigravity", "agy"),
 ]
 # Cleaning up a sentence is the lightest thing either of them will ever be
 # asked, so the small model comes first.
@@ -900,6 +902,7 @@ class SettingsWindow(QDialog):
 
     _models_loaded = pyqtSignal(list, str)
     _gemini_models_loaded = pyqtSignal(list, str)
+    _deepseek_models_loaded = pyqtSignal(list, str)
     _opencode_models_loaded = pyqtSignal(list, str)
     _transcribe_models_loaded = pyqtSignal(list, str)
     _codex_models_loaded = pyqtSignal(list)
@@ -989,6 +992,7 @@ class SettingsWindow(QDialog):
 
         self._models_loaded.connect(self._on_models_loaded)
         self._gemini_models_loaded.connect(self._on_gemini_models_loaded)
+        self._deepseek_models_loaded.connect(self._on_deepseek_models_loaded)
         self._transcribe_models_loaded.connect(self._on_transcribe_models_loaded)
         self._codex_models_loaded.connect(self._on_codex_models_loaded)
         self._opencode_models_loaded.connect(self._on_opencode_models_loaded)
@@ -1344,6 +1348,9 @@ class SettingsWindow(QDialog):
         self.gemini_key = self._key_row(
             keys_form, "gemini", t("(falls back to GEMINI_API_KEY)"),
             self._test_gemini, service="Google AI Studio")
+        self.deepseek_key = self._key_row(
+            keys_form, "deepseek", t("(falls back to DEEPSEEK_API_KEY)"),
+            self._test_deepseek, service="DeepSeek")
         self.opencode_key = self._key_row(
             keys_form, "opencode", t("(falls back to OPENCODE_API_KEY)"),
             self._test_opencode, service="OpenCode Go")
@@ -1457,6 +1464,14 @@ class SettingsWindow(QDialog):
         self.cleanup_gemini_model_row = self._row(
             self.cleanup_gemini_model, self.refresh_gemini_models)
         orr_form.addRow(t("Model"), self.cleanup_gemini_model_row)
+        self.cleanup_deepseek_model = QComboBox()
+        self.cleanup_deepseek_model.setEditable(True)
+        self.cleanup_deepseek_model.addItems(DEEPSEEK_MODELS)
+        self.refresh_deepseek_models = QPushButton(t("Fetch model list"))
+        self.refresh_deepseek_models.clicked.connect(self._load_deepseek_models)
+        self.cleanup_deepseek_model_row = self._row(
+            self.cleanup_deepseek_model, self.refresh_deepseek_models)
+        orr_form.addRow(t("Model"), self.cleanup_deepseek_model_row)
 
         # One row per provider rather than one box that means a different thing
         # in each: an OpenRouter id and a Claude alias do not belong in the same
@@ -2326,6 +2341,7 @@ class SettingsWindow(QDialog):
             self._key_fields[name].setText(conf[who.key])
             self._models[name] = conf[who.model]
         self.gemini_key.setText(conf["gemini_api_key"])
+        self.deepseek_key.setText(conf["deepseek_api_key"])
         self.opencode_key.setText(conf["opencode_api_key"])
         self._shown_provider = ""
         self._select_data(self.transcribe_provider, conf["transcribe_provider"])
@@ -2340,6 +2356,9 @@ class SettingsWindow(QDialog):
         self.cleanup_model.setCurrentText(conf["cleanup_model"])
         self.cleanup_gemini_model.setCurrentText(
             conf["cleanup_gemini_model"] or cfg.DEFAULTS["cleanup_gemini_model"]
+        )
+        self.cleanup_deepseek_model.setCurrentText(
+            conf["cleanup_deepseek_model"] or cfg.DEFAULTS["cleanup_deepseek_model"]
         )
         self.cleanup_claude_model.setCurrentText(conf["cleanup_claude_model"])
         self.cleanup_codex_model.setCurrentText(
@@ -2461,6 +2480,7 @@ class SettingsWindow(QDialog):
             conf[who.model] = self._models[name].strip() or cfg.DEFAULTS[who.model]
         conf["openrouter_file_model"] = self.file_model.currentText().strip()
         conf["gemini_api_key"] = self.gemini_key.text().strip()
+        conf["deepseek_api_key"] = self.deepseek_key.text().strip()
         conf["opencode_api_key"] = self.opencode_key.text().strip()
         conf["local_model"] = self.local_whisper.selected()
         conf["local_gpu"] = self.local_gpu.isChecked()
@@ -2473,6 +2493,10 @@ class SettingsWindow(QDialog):
         conf["cleanup_gemini_model"] = (
             self.cleanup_gemini_model.currentText().strip()
             or cfg.DEFAULTS["cleanup_gemini_model"]
+        )
+        conf["cleanup_deepseek_model"] = (
+            self.cleanup_deepseek_model.currentText().strip()
+            or cfg.DEFAULTS["cleanup_deepseek_model"]
         )
         conf["cleanup_claude_model"] = (self.cleanup_claude_model.currentText().strip()
                                         or cfg.DEFAULTS["cleanup_claude_model"])
@@ -2751,6 +2775,31 @@ class SettingsWindow(QDialog):
         self.cleanup_gemini_model.setCurrentText(current)
         self.models_label.setText(t("{count} models loaded.", count=len(models)))
 
+    def _load_deepseek_models(self):
+        self.refresh_deepseek_models.setEnabled(False)
+        self.models_label.setText(t("Fetching model list…"))
+        key, base = self._typed_key("deepseek")
+
+        def work():
+            try:
+                self._deepseek_models_loaded.emit(
+                    api.openai_models(key, base, "DeepSeek"), "")
+            except api.ApiError as exc:
+                self._deepseek_models_loaded.emit([], str(exc))
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _on_deepseek_models_loaded(self, models, error):
+        self.refresh_deepseek_models.setEnabled(True)
+        if error:
+            self.models_label.setText(t("Could not fetch the list: {error}", error=error))
+            return
+        current = self.cleanup_deepseek_model.currentText()
+        self.cleanup_deepseek_model.clear()
+        self.cleanup_deepseek_model.addItems(models)
+        self.cleanup_deepseek_model.setCurrentText(current)
+        self.models_label.setText(t("{count} models loaded.", count=len(models)))
+
     def _load_codex_models(self):
         """Ask Codex which models it offers, off the interface thread.
 
@@ -2855,6 +2904,12 @@ class SettingsWindow(QDialog):
         if gemini_key:
             jobs.append(("gemini",
                          lambda: api.gemini_models(gemini_key, gemini_base)))
+        deepseek_key = self.conf.deepseek_key()
+        deepseek_base = self.conf["deepseek_base_url"]
+        if deepseek_key:
+            jobs.append(("deepseek",
+                         lambda: api.openai_models(deepseek_key, deepseek_base,
+                                                   "DeepSeek")))
         opencode_key = self.conf.opencode_key()
         opencode_base = self.conf["opencode_base_url"]
         if opencode_key:
@@ -2875,6 +2930,12 @@ class SettingsWindow(QDialog):
     def _on_hosted_models_loaded(self, provider, models):
         if provider == "opencode":
             self._fill_opencode_boxes(models)
+            return
+        if provider == "deepseek":
+            current = self.cleanup_deepseek_model.currentText()
+            self.cleanup_deepseek_model.clear()
+            self.cleanup_deepseek_model.addItems(models)
+            self.cleanup_deepseek_model.setCurrentText(current)
             return
         combos = ((self.cleanup_model, self.meeting_model)
                   if provider == "openrouter" else (self.cleanup_gemini_model,))
@@ -2907,6 +2968,13 @@ class SettingsWindow(QDialog):
         self._test_key("gemini", lambda: t(
             "Connection works. {count} models visible.",
             count=len(api.gemini_models(key, base)),
+        ))
+
+    def _test_deepseek(self):
+        key, base = self._typed_key("deepseek")
+        self._test_key("deepseek", lambda: t(
+            "Connection works. {count} models visible.",
+            count=len(api.openai_models(key, base, "DeepSeek")),
         ))
 
     def _test_opencode(self):
@@ -3151,6 +3219,8 @@ class SettingsWindow(QDialog):
                                         provider == "openrouter")
         self.cleanup_form.setRowVisible(self.cleanup_gemini_model_row,
                                         provider == "gemini")
+        self.cleanup_form.setRowVisible(self.cleanup_deepseek_model_row,
+                                        provider == "deepseek")
         self.cleanup_form.setRowVisible(self.cleanup_claude_model,
                                         provider == "claude")
         self.cleanup_form.setRowVisible(self.cleanup_codex_model,
@@ -3173,6 +3243,8 @@ class SettingsWindow(QDialog):
             self.models_label.setText(t("Runs on Google AI Studio."))
         elif provider == "opencode":
             self.models_label.setText(t("Runs on OpenCode Go."))
+        elif provider == "deepseek":
+            self.models_label.setText(t("Runs on DeepSeek."))
         elif not binary:
             self.models_label.setText(t("Runs on OpenRouter."))
         elif found:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -513,6 +513,23 @@ class Cleanup(DikteTest):
                              service="Google AI Studio")
         self.assertNotIn("reasoning_effort", sent_json(calls[0]))
 
+    def test_deepseek_can_turn_thinking_off(self):
+        _, calls = self.call(chat_reply("Hello."), reasoning="none",
+                             provider="deepseek", service="DeepSeek")
+        payload = sent_json(calls[0])
+        self.assertEqual(payload["thinking"], {"type": "disabled"})
+        self.assertNotIn("reasoning_effort", payload)
+
+    def test_deepseek_maps_the_shared_effort_ladder(self):
+        for asked, expected in (("minimal", "low"), ("medium", "high"),
+                                ("xhigh", "high"), ("max", "max")):
+            with self.subTest(asked=asked):
+                _, calls = self.call(chat_reply("Hello."), reasoning=asked,
+                                     provider="deepseek", service="DeepSeek")
+                payload = sent_json(calls[0])
+                self.assertEqual(payload["thinking"], {"type": "enabled"})
+                self.assertEqual(payload["reasoning_effort"], expected)
+
     def test_a_missing_gemini_key_says_google_ai_studio(self):
         with self.assertRaises(api.ApiError) as caught:
             api.cleanup("hello", "", "gemini-3.5-flash-lite", "prompt",

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -61,6 +61,7 @@ class Provider(DikteTest):
         self.assertEqual(cleanup.executable("openrouter"), "")
         self.assertEqual(cleanup.executable("gemini"), "")
         self.assertEqual(cleanup.executable("opencode"), "")
+        self.assertEqual(cleanup.executable("deepseek"), "")
 
     def test_the_model_named_in_the_history_is_the_one_that_did_it(self):
         self.assertEqual(cleanup.model(self.config(cleanup_model="some/model")),
@@ -79,6 +80,9 @@ class Provider(DikteTest):
         self.assertEqual(
             cleanup.model(self.config(cleanup_provider="gemini")),
             "gemini-3.5-flash-lite")
+        self.assertEqual(
+            cleanup.model(self.config(cleanup_provider="deepseek")),
+            "deepseek-flash")
         # Antigravity is left on its own default the way Codex is.
         self.assertEqual(
             cleanup.model(self.config(cleanup_provider="agy")), "agy")
@@ -108,6 +112,35 @@ class OpenRouter(DikteTest):
         with patcher, mock.patch.object(api, "cleanup", return_value="Done."):
             cleanup.run("uh, done", conf, "the rules")
         self.assertEqual(calls, [])
+
+
+class DeepSeek(DikteTest):
+    def test_it_uses_deepseek_s_endpoint_key_and_model(self):
+        conf = self.config(cleanup_provider="deepseek",
+                           deepseek_api_key="sk-deepseek-test",
+                           cleanup_deepseek_model="deepseek-flash",
+                           cleanup_reasoning="none")
+        with mock.patch.object(api, "cleanup", return_value="Done.") as call:
+            self.assertEqual(cleanup.run("uh, done", conf, "the rules"), "Done.")
+        text, key, model, prompt = call.call_args.args
+        self.assertEqual(
+            (text, key, model, prompt),
+            ("uh, done", "sk-deepseek-test", "deepseek-flash", "the rules"),
+        )
+        self.assertEqual(call.call_args.kwargs["provider"], "deepseek")
+        self.assertEqual(call.call_args.kwargs["service"], "DeepSeek")
+        self.assertEqual(call.call_args.kwargs["base_url"],
+                         "https://api.deepseek.com")
+        self.assertEqual(call.call_args.kwargs["reasoning"], "none")
+
+    def test_no_cli_is_started_for_it(self):
+        conf = self.config(cleanup_provider="deepseek",
+                           deepseek_api_key="sk-deepseek-test")
+        patcher, calls = fake_cli(stdout="never")
+        with patcher, mock.patch.object(api, "cleanup", return_value="Done."):
+            cleanup.run("uh, done", conf, "the rules")
+        self.assertEqual(calls, [])
+
 
 
 class OpenCode(DikteTest):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -435,6 +435,16 @@ class Providers(DikteTest):
         self.assertEqual(code, 0)
         self.assertIn("opencode: connection works, 1 models visible", out)
 
+    def test_deepseek_is_a_choice_and_reports_under_its_own_name(self):
+        parser = cli.build_parser()
+        self.assertEqual(
+            parser.parse_args(["test-key", "deepseek"]).which, "deepseek")
+        self.write_config({"deepseek_api_key": "sk-deepseek-test"})
+        with fake_urlopen({"data": [{"id": "deepseek-flash"}]}):
+            code, out, _ = self.run_cmd(cli.cmd_test_key, which="deepseek")
+        self.assertEqual(code, 0)
+        self.assertIn("deepseek: connection works, 1 models visible", out)
+
 
 class Updates(DikteTest):
     """`dikte update` looks, says what it found, and installs nothing."""
@@ -523,6 +533,16 @@ class Doctor(DikteTest):
         self.assertIn("OpenCode Go key, cleaning up on glm-5.3",
                       self.run_doctor(as_json=False, cleanup_provider="opencode",
                                       cleanup_opencode_model="glm-5.3"))
+
+    def test_cleanup_on_deepseek_is_a_question_about_its_own_key(self):
+        reply = self.run_doctor(cleanup_provider="deepseek",
+                                cleanup_deepseek_model="deepseek-flash")
+        self.assertEqual(reply["cleanup"]["provider"], "deepseek")
+        self.assertEqual(reply["cleanup"]["model"], "deepseek-flash")
+        self.assertIn(
+            "DeepSeek key, cleaning up on deepseek-flash",
+            self.run_doctor(as_json=False, cleanup_provider="deepseek"),
+        )
 
     def test_it_survives_every_provider_cleanup_can_be_set_to(self):
         """It used to raise KeyError on the local model, whose executable is ""."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -604,12 +604,20 @@ class Defaults(unittest.TestCase):
         self.assertEqual(cfg.DEFAULTS["openai_api_key"], "")
         self.assertEqual(cfg.DEFAULTS["openrouter_api_key"], "")
         self.assertEqual(cfg.DEFAULTS["gemini_api_key"], "")
+        self.assertEqual(cfg.DEFAULTS["deepseek_api_key"], "")
         self.assertEqual(cfg.DEFAULTS["opencode_api_key"], "")
 
     def test_google_ai_studio_is_a_cleanup_provider_and_not_a_transcriber(self):
         """Its compatible endpoint has no /audio/transcriptions behind it."""
         self.assertNotIn("gemini", cfg.TRANSCRIBERS)
         self.assertIn("gemini", cleanup.PROVIDERS)
+
+    def test_deepseek_is_a_cleanup_provider_and_not_a_transcriber(self):
+        self.assertNotIn("deepseek", cfg.TRANSCRIBERS)
+        self.assertIn("deepseek", cleanup.PROVIDERS)
+        self.assertEqual(cfg.DEFAULTS["deepseek_base_url"],
+                         "https://api.deepseek.com")
+        self.assertEqual(cfg.DEFAULTS["cleanup_deepseek_model"], "deepseek-flash")
 
     def test_opencode_ships_on_its_own_endpoint(self):
         self.assertEqual(cfg.DEFAULTS["opencode_base_url"],

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -62,6 +62,7 @@ CHANGED = {
     "groq_api_key": "gsk-test-key",
     "openrouter_api_key": "sk-or-test-key",
     "gemini_api_key": "AIza-test-key",
+    "deepseek_api_key": "sk-deepseek-test-key",
     "transcribe_provider": "openrouter",
     "transcribe_model": "whisper-1",
     "groq_transcribe_model": "whisper-large-v3",
@@ -72,6 +73,7 @@ CHANGED = {
     "cleanup_claude_model": "opus",
     "cleanup_codex_model": "gpt-5",
     "cleanup_gemini_model": "gemini-2.5-flash",
+    "cleanup_deepseek_model": "deepseek-v4-pro",
     "cleanup_agy_model": "gemini-3.1-pro-low",
     "cleanup_reasoning": "high",
     "local_model": "ggml-small.bin",
@@ -363,6 +365,7 @@ class Settings(DikteTest):
         boxes = {"openrouter": window.cleanup_model_row,
                  "opencode": window.cleanup_opencode_model_row,
                  "claude": window.cleanup_claude_model,
+                 "deepseek": window.cleanup_deepseek_model_row,
                  "codex": window.cleanup_codex_model}
         for provider, box in boxes.items():
             with self.subTest(provider=provider):
@@ -394,6 +397,7 @@ class Settings(DikteTest):
             window.file_model,
             window.cleanup_model,
             window.cleanup_gemini_model,
+            window.cleanup_deepseek_model,
             window.cleanup_opencode_model,
             window.cleanup_agy_model,
             window.cleanup_claude_model,
@@ -514,10 +518,11 @@ class Settings(DikteTest):
     def test_a_key_on_file_is_fetched_with_at_open(self):
         window = self.window(self.config(openrouter_api_key="sk-or-x",
                                          gemini_api_key="AIza-x",
+                                         deepseek_api_key="sk-deepseek-x",
                                          opencode_api_key="opencode-x"))
         with mock.patch.object(settings_ui.threading, "Thread") as thread:
             REAL_LOAD_HOSTED_MODELS(window)
-        self.assertEqual(thread.call_count, 3)
+        self.assertEqual(thread.call_count, 4)
 
     def test_the_update_line_names_the_version_that_is_running(self):
         window = self.window(cfg.Config())
@@ -1966,6 +1971,7 @@ class LocalModels(DikteTest):
         window = self.window(cfg.Config())
         rows = {"openrouter": window.cleanup_model_row,
                 "gemini": window.cleanup_gemini_model_row,
+                "deepseek": window.cleanup_deepseek_model_row,
                 "claude": window.cleanup_claude_model,
                 "codex": window.cleanup_codex_model,
                 "agy": window.cleanup_agy_model}


### PR DESCRIPTION
## What

- add DeepSeek as a first-class cleanup provider
- expose API key, model discovery, and model selection in Settings and CLI
- map cleanup reasoning controls to DeepSeek thinking mode
- document `DEEPSEEK_API_KEY` and the default `deepseek-flash` model

## Verification

- `/opt/homebrew/bin/python3.14 -m unittest discover` (1680 tests, 44 skipped)
- live `dikte test-key deepseek --json`
- local Whisper + DeepSeek cleanup file transcription smoke test