### PR TITLE
Fix macOS Download button message to reference PATH

### DIFF
--- a/dikte/ggml.py
+++ b/dikte/ggml.py
@@ -623,8 +623,9 @@ def install_program(program, tag="", on_progress=None, should_stop=None,
         if sys.platform == "darwin" and program is WHISPER:
             raise LocalError(t(
                 "whisper.cpp has no macOS build, and Homebrew's leaves out the "
-                "server. Build whisper-server yourself and give its path here, "
-                "or transcribe in the cloud. See the README."
+                "server. Build it (cmake -B build -DWHISPER_BUILD_SERVER=ON "
+                "-DGGML_METAL=ON && cmake --build build -j), put the binary "
+                "on the PATH, or transcribe in the cloud. See the README."
             ))
         raise LocalError(t("{repo} {tag} has no build for this machine.",
                            repo=program.repo, tag=tag))

--- a/tests/test_ggml.py
+++ b/tests/test_ggml.py
@@ -415,7 +415,8 @@ class InstallProgram(Local):
         with fake_urlopen(listing):
             with self.assertRaises(ggml.LocalError) as caught:
                 ggml.install_program(ggml.WHISPER)
-        self.assertIn("Build whisper-server yourself", str(caught.exception))
+        self.assertIn("Build it (cmake", str(caught.exception))
+        self.assertIn("put the binary on the PATH", str(caught.exception))
 
     def test_a_mac_uses_the_native_llama_archive_instead_of_ubuntu(self):
         self.patch_attr(sys, "platform", "darwin")


### PR DESCRIPTION
Fixes #72

## Problem
The error message on macOS said "Build whisper-server yourself and give its path here", but there is no such field in the settings UI or CLI to configure `local_binary`.

## Solution
Changed the message to tell users to:
1. Build whisper-server with the exact cmake command (matching README)
2. Put the binary on the PATH (which actually works via `shutil.which`)

## Changes
- Updated error message in `dikte/ggml.py` to reference PATH and include full build command
- Updated test in `tests/test_ggml.py` to match new message
- All 1673 tests pass ✅

## Testing
```bash
python -m unittest discover
# Ran 1673 tests in 36.034s
# OK
```