### PR TITLE
Prepare the managed Whisper v1.9.4 dependency bundle

### DIFF
--- a/.github/workflows/whisper-vulkan.yml
+++ b/.github/workflows/whisper-vulkan.yml
@@ -46,7 +46,7 @@ env:
   WHISPER_VERSION: ${{ inputs.whisper_version || '1.9.4' }}
   WHISPER_COMMIT: ${{ inputs.whisper_commit || '927cfce34f31707e17f2bff35c349632fb9e2c3a' }}
   REVIEWED_WHISPER_VERSION: "1.9.4"
-  REVIEWED_WHISPER_SHA256: 042769c8e70c1f603b0eac8dd57bca4eaaf369f68e1e3cf6a25d1b5984aba055
+  REVIEWED_WHISPER_SHA256: 381ec8f07071d616e243b94d275e29763d6d2b4c7204017c166caf389e1f2349
 
 jobs:
   build:
@@ -128,7 +128,9 @@ jobs:
           test "$actual" = "$expected"
 
       - name: Validate archive and ELF contract
-        run: OUT_DIR=dist packaging/whisper-vulkan/validate-package.sh
+        run: >-
+          OUT_DIR=dist SOURCE_DIR=vendor/whisper.cpp
+          packaging/whisper-vulkan/validate-package.sh
 
       - name: Schema-validate CycloneDX 1.6 SBOM
         run: |

--- a/.github/workflows/whisper-vulkan.yml
+++ b/.github/workflows/whisper-vulkan.yml
@@ -1,9 +1,9 @@
 name: whisper.cpp Vulkan bundle
 
 # Only what the bundle is built from. Compiling the Vulkan shaders takes
-# tens of minutes, and a README typo is not worth one: what ties ggml.py to
-# this release is a handful of assertions in tests/test_packaging.py, and
-# those run on every pull request in milliseconds.
+# tens of minutes, and a README typo is not worth one. The dependency bundle
+# can be reviewed and published before the installer switches to it; both
+# contracts are covered by tests/test_packaging.py.
 on:
   pull_request:
     paths:
@@ -14,12 +14,12 @@ on:
       whisper_version:
         description: Upstream whisper.cpp version (without v)
         required: true
-        default: "1.9.3"
+        default: "1.9.4"
         type: string
       whisper_commit:
         description: Peeled commit SHA for that reviewed upstream tag
         required: true
-        default: "371b5a7561823ab2bb32142d2751e35e7534727b"
+        default: "927cfce34f31707e17f2bff35c349632fb9e2c3a"
         type: string
       expected_sha256:
         description: >-
@@ -43,10 +43,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  WHISPER_VERSION: ${{ inputs.whisper_version || '1.9.3' }}
-  WHISPER_COMMIT: ${{ inputs.whisper_commit || '371b5a7561823ab2bb32142d2751e35e7534727b' }}
-  REVIEWED_WHISPER_VERSION: "1.9.3"
-  REVIEWED_WHISPER_SHA256: c25ca76504144da488eb74441390a7b9aa7ce547e5f2f391cbd831253c9b54d8
+  WHISPER_VERSION: ${{ inputs.whisper_version || '1.9.4' }}
+  WHISPER_COMMIT: ${{ inputs.whisper_commit || '927cfce34f31707e17f2bff35c349632fb9e2c3a' }}
+  REVIEWED_WHISPER_VERSION: "1.9.4"
+  REVIEWED_WHISPER_SHA256: 042769c8e70c1f603b0eac8dd57bca4eaaf369f68e1e3cf6a25d1b5984aba055
 
 jobs:
   build:

--- a/packaging/whisper-vulkan/build-package.sh
+++ b/packaging/whisper-vulkan/build-package.sh
@@ -54,6 +54,15 @@ cp -a "$build/bin"/libggml.so* "$root/"
 cp -a "$build/bin"/libggml-base.so* "$root/"
 cp -a "$build/bin"/libggml-cpu*.so* "$root/"
 cp -a "$build/bin"/libggml-vulkan.so* "$root/"
+ggml_libraries=()
+for library in "$root"/libggml.so.*.*.*; do
+  if [[ -f "$library" && ! -L "$library" ]]; then
+    ggml_libraries+=("$library")
+  fi
+done
+test "${#ggml_libraries[@]}" -eq 1
+GGML_VERSION="${ggml_libraries[0]##*/libggml.so.}"
+[[ "$GGML_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
 
 # Strip real ELF files only; preserve the SONAME symlink chains.
 while IFS= read -r -d '' file; do
@@ -106,6 +115,7 @@ EOF
 
 # A deterministic CycloneDX sidecar generated from the files actually shipped.
 ROOT="$root" VERSION="$WHISPER_VERSION" COMMIT="$WHISPER_COMMIT" EPOCH="$SOURCE_DATE_EPOCH" \
+GGML_VERSION="$GGML_VERSION" \
 python3 /packaging/make-sbom.py > "$root/$asset.cdx.json"
 
 (

--- a/packaging/whisper-vulkan/build-package.sh
+++ b/packaging/whisper-vulkan/build-package.sh
@@ -54,16 +54,6 @@ cp -a "$build/bin"/libggml.so* "$root/"
 cp -a "$build/bin"/libggml-base.so* "$root/"
 cp -a "$build/bin"/libggml-cpu*.so* "$root/"
 cp -a "$build/bin"/libggml-vulkan.so* "$root/"
-ggml_libraries=()
-for library in "$root"/libggml.so.*.*.*; do
-  if [[ -f "$library" && ! -L "$library" ]]; then
-    ggml_libraries+=("$library")
-  fi
-done
-test "${#ggml_libraries[@]}" -eq 1
-GGML_VERSION="${ggml_libraries[0]##*/libggml.so.}"
-[[ "$GGML_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-
 # Strip real ELF files only; preserve the SONAME symlink chains.
 while IFS= read -r -d '' file; do
   if file "$file" | grep -q ELF; then
@@ -114,8 +104,8 @@ cat > "$root/BUILD-INFO.json" <<EOF
 EOF
 
 # A deterministic CycloneDX sidecar generated from the files actually shipped.
-ROOT="$root" VERSION="$WHISPER_VERSION" COMMIT="$WHISPER_COMMIT" EPOCH="$SOURCE_DATE_EPOCH" \
-GGML_VERSION="$GGML_VERSION" \
+ROOT="$root" SOURCE_DIR="$source_copy" VERSION="$WHISPER_VERSION" \
+COMMIT="$WHISPER_COMMIT" EPOCH="$SOURCE_DATE_EPOCH" \
 python3 /packaging/make-sbom.py > "$root/$asset.cdx.json"
 
 (

--- a/packaging/whisper-vulkan/make-sbom.py
+++ b/packaging/whisper-vulkan/make-sbom.py
@@ -10,6 +10,7 @@ root = Path(os.environ["ROOT"])
 version = os.environ["VERSION"]
 commit = os.environ["COMMIT"]
 epoch = int(os.environ["EPOCH"])
+ggml_version = os.environ["GGML_VERSION"]
 asset = "whisper-bin-ubuntu-vulkan-x64"
 sbom_path = root / f"{asset}.cdx.json"
 
@@ -35,7 +36,7 @@ ts = datetime.datetime.fromtimestamp(
     epoch, datetime.timezone.utc,
 ).isoformat().replace("+00:00", "Z")
 root_ref = f"pkg:github/ggml-org/whisper.cpp@{version}?commit={commit}"
-ggml_ref = "pkg:github/ggml-org/ggml@0.20.2"
+ggml_ref = f"pkg:github/ggml-org/ggml@v{ggml_version}"
 httplib_ref = "pkg:github/yhirose/cpp-httplib@0.20.0"
 json_ref = "pkg:github/nlohmann/json@3.11.2"
 
@@ -78,7 +79,7 @@ sbom = {
             "bom-ref": ggml_ref,
             "group": "ggml-org",
             "name": "ggml",
-            "version": "0.20.2",
+            "version": ggml_version,
             "purl": ggml_ref,
             "licenses": [{"expression": "MIT"}],
             "properties": [{

--- a/packaging/whisper-vulkan/make-sbom.py
+++ b/packaging/whisper-vulkan/make-sbom.py
@@ -3,15 +3,47 @@ import datetime
 import hashlib
 import json
 import os
+import re
 import uuid
 from pathlib import Path
 
 root = Path(os.environ["ROOT"])
+source = Path(os.environ["SOURCE_DIR"])
 version = os.environ["VERSION"]
 commit = os.environ["COMMIT"]
 epoch = int(os.environ["EPOCH"])
-ggml_version = os.environ["GGML_VERSION"]
 asset = "whisper-bin-ubuntu-vulkan-x64"
+
+
+def one_match(pattern, path, component):
+    matches = re.findall(pattern, path.read_text(encoding="utf-8"), re.MULTILINE)
+    if len(matches) != 1:
+        raise ValueError(f"expected one {component} version in {path}, got {matches}")
+    return matches[0]
+
+
+def numeric_version(version, component):
+    if not re.fullmatch(r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)", version):
+        raise ValueError(f"invalid {component} version: {version}")
+    return version
+
+
+ggml_libraries = [path for path in root.glob("libggml.so.*.*.*")
+                  if path.is_file() and not path.is_symlink()]
+if len(ggml_libraries) != 1:
+    raise ValueError(f"expected one versioned GGML library, got {ggml_libraries}")
+ggml_version = numeric_version(
+    ggml_libraries[0].name.removeprefix("libggml.so."), "GGML",
+)
+httplib_version = numeric_version(one_match(
+    r'^#define\s+CPPHTTPLIB_VERSION\s+"([^"]+)"\s*$',
+    source / "examples/server/httplib.h", "cpp-httplib",
+), "cpp-httplib")
+json_header = source / "examples/json.hpp"
+json_version = numeric_version(".".join(one_match(
+    rf"^#define\s+NLOHMANN_JSON_VERSION_{part}\s+([0-9]+)(?:\s|$).*",
+    json_header, f"nlohmann-json {part.lower()}",
+) for part in ("MAJOR", "MINOR", "PATCH")), "nlohmann-json")
 sbom_path = root / f"{asset}.cdx.json"
 
 def digest(path):
@@ -37,8 +69,8 @@ ts = datetime.datetime.fromtimestamp(
 ).isoformat().replace("+00:00", "Z")
 root_ref = f"pkg:github/ggml-org/whisper.cpp@{version}?commit={commit}"
 ggml_ref = f"pkg:github/ggml-org/ggml@v{ggml_version}"
-httplib_ref = "pkg:github/yhirose/cpp-httplib@0.20.0"
-json_ref = "pkg:github/nlohmann/json@3.11.2"
+httplib_ref = f"pkg:github/yhirose/cpp-httplib@v{httplib_version}"
+json_ref = f"pkg:github/nlohmann/json@v{json_version}"
 
 sbom = {
     "bomFormat": "CycloneDX",
@@ -92,7 +124,7 @@ sbom = {
             "bom-ref": httplib_ref,
             "group": "yhirose",
             "name": "cpp-httplib",
-            "version": "0.20.0",
+            "version": httplib_version,
             "purl": httplib_ref,
             "licenses": [{"expression": "MIT"}],
         },
@@ -101,7 +133,7 @@ sbom = {
             "bom-ref": json_ref,
             "group": "nlohmann",
             "name": "json",
-            "version": "3.11.2",
+            "version": json_version,
             "purl": json_ref,
             "licenses": [{"expression": "MIT"}],
         },

--- a/packaging/whisper-vulkan/validate-package.sh
+++ b/packaging/whisper-vulkan/validate-package.sh
@@ -129,8 +129,8 @@ for family, versions in seen.items():
     print(f'maximum {family} symbol:', '.'.join(map(str, max(versions))))
 PY
 
-python3 - "$root/$asset.cdx.json" <<'PY'
-import json, pathlib, sys
+python3 - "$root/$asset.cdx.json" "$SOURCE_DIR" <<'PY'
+import json, pathlib, re, sys
 with open(sys.argv[1], encoding='utf-8') as stream:
     doc = json.load(stream)
 assert doc['bomFormat'] == 'CycloneDX'
@@ -138,20 +138,45 @@ assert doc['specVersion'] == '1.6'
 assert doc['metadata']['component']['name'] == 'whisper-server'
 assert len(doc['components']) >= 3
 root = pathlib.Path(sys.argv[1]).parent
+source = pathlib.Path(sys.argv[2])
+
+def one_match(pattern, path):
+    matches = re.findall(pattern, path.read_text(encoding='utf-8'), re.MULTILINE)
+    assert len(matches) == 1, (path, matches)
+    return matches[0]
+
+def numeric_version(version):
+    assert re.fullmatch(
+        r'(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)',
+        version,
+    ), version
+    return version
+
 libraries = [path for path in root.glob('libggml.so.*.*.*')
              if path.is_file() and not path.is_symlink()]
 assert len(libraries) == 1, libraries
-version = libraries[0].name.removeprefix('libggml.so.')
-assert version.count('.') == 2 and all(
-    part.isdigit() and (part == '0' or not part.startswith('0'))
-    for part in version.split('.')
-), version
-ggml_components = [component for component in doc['components']
-                   if component['name'] == 'ggml']
-assert len(ggml_components) == 1, ggml_components
-ggml = ggml_components[0]
-assert ggml['version'] == version, (ggml['version'], version)
-assert ggml['purl'] == f'pkg:github/ggml-org/ggml@v{version}'
+ggml_version = numeric_version(libraries[0].name.removeprefix('libggml.so.'))
+httplib_version = numeric_version(one_match(
+    r'^#define\s+CPPHTTPLIB_VERSION\s+"([^"]+)"\s*$',
+    source / 'examples/server/httplib.h',
+))
+json_header = source / 'examples/json.hpp'
+json_version = numeric_version('.'.join(one_match(
+    rf'^#define\s+NLOHMANN_JSON_VERSION_{part}\s+([0-9]+)(?:\s|$).*',
+    json_header,
+) for part in ('MAJOR', 'MINOR', 'PATCH')))
+expected = {
+    'ggml': ('ggml-org/ggml', ggml_version),
+    'cpp-httplib': ('yhirose/cpp-httplib', httplib_version),
+    'json': ('nlohmann/json', json_version),
+}
+for name, (repository, version) in expected.items():
+    components = [component for component in doc['components']
+                  if component['name'] == name]
+    assert len(components) == 1, (name, components)
+    component = components[0]
+    assert component['version'] == version, (name, component['version'], version)
+    assert component['purl'] == f'pkg:github/{repository}@v{version}'
 print('SBOM components:', len(doc['components']))
 PY
 

--- a/packaging/whisper-vulkan/validate-package.sh
+++ b/packaging/whisper-vulkan/validate-package.sh
@@ -130,13 +130,28 @@ for family, versions in seen.items():
 PY
 
 python3 - "$root/$asset.cdx.json" <<'PY'
-import json, sys
+import json, pathlib, sys
 with open(sys.argv[1], encoding='utf-8') as stream:
     doc = json.load(stream)
 assert doc['bomFormat'] == 'CycloneDX'
 assert doc['specVersion'] == '1.6'
 assert doc['metadata']['component']['name'] == 'whisper-server'
 assert len(doc['components']) >= 3
+root = pathlib.Path(sys.argv[1]).parent
+libraries = [path for path in root.glob('libggml.so.*.*.*')
+             if path.is_file() and not path.is_symlink()]
+assert len(libraries) == 1, libraries
+version = libraries[0].name.removeprefix('libggml.so.')
+assert version.count('.') == 2 and all(
+    part.isdigit() and (part == '0' or not part.startswith('0'))
+    for part in version.split('.')
+), version
+ggml_components = [component for component in doc['components']
+                   if component['name'] == 'ggml']
+assert len(ggml_components) == 1, ggml_components
+ggml = ggml_components[0]
+assert ggml['version'] == version, (ggml['version'], version)
+assert ggml['purl'] == f'pkg:github/ggml-org/ggml@v{version}'
 print('SBOM components:', len(doc['components']))
 PY
 

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -160,7 +160,7 @@ class WhisperVulkanPackaging(unittest.TestCase):
         self.assertIn("libggml-cpu*.so", script)
         self.assertIn("libggml-vulkan.so", script)
 
-    def test_the_dependency_release_matches_the_installer(self):
+    def test_the_dependency_candidate_can_precede_the_installer_pin(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         script = (PACKAGING / "build-package.sh").read_text(
             encoding="utf-8")
@@ -170,11 +170,12 @@ class WhisperVulkanPackaging(unittest.TestCase):
         self.assertIn("RELEASE_TAG: whisper.cpp-v${{ inputs.whisper_version }}",
                       workflow)
         self.assertIn("WHISPER_VERSION:=1.9.3", script)
-        commit = "371b5a7561823ab2bb32142d2751e35e7534727b"
-        self.assertIn(f"WHISPER_COMMIT:={commit}", script)
+        self.assertIn("REVIEWED_WHISPER_VERSION: \"1.9.4\"", workflow)
+        commit = "927cfce34f31707e17f2bff35c349632fb9e2c3a"
+        digest = "042769c8e70c1f603b0eac8dd57bca4eaaf369f68e1e3cf6a25d1b5984aba055"
         self.assertIn(commit, workflow)
+        self.assertIn(digest, workflow)
         self.assertIn(ggml.MANAGED_WHISPER_VULKAN, workflow)
-        self.assertIn(ggml.MANAGED_WHISPER_SHA256, workflow)
 
     def test_the_bundle_carries_metadata_and_all_required_licenses(self):
         script = (PACKAGING / "build-package.sh").read_text(
@@ -194,6 +195,7 @@ class WhisperVulkanPackaging(unittest.TestCase):
                 "VERSION": "1.9.3",
                 "COMMIT": "371b5a7561823ab2bb32142d2751e35e7534727b",
                 "EPOCH": "1787219223",
+                "GGML_VERSION": "9.8.7",
             }
             with sbom.open("w", encoding="utf-8") as output:
                 subprocess.run(
@@ -209,8 +211,11 @@ class WhisperVulkanPackaging(unittest.TestCase):
 
     def test_the_sbom_lists_ggml(self):
         document, _ = self._make_test_sbom()
-        names = {component["name"] for component in document["components"]}
-        self.assertIn("ggml", names)
+        ggml_component = next(component for component in document["components"]
+                              if component["name"] == "ggml")
+        self.assertEqual(ggml_component["version"], "9.8.7")
+        self.assertEqual(ggml_component["purl"],
+                         "pkg:github/ggml-org/ggml@v9.8.7")
 
 
 if __name__ == "__main__":

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -44,6 +44,7 @@ class WhisperVulkanPackaging(unittest.TestCase):
                      "Publish dependency release"):
             self.assertIn(step, workflow)
         self.assertNotRegex(workflow, r"uses: [^\n]+@v\d+(?:\s|$)")
+        self.assertIn("SOURCE_DIR=vendor/whisper.cpp", workflow)
 
     def test_publish_is_safe_for_dikte_and_limited_to_reviewed_master(self):
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -172,7 +173,7 @@ class WhisperVulkanPackaging(unittest.TestCase):
         self.assertIn("WHISPER_VERSION:=1.9.3", script)
         self.assertIn("REVIEWED_WHISPER_VERSION: \"1.9.4\"", workflow)
         commit = "927cfce34f31707e17f2bff35c349632fb9e2c3a"
-        digest = "042769c8e70c1f603b0eac8dd57bca4eaaf369f68e1e3cf6a25d1b5984aba055"
+        digest = "381ec8f07071d616e243b94d275e29763d6d2b4c7204017c166caf389e1f2349"
         self.assertIn(commit, workflow)
         self.assertIn(digest, workflow)
         self.assertIn(ggml.MANAGED_WHISPER_VULKAN, workflow)
@@ -187,15 +188,29 @@ class WhisperVulkanPackaging(unittest.TestCase):
 
     def _make_test_sbom(self):
         with tempfile.TemporaryDirectory() as temporary:
-            root = pathlib.Path(temporary)
+            temporary = pathlib.Path(temporary)
+            root = temporary / "bundle"
+            source = temporary / "source"
+            root.mkdir()
+            (source / "examples/server").mkdir(parents=True)
             (root / "whisper-server").write_bytes(b"elf")
+            (root / "libggml.so.9.8.7").write_bytes(b"elf")
+            (source / "examples/server/httplib.h").write_text(
+                '#define CPPHTTPLIB_VERSION "6.5.4"\n', encoding="utf-8",
+            )
+            (source / "examples/json.hpp").write_text(
+                "#define NLOHMANN_JSON_VERSION_MAJOR 3\n"
+                "#define NLOHMANN_JSON_VERSION_MINOR 2\n"
+                "#define NLOHMANN_JSON_VERSION_PATCH 1\n",
+                encoding="utf-8",
+            )
             sbom = root / "whisper-bin-ubuntu-vulkan-x64.cdx.json"
             environment = os.environ | {
                 "ROOT": str(root),
+                "SOURCE_DIR": str(source),
                 "VERSION": "1.9.3",
                 "COMMIT": "371b5a7561823ab2bb32142d2751e35e7534727b",
                 "EPOCH": "1787219223",
-                "GGML_VERSION": "9.8.7",
             }
             with sbom.open("w", encoding="utf-8") as output:
                 subprocess.run(
@@ -209,13 +224,20 @@ class WhisperVulkanPackaging(unittest.TestCase):
         names = {component["name"] for component in document["components"]}
         self.assertNotIn(sbom_name, names)
 
-    def test_the_sbom_lists_ggml(self):
+    def test_the_sbom_derives_vendored_component_versions(self):
         document, _ = self._make_test_sbom()
-        ggml_component = next(component for component in document["components"]
-                              if component["name"] == "ggml")
-        self.assertEqual(ggml_component["version"], "9.8.7")
-        self.assertEqual(ggml_component["purl"],
-                         "pkg:github/ggml-org/ggml@v9.8.7")
+        components = {component["name"]: component
+                      for component in document["components"]}
+        expected = {
+            "ggml": "9.8.7",
+            "cpp-httplib": "6.5.4",
+            "json": "3.2.1",
+        }
+        for name, version in expected.items():
+            self.assertEqual(components[name]["version"], version)
+            self.assertEqual(
+                components[name]["purl"].rsplit("@", 1)[1], f"v{version}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- prepare the managed Linux Vulkan workflow for whisper.cpp v1.9.4
- derive GGML, cpp-httplib, and nlohmann/json versions from the packaged binary and vendored source instead of maintaining them manually
- validate that each CycloneDX component version and purl matches what was built
- leave the application upgrade for a follow-up after the v1.9.4 bundle is published

## Verification

- two clean v1.9.4 builds produced byte-identical archives, SBOMs, and checksum sidecars
- reviewed archive SHA-256: `381ec8f07071d616e243b94d275e29763d6d2b4c7204017c166caf389e1f2349`
- package and SBOM validation passed
- the identical binaries passed CPU, no-ICD, Vulkan, and real RX 6750 XT validation
- all 1,673 tests passed

## Release order

After merging this PR:

1. Run the dependency workflow from `master` without publishing and verify the reviewed digest.
2. Run it again with publishing enabled and verify the prerelease assets, SBOM, checksum, and attestations.
3. Update the application installer to v1.9.4 in a separate PR.
